### PR TITLE
Add folder path semantics and desktop navigation

### DIFF
--- a/apps/desktop/src/app/routes/__root.tsx
+++ b/apps/desktop/src/app/routes/__root.tsx
@@ -5,12 +5,8 @@ export function RootRoute() {
     <main
       style={{
         fontFamily: "ui-sans-serif, system-ui, sans-serif",
-        minHeight: "100vh",
         margin: 0,
-        padding: "3rem",
-        background:
-          "radial-gradient(circle at top left, rgba(151, 196, 89, 0.28), transparent 34%), #f5f1e8",
-        color: "#27500A",
+        minHeight: "100vh",
       }}
     >
       <Outlet />

--- a/apps/desktop/src/app/routes/index.tsx
+++ b/apps/desktop/src/app/routes/index.tsx
@@ -1,5 +1,5 @@
-import { ShellCard } from "../../shared";
+import { FolderNavigationWorkspace } from "../../features/folder-navigation";
 
 export function HomeRoute() {
-  return <ShellCard />;
+  return <FolderNavigationWorkspace />;
 }

--- a/apps/desktop/src/features/folder-navigation/index.ts
+++ b/apps/desktop/src/features/folder-navigation/index.ts
@@ -1,0 +1,1 @@
+export { FolderNavigationWorkspace } from "./ui/FolderNavigationWorkspace";

--- a/apps/desktop/src/features/folder-navigation/ui/FolderNavigationWorkspace.css
+++ b/apps/desktop/src/features/folder-navigation/ui/FolderNavigationWorkspace.css
@@ -1,0 +1,159 @@
+.folder-navigation {
+  background: #f7f8f5;
+  color: #17211b;
+  display: grid;
+  grid-template-columns: 18rem minmax(20rem, 28rem) minmax(20rem, 1fr);
+  min-height: 100vh;
+  overflow-x: auto;
+}
+
+.folder-navigation__sidebar,
+.folder-navigation__note-list,
+.folder-navigation__pane {
+  padding: 1.25rem;
+}
+
+.folder-navigation__sidebar,
+.folder-navigation__note-list {
+  border-right: 1px solid #dce4dd;
+}
+
+.folder-navigation__eyebrow {
+  color: #4d6959;
+  font-size: 0.875rem;
+  margin: 0 0 0.5rem;
+}
+
+.folder-navigation__title {
+  font-size: 1.5rem;
+  line-height: 1.2;
+  margin: 0 0 1.5rem;
+}
+
+.folder-navigation__heading {
+  font-size: 1.375rem;
+  margin: 0 0 1rem;
+}
+
+.folder-navigation__root-button,
+.folder-navigation__folder-button {
+  align-items: center;
+  border: 1px solid transparent;
+  border-radius: 8px;
+  color: #17211b;
+  cursor: pointer;
+  display: flex;
+  justify-content: space-between;
+}
+
+.folder-navigation__root-button {
+  background: #ffffff;
+  border-color: #dce4dd;
+  min-height: 2.5rem;
+  padding: 0 0.75rem;
+  width: 100%;
+}
+
+.folder-navigation__folder-button {
+  background: transparent;
+  flex: 1;
+  min-height: 2rem;
+  padding: 0 0.625rem;
+  text-align: left;
+}
+
+.folder-navigation__root-button--selected,
+.folder-navigation__folder-button--selected {
+  background: #ddf3e7;
+  border-color: #1f7a5c;
+}
+
+.folder-navigation__tree {
+  display: grid;
+  gap: 0.25rem;
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.folder-navigation__tree--root {
+  margin-top: 1rem;
+}
+
+.folder-navigation__folder-row {
+  display: flex;
+  gap: 0.375rem;
+}
+
+.folder-navigation__toggle {
+  background: #e6f0e7;
+  border: 0;
+  border-radius: 6px;
+  color: #25543c;
+  cursor: pointer;
+  width: 1.75rem;
+}
+
+.folder-navigation__toggle:disabled {
+  background: transparent;
+  cursor: default;
+}
+
+.folder-navigation__count,
+.folder-navigation__muted {
+  color: #5f6d64;
+}
+
+.folder-navigation__notes {
+  display: grid;
+  gap: 0.75rem;
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.folder-navigation__note,
+.folder-navigation__empty,
+.folder-navigation__editor {
+  background: #ffffff;
+  border: 1px solid #dce4dd;
+  border-radius: 8px;
+}
+
+.folder-navigation__note,
+.folder-navigation__empty {
+  padding: 0.875rem;
+}
+
+.folder-navigation__note-title {
+  font-size: 1rem;
+  margin: 0 0 0.5rem;
+}
+
+.folder-navigation__muted {
+  font-size: 0.875rem;
+  line-height: 1.5;
+  margin: 0;
+}
+
+.folder-navigation__editor {
+  min-height: 18rem;
+  padding: 1rem;
+}
+
+.folder-navigation__editor p {
+  line-height: 1.6;
+  margin: 0;
+}
+
+@media (max-width: 760px) {
+  .folder-navigation {
+    grid-template-columns: minmax(18rem, 1fr);
+  }
+
+  .folder-navigation__sidebar,
+  .folder-navigation__note-list {
+    border-bottom: 1px solid #dce4dd;
+    border-right: 0;
+  }
+}

--- a/apps/desktop/src/features/folder-navigation/ui/FolderNavigationWorkspace.tsx
+++ b/apps/desktop/src/features/folder-navigation/ui/FolderNavigationWorkspace.tsx
@@ -1,0 +1,268 @@
+import {
+  appName,
+  buildFolderTree,
+  getFolderDisplayName,
+  getFolderPathForNote,
+  isNoteInFolderScope,
+  normalizeFolderPath,
+  normalizeNoteFilePath,
+} from "@grove/core";
+import type { FolderScope, FolderTreeNode, NoteFilePath } from "@grove/core";
+import { useMemo, useState } from "react";
+
+import "./FolderNavigationWorkspace.css";
+
+type NoteListItem = {
+  id: string;
+  title: string;
+  path: NoteFilePath;
+  updatedLabel: string;
+};
+
+type FolderNodeProps = {
+  node: FolderTreeNode;
+  selectedFolderPath: FolderScope;
+  expandedFolderPaths: readonly string[];
+  onSelect: (path: FolderScope) => void;
+  onToggle: (path: string) => void;
+};
+
+type SidebarProps = {
+  folderTree: readonly FolderTreeNode[];
+  selectedFolderPath: FolderScope;
+  expandedFolderPaths: readonly string[];
+  onSelect: (path: FolderScope) => void;
+  onToggle: (path: string) => void;
+};
+
+type NoteListProps = {
+  selectedFolderPath: FolderScope;
+  scopedNotes: readonly NoteListItem[];
+};
+
+const notes: readonly NoteListItem[] = [
+  {
+    id: "note-inbox",
+    title: "Daily capture",
+    path: normalizeNoteFilePath("Inbox.md"),
+    updatedLabel: "Today",
+  },
+  {
+    id: "note-plan",
+    title: "Grove workspace plan",
+    path: normalizeNoteFilePath("Projects/Grove/Workspace Plan.md"),
+    updatedLabel: "Yesterday",
+  },
+  {
+    id: "note-research",
+    title: "Folder navigation notes",
+    path: normalizeNoteFilePath("Projects/Grove/Research/Folder Navigation.md"),
+    updatedLabel: "Apr 12",
+  },
+  {
+    id: "note-sync",
+    title: "Sync provider questions",
+    path: normalizeNoteFilePath("Projects/Sync/Provider Questions.md"),
+    updatedLabel: "Apr 10",
+  },
+  {
+    id: "note-archive",
+    title: "Launch retrospective",
+    path: normalizeNoteFilePath("Archive/2026/Launch Retro.md"),
+    updatedLabel: "Apr 8",
+  },
+];
+
+const explicitFolders = [
+  normalizeFolderPath("Projects/Grove/Ideas"),
+  normalizeFolderPath("Reading"),
+] as const;
+
+function filterNotesByFolderScope(
+  noteList: readonly NoteListItem[],
+  selectedFolderPath: FolderScope,
+): NoteListItem[] {
+  return noteList.filter((note) => isNoteInFolderScope(note.path, selectedFolderPath));
+}
+
+function getFolderLabel(folderPath: FolderScope): string {
+  return folderPath === null ? "Workspace" : getFolderDisplayName(folderPath);
+}
+
+function FolderNode({
+  node,
+  selectedFolderPath,
+  expandedFolderPaths,
+  onSelect,
+  onToggle,
+}: FolderNodeProps) {
+  const expanded = expandedFolderPaths.includes(node.path);
+  const selected = selectedFolderPath === node.path;
+  const hasChildren = node.children.length > 0;
+
+  return (
+    <li>
+      <div
+        className="folder-navigation__folder-row"
+        style={{ paddingLeft: `${node.depth * 0.75}rem` }}
+      >
+        <button
+          type="button"
+          className="folder-navigation__toggle"
+          onClick={() => onToggle(node.path)}
+          aria-label={expanded ? `Collapse ${node.name}` : `Expand ${node.name}`}
+          disabled={!hasChildren}
+        >
+          {hasChildren ? (expanded ? "-" : "+") : ""}
+        </button>
+        <button
+          type="button"
+          className={
+            selected
+              ? "folder-navigation__folder-button folder-navigation__folder-button--selected"
+              : "folder-navigation__folder-button"
+          }
+          onClick={() => onSelect(node.path)}
+          aria-pressed={selected}
+        >
+          <span>{node.name}</span>
+          <span className="folder-navigation__count">{node.totalNoteCount}</span>
+        </button>
+      </div>
+      {expanded ? (
+        <ol className="folder-navigation__tree">
+          {node.children.map((child) => (
+            <FolderNode
+              key={child.path}
+              node={child}
+              selectedFolderPath={selectedFolderPath}
+              expandedFolderPaths={expandedFolderPaths}
+              onSelect={onSelect}
+              onToggle={onToggle}
+            />
+          ))}
+        </ol>
+      ) : null}
+    </li>
+  );
+}
+
+function Sidebar({
+  folderTree,
+  selectedFolderPath,
+  expandedFolderPaths,
+  onSelect,
+  onToggle,
+}: SidebarProps) {
+  return (
+    <aside className="folder-navigation__sidebar">
+      <p className="folder-navigation__eyebrow">{appName}</p>
+      <h1 className="folder-navigation__title">Library</h1>
+      <button
+        type="button"
+        className={
+          selectedFolderPath === null
+            ? "folder-navigation__root-button folder-navigation__root-button--selected"
+            : "folder-navigation__root-button"
+        }
+        onClick={() => onSelect(null)}
+        aria-pressed={selectedFolderPath === null}
+      >
+        <span>All notes</span>
+        <span>{notes.length}</span>
+      </button>
+      <ol className="folder-navigation__tree folder-navigation__tree--root">
+        {folderTree.map((node) => (
+          <FolderNode
+            key={node.path}
+            node={node}
+            selectedFolderPath={selectedFolderPath}
+            expandedFolderPaths={expandedFolderPaths}
+            onSelect={onSelect}
+            onToggle={onToggle}
+          />
+        ))}
+      </ol>
+    </aside>
+  );
+}
+
+function NoteList({ selectedFolderPath, scopedNotes }: NoteListProps) {
+  return (
+    <section className="folder-navigation__note-list" aria-label="Notes">
+      <p className="folder-navigation__eyebrow">{getFolderLabel(selectedFolderPath)}</p>
+      <h2 className="folder-navigation__heading">Notes</h2>
+      {scopedNotes.length > 0 ? (
+        <ol className="folder-navigation__notes">
+          {scopedNotes.map((note) => (
+            <li key={note.id} className="folder-navigation__note">
+              <h3 className="folder-navigation__note-title">{note.title}</h3>
+              <p className="folder-navigation__muted">
+                {getFolderDisplayName(getFolderPathForNote(note.path))} · {note.updatedLabel}
+              </p>
+            </li>
+          ))}
+        </ol>
+      ) : (
+        <div className="folder-navigation__empty">
+          <h3 className="folder-navigation__note-title">No notes here yet</h3>
+          <p className="folder-navigation__muted">Start in {getFolderLabel(selectedFolderPath)}.</p>
+        </div>
+      )}
+    </section>
+  );
+}
+
+function ActivePane() {
+  return (
+    <section className="folder-navigation__pane">
+      <p className="folder-navigation__eyebrow">Active pane</p>
+      <h2 className="folder-navigation__heading">Workspace Plan</h2>
+      <div className="folder-navigation__editor">
+        <p>Keep the current draft open while moving through nearby project notes.</p>
+      </div>
+    </section>
+  );
+}
+
+export function FolderNavigationWorkspace() {
+  const [selectedFolderPath, setSelectedFolderPath] = useState<FolderScope>(null);
+  const [expandedFolderPaths, setExpandedFolderPaths] = useState<readonly string[]>([
+    "Projects",
+    "Projects/Grove",
+  ]);
+
+  const folderTree = useMemo(() => {
+    return buildFolderTree(
+      notes.map((note) => note.path),
+      explicitFolders,
+    );
+  }, []);
+  const scopedNotes = useMemo(() => {
+    return filterNotesByFolderScope(notes, selectedFolderPath);
+  }, [selectedFolderPath]);
+
+  function toggleFolder(path: string): void {
+    setExpandedFolderPaths((currentPaths) => {
+      if (currentPaths.includes(path)) {
+        return currentPaths.filter((currentPath) => currentPath !== path);
+      }
+
+      return [...currentPaths, path];
+    });
+  }
+
+  return (
+    <section className="folder-navigation">
+      <Sidebar
+        folderTree={folderTree}
+        selectedFolderPath={selectedFolderPath}
+        expandedFolderPaths={expandedFolderPaths}
+        onSelect={setSelectedFolderPath}
+        onToggle={toggleFolder}
+      />
+      <NoteList selectedFolderPath={selectedFolderPath} scopedNotes={scopedNotes} />
+      <ActivePane />
+    </section>
+  );
+}

--- a/apps/desktop/src/features/index.ts
+++ b/apps/desktop/src/features/index.ts
@@ -1,1 +1,1 @@
-export {};
+export { FolderNavigationWorkspace } from "./folder-navigation";

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -98,6 +98,36 @@ WikiLink はプラグインではなくコア責務です。
 `core` の `LinkResolver` は純粋関数として定義します。
 `packages/db` はその解決ルールを呼び出して index を更新する orchestration を担当し、独自の解決ロジックは持ちません。
 
+## フォルダ path semantics
+
+フォルダ階層は `Note.filePath` から導出します。
+`Note` に独立した `folderId` や親子関係の正本は持たせず、Markdown ファイルの workspace 相対 path を正本にします。
+
+公開型:
+
+- `NoteFilePath`: workspace 相対の Markdown ファイル path
+- `FolderPath`: workspace 相対の folder path
+- `FolderScope`: `FolderPath | null`
+- `FolderTreeNode`: folder tree 表示や scoped note list の入力に使う派生構造
+
+path の不変条件:
+
+- separator は `/` に正規化する
+- 絶対 path と Windows drive prefix は許可しない
+- `.` と `..` segment は許可しない
+- workspace root の folder scope は `null` で表す
+- note file path は `.md` / `.MD` など Markdown 拡張子を必須にする
+
+move / rename semantics:
+
+- note move は note file name を維持し、target `FolderScope` へ path prefix を付け替える
+- folder rename は対象 folder 配下の note path prefix だけを置き換える
+- root への移動や rename は target `FolderScope` を `null` にする
+- folder tree と note count は `NoteFilePath[]` と必要に応じた明示的な空 folder list から再構築する
+
+リンク、タグ、その他 metadata は folder 階層の正本ではありません。
+folder path 変更後は `packages/db` が `core` の path semantics と WikiLink 解決ルールを呼び、SQLite index を再構築または更新します。
+
 ## app-host 境界
 
 `core` には host 依存を隔離するための抽象を置きます。

--- a/packages/core/src/folders.test.ts
+++ b/packages/core/src/folders.test.ts
@@ -20,6 +20,7 @@ describe("folder path semantics", () => {
     expect(() => normalizeFolderPath("/Projects")).toThrow("must not be absolute");
     expect(() => normalizeFolderPath("Projects/../Secrets")).toThrow("must not include dot");
     expect(() => normalizeFolderPath("C:\\Users\\Notes")).toThrow("must not include a drive");
+    expect(() => normalizeFolderPath("C:Users\\Notes")).toThrow("must not include a drive");
   });
 
   it("uses null as the workspace root folder scope", () => {

--- a/packages/core/src/folders.test.ts
+++ b/packages/core/src/folders.test.ts
@@ -1,0 +1,131 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  buildFolderTree,
+  getFolderPathForNote,
+  isNoteInFolderScope,
+  moveNoteToFolder,
+  normalizeFolderPath,
+  normalizeFolderScope,
+  normalizeNoteFilePath,
+  renameFolderInNotePath,
+} from "./folders";
+
+describe("folder path semantics", () => {
+  it("normalizes workspace relative folder paths to slash-separated paths", () => {
+    expect(normalizeFolderPath("Projects\\Grove//Research/")).toBe("Projects/Grove/Research");
+  });
+
+  it("rejects absolute and parent-traversing paths", () => {
+    expect(() => normalizeFolderPath("/Projects")).toThrow("must not be absolute");
+    expect(() => normalizeFolderPath("Projects/../Secrets")).toThrow("must not include dot");
+    expect(() => normalizeFolderPath("C:\\Users\\Notes")).toThrow("must not include a drive");
+  });
+
+  it("uses null as the workspace root folder scope", () => {
+    expect(normalizeFolderScope(null)).toBeNull();
+    expect(normalizeFolderScope("")).toBeNull();
+    expect(normalizeFolderScope("Projects")).toBe("Projects");
+  });
+});
+
+describe("note file path semantics", () => {
+  it("requires Markdown note file paths", () => {
+    expect(normalizeNoteFilePath("Projects/Grove/Plan.MD")).toBe("Projects/Grove/Plan.MD");
+    expect(() => normalizeNoteFilePath("Projects/Grove/Plan.txt")).toThrow("Markdown");
+  });
+
+  it("derives folder path from a note path", () => {
+    expect(getFolderPathForNote(normalizeNoteFilePath("Inbox.md"))).toBeNull();
+    expect(getFolderPathForNote(normalizeNoteFilePath("Projects/Grove/Plan.md"))).toBe(
+      "Projects/Grove",
+    );
+  });
+
+  it("filters note paths by root or descendant folder scope", () => {
+    const notePath = normalizeNoteFilePath("Projects/Grove/Plan.md");
+
+    expect(isNoteInFolderScope(notePath, null)).toBe(true);
+    expect(isNoteInFolderScope(notePath, normalizeFolderPath("Projects"))).toBe(true);
+    expect(isNoteInFolderScope(notePath, normalizeFolderPath("Archive"))).toBe(false);
+  });
+
+  it("moves note paths into a target folder scope", () => {
+    const notePath = normalizeNoteFilePath("Projects/Grove/Plan.md");
+
+    expect(moveNoteToFolder(notePath, normalizeFolderPath("Archive"))).toBe("Archive/Plan.md");
+    expect(moveNoteToFolder(notePath, null)).toBe("Plan.md");
+  });
+
+  it("renames folder prefixes for descendant note paths only", () => {
+    const notePath = normalizeNoteFilePath("Projects/Grove/Plan.md");
+
+    expect(
+      renameFolderInNotePath(
+        notePath,
+        normalizeFolderPath("Projects"),
+        normalizeFolderPath("Areas"),
+      ),
+    ).toBe("Areas/Grove/Plan.md");
+    expect(renameFolderInNotePath(notePath, normalizeFolderPath("Archive"), null)).toBe(notePath);
+  });
+});
+
+describe("buildFolderTree", () => {
+  it("includes explicit empty folders and aggregates descendant note counts", () => {
+    const tree = buildFolderTree(
+      [
+        normalizeNoteFilePath("Projects/Grove/Plan.md"),
+        normalizeNoteFilePath("Projects/Roadmap.md"),
+        normalizeNoteFilePath("Archive/2026/Retro.md"),
+        normalizeNoteFilePath("Inbox.md"),
+      ],
+      [normalizeFolderPath("Projects/Empty")],
+    );
+
+    expect(tree).toStrictEqual([
+      {
+        path: "Archive",
+        name: "Archive",
+        depth: 1,
+        directNoteCount: 0,
+        totalNoteCount: 1,
+        children: [
+          {
+            path: "Archive/2026",
+            name: "2026",
+            depth: 2,
+            directNoteCount: 1,
+            totalNoteCount: 1,
+            children: [],
+          },
+        ],
+      },
+      {
+        path: "Projects",
+        name: "Projects",
+        depth: 1,
+        directNoteCount: 1,
+        totalNoteCount: 2,
+        children: [
+          {
+            path: "Projects/Empty",
+            name: "Empty",
+            depth: 2,
+            directNoteCount: 0,
+            totalNoteCount: 0,
+            children: [],
+          },
+          {
+            path: "Projects/Grove",
+            name: "Grove",
+            depth: 2,
+            directNoteCount: 1,
+            totalNoteCount: 1,
+            children: [],
+          },
+        ],
+      },
+    ]);
+  });
+});

--- a/packages/core/src/folders.ts
+++ b/packages/core/src/folders.ts
@@ -17,7 +17,7 @@ type MutableFolderTreeNode = Omit<FolderTreeNode, "children"> & {
   children: MutableFolderTreeNode[];
 };
 
-const WINDOWS_DRIVE_PATH = /^[a-zA-Z]:[\\/]/;
+const WINDOWS_DRIVE_PATH = /^[a-zA-Z]:/;
 
 function normalizeWorkspacePath(input: string): string {
   if (input.length === 0) {

--- a/packages/core/src/folders.ts
+++ b/packages/core/src/folders.ts
@@ -1,0 +1,239 @@
+type Opaque<Type, Token extends string> = Type & { readonly __type: Token };
+
+export type FolderPath = Opaque<string, "FolderPath">;
+export type NoteFilePath = Opaque<string, "NoteFilePath">;
+export type FolderScope = FolderPath | null;
+
+export type FolderTreeNode = {
+  path: FolderPath;
+  name: string;
+  depth: number;
+  directNoteCount: number;
+  totalNoteCount: number;
+  children: FolderTreeNode[];
+};
+
+type MutableFolderTreeNode = Omit<FolderTreeNode, "children"> & {
+  children: MutableFolderTreeNode[];
+};
+
+const WINDOWS_DRIVE_PATH = /^[a-zA-Z]:[\\/]/;
+
+function normalizeWorkspacePath(input: string): string {
+  if (input.length === 0) {
+    throw new Error("Workspace relative path must not be empty.");
+  }
+
+  if (WINDOWS_DRIVE_PATH.test(input)) {
+    throw new Error("Workspace relative path must not include a drive prefix.");
+  }
+
+  const normalizedSeparators = input.replaceAll("\\", "/");
+
+  if (normalizedSeparators.startsWith("/")) {
+    throw new Error("Workspace relative path must not be absolute.");
+  }
+
+  const segments = normalizedSeparators.split("/").filter((segment) => segment.length > 0);
+
+  if (segments.length === 0) {
+    throw new Error("Workspace relative path must include at least one segment.");
+  }
+
+  if (segments.some((segment) => segment === "." || segment === "..")) {
+    throw new Error("Workspace relative path must not include dot segments.");
+  }
+
+  return segments.join("/");
+}
+
+function asFolderPath(path: string): FolderPath {
+  return path as FolderPath;
+}
+
+function asNoteFilePath(path: string): NoteFilePath {
+  return path as NoteFilePath;
+}
+
+function getSegments(path: string): string[] {
+  return path.split("/");
+}
+
+function getParentFolderPath(path: FolderPath): FolderPath | null {
+  const segments = getSegments(path);
+
+  if (segments.length === 1) {
+    return null;
+  }
+
+  return asFolderPath(segments.slice(0, -1).join("/"));
+}
+
+function ensureFolderNode(
+  nodes: Map<string, MutableFolderTreeNode>,
+  path: FolderPath,
+): MutableFolderTreeNode {
+  const existingNode = nodes.get(path);
+
+  if (existingNode !== undefined) {
+    return existingNode;
+  }
+
+  const node: MutableFolderTreeNode = {
+    path,
+    name: getFolderDisplayName(path),
+    depth: getWorkspacePathDepth(path),
+    directNoteCount: 0,
+    totalNoteCount: 0,
+    children: [],
+  };
+  nodes.set(path, node);
+
+  const parentPath = getParentFolderPath(path);
+
+  if (parentPath !== null) {
+    ensureFolderNode(nodes, parentPath).children.push(node);
+  }
+
+  return node;
+}
+
+function incrementAncestorCounts(
+  nodes: Map<string, MutableFolderTreeNode>,
+  folderPath: FolderPath | null,
+): void {
+  let currentPath = folderPath;
+
+  while (currentPath !== null) {
+    const node = ensureFolderNode(nodes, currentPath);
+    node.totalNoteCount += 1;
+    currentPath = getParentFolderPath(currentPath);
+  }
+}
+
+function sortFolderTreeNodes(nodes: MutableFolderTreeNode[]): FolderTreeNode[] {
+  return [...nodes]
+    .sort((left, right) => compareWorkspacePaths(left.path, right.path))
+    .map((node) => ({
+      ...node,
+      children: sortFolderTreeNodes(node.children),
+    }));
+}
+
+export function normalizeFolderPath(input: string): FolderPath {
+  return asFolderPath(normalizeWorkspacePath(input));
+}
+
+export function normalizeFolderScope(input: string | null): FolderScope {
+  if (input === null || input === "") {
+    return null;
+  }
+
+  return normalizeFolderPath(input);
+}
+
+export function normalizeNoteFilePath(input: string): NoteFilePath {
+  const path = normalizeWorkspacePath(input);
+
+  if (!path.toLowerCase().endsWith(".md")) {
+    throw new Error("Note file path must point to a Markdown file.");
+  }
+
+  return asNoteFilePath(path);
+}
+
+export function getFolderPathForNote(notePath: NoteFilePath): FolderPath | null {
+  const segments = getSegments(notePath);
+
+  if (segments.length === 1) {
+    return null;
+  }
+
+  return asFolderPath(segments.slice(0, -1).join("/"));
+}
+
+export function getWorkspacePathDepth(path: FolderPath | NoteFilePath): number {
+  return getSegments(path).length;
+}
+
+export function getFolderDisplayName(folderPath: FolderScope): string {
+  if (folderPath === null) {
+    return "All Notes";
+  }
+
+  const segments = getSegments(folderPath);
+  return segments[segments.length - 1] ?? "All Notes";
+}
+
+export function isNoteInFolderScope(notePath: NoteFilePath, folderScope: FolderScope): boolean {
+  if (folderScope === null) {
+    return true;
+  }
+
+  return notePath.startsWith(`${folderScope}/`);
+}
+
+export function moveNoteToFolder(
+  notePath: NoteFilePath,
+  targetFolderPath: FolderScope,
+): NoteFilePath {
+  const fileName = getSegments(notePath).at(-1);
+
+  if (fileName === undefined) {
+    throw new Error("Note file path must include a file name.");
+  }
+
+  if (targetFolderPath === null) {
+    return asNoteFilePath(fileName);
+  }
+
+  return asNoteFilePath(`${targetFolderPath}/${fileName}`);
+}
+
+export function renameFolderInNotePath(
+  notePath: NoteFilePath,
+  fromFolderPath: FolderPath,
+  toFolderPath: FolderScope,
+): NoteFilePath {
+  if (!isNoteInFolderScope(notePath, fromFolderPath)) {
+    return notePath;
+  }
+
+  const suffix = notePath.slice(fromFolderPath.length + 1);
+
+  if (toFolderPath === null) {
+    return asNoteFilePath(suffix);
+  }
+
+  return asNoteFilePath(`${toFolderPath}/${suffix}`);
+}
+
+export function compareWorkspacePaths(left: string, right: string): number {
+  return left.localeCompare(right, "en", { sensitivity: "base" });
+}
+
+export function buildFolderTree(
+  notePaths: readonly NoteFilePath[],
+  explicitFolderPaths: readonly FolderPath[] = [],
+): FolderTreeNode[] {
+  const nodes = new Map<string, MutableFolderTreeNode>();
+
+  for (const folderPath of explicitFolderPaths) {
+    ensureFolderNode(nodes, folderPath);
+  }
+
+  for (const notePath of notePaths) {
+    const folderPath = getFolderPathForNote(notePath);
+
+    if (folderPath === null) {
+      continue;
+    }
+
+    const node = ensureFolderNode(nodes, folderPath);
+    node.directNoteCount += 1;
+    incrementAncestorCounts(nodes, folderPath);
+  }
+
+  const rootNodes = [...nodes.values()].filter((node) => getParentFolderPath(node.path) === null);
+  return sortFolderTreeNodes(rootNodes);
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,5 +1,20 @@
 export const appName = "Grove";
 
+export {
+  buildFolderTree,
+  compareWorkspacePaths,
+  getFolderDisplayName,
+  getFolderPathForNote,
+  getWorkspacePathDepth,
+  isNoteInFolderScope,
+  moveNoteToFolder,
+  normalizeFolderPath,
+  normalizeFolderScope,
+  normalizeNoteFilePath,
+  renameFolderInNotePath,
+} from "./folders";
+export type { FolderPath, FolderScope, FolderTreeNode, NoteFilePath } from "./folders";
+
 export type NoteLink = {
   fromId: string;
   toId: string;


### PR DESCRIPTION
## Summary
- add core folder/note path semantics with normalization, scope filtering, move/rename helpers, and folder tree derivation
- document the folder representation contract in packages/core README
- replace the desktop shell card with a folder-scoped library layout using the shared core path helpers

## Testing
- pnpm --filter @grove/core test
- pnpm typecheck
- pnpm lint
- pnpm format
- pnpm --filter @grove/desktop build

Refs #15
