### PR TITLE
Add desktop folder workspace state mutations

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -8,6 +8,7 @@
     "build": "vite build",
     "tauri:dev": "tauri dev",
     "tauri:build": "tauri build",
+    "test": "vitest run",
     "typecheck": "tsc -p tsconfig.json"
   },
   "dependencies": {

--- a/apps/desktop/src/features/folder-navigation/model/folderWorkspaceState.test.ts
+++ b/apps/desktop/src/features/folder-navigation/model/folderWorkspaceState.test.ts
@@ -1,0 +1,89 @@
+import { describe, expect, it } from "vitest";
+
+import { normalizeFolderPath, normalizeNoteFilePath } from "@grove/core";
+import type { FolderWorkspaceState } from "./folderWorkspaceState";
+import { moveNoteInFolderWorkspace, renameFolderInWorkspace } from "./folderWorkspaceState";
+
+const workspaceState: FolderWorkspaceState = {
+  notes: [
+    {
+      id: "note-root",
+      title: "Inbox",
+      path: normalizeNoteFilePath("Inbox.md"),
+      updatedLabel: "Today",
+    },
+    {
+      id: "note-plan",
+      title: "Plan",
+      path: normalizeNoteFilePath("Projects/Grove/Plan.md"),
+      updatedLabel: "Yesterday",
+    },
+    {
+      id: "note-research",
+      title: "Research",
+      path: normalizeNoteFilePath("Projects/Grove/Research/Notes.md"),
+      updatedLabel: "Apr 12",
+    },
+  ],
+  explicitFolders: [normalizeFolderPath("Projects/Grove/Ideas"), normalizeFolderPath("Reading")],
+  selectedFolderPath: normalizeFolderPath("Projects/Grove"),
+  expandedFolderPaths: ["Projects", "Projects/Grove", "Projects/Grove/Research"],
+};
+
+describe("moveNoteInFolderWorkspace", () => {
+  it("moves the selected note and selects the target folder scope", () => {
+    const result = moveNoteInFolderWorkspace(
+      workspaceState,
+      "note-plan",
+      normalizeFolderPath("Reading"),
+    );
+
+    expect(result.affectedNoteIds).toStrictEqual(["note-plan"]);
+    expect(result.state.notes.find((note) => note.id === "note-plan")?.path).toBe(
+      "Reading/Plan.md",
+    );
+    expect(result.state.selectedFolderPath).toBe("Reading");
+    expect(result.state.explicitFolders).toStrictEqual(workspaceState.explicitFolders);
+  });
+});
+
+describe("renameFolderInWorkspace", () => {
+  it("renames descendant notes and explicit empty folders as one state change", () => {
+    const result = renameFolderInWorkspace(
+      workspaceState,
+      normalizeFolderPath("Projects/Grove"),
+      normalizeFolderPath("Areas/Grove"),
+    );
+
+    expect(result.affectedNoteIds).toStrictEqual(["note-plan", "note-research"]);
+    expect(result.state.notes.map((note) => note.path)).toStrictEqual([
+      "Inbox.md",
+      "Areas/Grove/Plan.md",
+      "Areas/Grove/Research/Notes.md",
+    ]);
+    expect(result.state.explicitFolders).toStrictEqual(["Areas/Grove/Ideas", "Reading"]);
+    expect(result.state.expandedFolderPaths).toStrictEqual([
+      "Areas/Grove",
+      "Areas/Grove/Research",
+      "Projects",
+    ]);
+    expect(result.state.selectedFolderPath).toBe("Areas/Grove");
+  });
+
+  it("moves renamed folder contents to the workspace root", () => {
+    const result = renameFolderInWorkspace(
+      workspaceState,
+      normalizeFolderPath("Projects/Grove"),
+      null,
+    );
+
+    expect(result.state.notes.map((note) => note.path)).toStrictEqual([
+      "Inbox.md",
+      "Plan.md",
+      "Research/Notes.md",
+    ]);
+    expect(result.state.explicitFolders).toStrictEqual(["Ideas", "Reading"]);
+    expect(result.state.expandedFolderPaths).toStrictEqual(["Projects", "Research"]);
+    expect(result.state.selectedFolderPath).toBeNull();
+  });
+});

--- a/apps/desktop/src/features/folder-navigation/model/folderWorkspaceState.test.ts
+++ b/apps/desktop/src/features/folder-navigation/model/folderWorkspaceState.test.ts
@@ -86,4 +86,14 @@ describe("renameFolderInWorkspace", () => {
     expect(result.state.expandedFolderPaths).toStrictEqual(["Projects", "Research"]);
     expect(result.state.selectedFolderPath).toBeNull();
   });
+
+  it("rejects moving a folder into its own descendant", () => {
+    expect(() =>
+      renameFolderInWorkspace(
+        workspaceState,
+        normalizeFolderPath("Projects/Grove"),
+        normalizeFolderPath("Projects/Grove/Research"),
+      ),
+    ).toThrow("outside the selected folder");
+  });
 });

--- a/apps/desktop/src/features/folder-navigation/model/folderWorkspaceState.test.ts
+++ b/apps/desktop/src/features/folder-navigation/model/folderWorkspaceState.test.ts
@@ -63,6 +63,7 @@ describe("renameFolderInWorkspace", () => {
     ]);
     expect(result.state.explicitFolders).toStrictEqual(["Areas/Grove/Ideas", "Reading"]);
     expect(result.state.expandedFolderPaths).toStrictEqual([
+      "Areas",
       "Areas/Grove",
       "Areas/Grove/Research",
       "Projects",

--- a/apps/desktop/src/features/folder-navigation/model/folderWorkspaceState.ts
+++ b/apps/desktop/src/features/folder-navigation/model/folderWorkspaceState.ts
@@ -1,0 +1,137 @@
+import {
+  compareWorkspacePaths,
+  moveNoteToFolder,
+  normalizeFolderPath,
+  renameFolderInNotePath,
+} from "@grove/core";
+import type { FolderPath, FolderScope, NoteFilePath } from "@grove/core";
+
+export type FolderNavigationNote = {
+  id: string;
+  title: string;
+  path: NoteFilePath;
+  updatedLabel: string;
+};
+
+export type FolderWorkspaceState = {
+  notes: readonly FolderNavigationNote[];
+  explicitFolders: readonly FolderPath[];
+  selectedFolderPath: FolderScope;
+  expandedFolderPaths: readonly string[];
+};
+
+export type FolderWorkspaceMutation = {
+  state: FolderWorkspaceState;
+  affectedNoteIds: readonly string[];
+};
+
+function isFolderPathWithin(folderPath: FolderPath, parentFolderPath: FolderPath): boolean {
+  return folderPath === parentFolderPath || folderPath.startsWith(`${parentFolderPath}/`);
+}
+
+function replaceFolderPrefix(
+  folderPath: FolderPath,
+  fromFolderPath: FolderPath,
+  toFolderPath: FolderScope,
+): FolderScope {
+  if (!isFolderPathWithin(folderPath, fromFolderPath)) {
+    return folderPath;
+  }
+
+  const suffix = folderPath === fromFolderPath ? "" : folderPath.slice(fromFolderPath.length + 1);
+
+  if (toFolderPath === null) {
+    return suffix === "" ? null : normalizeFolderPath(suffix);
+  }
+
+  return normalizeFolderPath(suffix === "" ? toFolderPath : `${toFolderPath}/${suffix}`);
+}
+
+function dedupeAndSortFolderPaths(folderPaths: readonly FolderPath[]): FolderPath[] {
+  return [...new Set(folderPaths)].sort(compareWorkspacePaths);
+}
+
+function dedupeExpandedFolderPaths(folderPaths: readonly string[]): string[] {
+  return [...new Set(folderPaths)].sort(compareWorkspacePaths);
+}
+
+export function isDescendantFolderPath(
+  folderPath: FolderPath,
+  parentFolderPath: FolderPath,
+): boolean {
+  return folderPath.startsWith(`${parentFolderPath}/`);
+}
+
+export function moveNoteInFolderWorkspace(
+  state: FolderWorkspaceState,
+  noteId: string,
+  targetFolderPath: FolderScope,
+): FolderWorkspaceMutation {
+  const affectedNoteIds: string[] = [];
+  const notes = state.notes.map((note) => {
+    if (note.id !== noteId) {
+      return note;
+    }
+
+    const nextPath = moveNoteToFolder(note.path, targetFolderPath);
+
+    if (nextPath !== note.path) {
+      affectedNoteIds.push(note.id);
+    }
+
+    return { ...note, path: nextPath };
+  });
+
+  return {
+    affectedNoteIds,
+    state: {
+      ...state,
+      notes,
+      selectedFolderPath: targetFolderPath,
+    },
+  };
+}
+
+export function renameFolderInWorkspace(
+  state: FolderWorkspaceState,
+  sourceFolderPath: FolderPath,
+  targetFolderPath: FolderScope,
+): FolderWorkspaceMutation {
+  const affectedNoteIds: string[] = [];
+  const notes = state.notes.map((note) => {
+    const nextPath = renameFolderInNotePath(note.path, sourceFolderPath, targetFolderPath);
+
+    if (nextPath !== note.path) {
+      affectedNoteIds.push(note.id);
+    }
+
+    return { ...note, path: nextPath };
+  });
+  const explicitFolders = dedupeAndSortFolderPaths(
+    state.explicitFolders.flatMap((folderPath) => {
+      const nextPath = replaceFolderPrefix(folderPath, sourceFolderPath, targetFolderPath);
+      return nextPath === null ? [] : [nextPath];
+    }),
+  );
+  const expandedFolderPaths = dedupeExpandedFolderPaths(
+    state.expandedFolderPaths.flatMap((folderPath) => {
+      const nextPath = replaceFolderPrefix(
+        normalizeFolderPath(folderPath),
+        sourceFolderPath,
+        targetFolderPath,
+      );
+      return nextPath === null ? [] : [nextPath];
+    }),
+  );
+
+  return {
+    affectedNoteIds,
+    state: {
+      ...state,
+      notes,
+      explicitFolders,
+      expandedFolderPaths,
+      selectedFolderPath: targetFolderPath,
+    },
+  };
+}

--- a/apps/desktop/src/features/folder-navigation/model/folderWorkspaceState.ts
+++ b/apps/desktop/src/features/folder-navigation/model/folderWorkspaceState.ts
@@ -55,6 +55,17 @@ function dedupeExpandedFolderPaths(folderPaths: readonly string[]): string[] {
   return [...new Set(folderPaths)].sort(compareWorkspacePaths);
 }
 
+function getFolderPathAncestors(folderPath: FolderPath): FolderPath[] {
+  const segments = folderPath.split("/");
+  const ancestors: FolderPath[] = [];
+
+  for (let index = 1; index < segments.length; index += 1) {
+    ancestors.push(normalizeFolderPath(segments.slice(0, index).join("/")));
+  }
+
+  return ancestors;
+}
+
 export function isDescendantFolderPath(
   folderPath: FolderPath,
   parentFolderPath: FolderPath,
@@ -117,8 +128,8 @@ export function renameFolderInWorkspace(
       return nextPath === null ? [] : [nextPath];
     }),
   );
-  const expandedFolderPaths = dedupeExpandedFolderPaths(
-    state.expandedFolderPaths.flatMap((folderPath) => {
+  const expandedFolderPaths = dedupeExpandedFolderPaths([
+    ...state.expandedFolderPaths.flatMap((folderPath) => {
       const nextPath = replaceFolderPrefix(
         normalizeFolderPath(folderPath),
         sourceFolderPath,
@@ -126,7 +137,8 @@ export function renameFolderInWorkspace(
       );
       return nextPath === null ? [] : [nextPath];
     }),
-  );
+    ...(targetFolderPath === null ? [] : getFolderPathAncestors(targetFolderPath)),
+  ]);
 
   return {
     affectedNoteIds,

--- a/apps/desktop/src/features/folder-navigation/model/folderWorkspaceState.ts
+++ b/apps/desktop/src/features/folder-navigation/model/folderWorkspaceState.ts
@@ -97,6 +97,10 @@ export function renameFolderInWorkspace(
   sourceFolderPath: FolderPath,
   targetFolderPath: FolderScope,
 ): FolderWorkspaceMutation {
+  if (targetFolderPath !== null && isDescendantFolderPath(targetFolderPath, sourceFolderPath)) {
+    throw new Error("Choose a folder outside the selected folder.");
+  }
+
   const affectedNoteIds: string[] = [];
   const notes = state.notes.map((note) => {
     const nextPath = renameFolderInNotePath(note.path, sourceFolderPath, targetFolderPath);

--- a/apps/desktop/src/features/folder-navigation/ui/FolderNavigationWorkspace.tsx
+++ b/apps/desktop/src/features/folder-navigation/ui/FolderNavigationWorkspace.tsx
@@ -4,23 +4,22 @@ import {
   getFolderDisplayName,
   getFolderPathForNote,
   isNoteInFolderScope,
-  moveNoteToFolder,
   normalizeFolderPath,
   normalizeFolderScope,
   normalizeNoteFilePath,
-  renameFolderInNotePath,
 } from "@grove/core";
-import type { FolderPath, FolderScope, FolderTreeNode, NoteFilePath } from "@grove/core";
+import type { FolderScope, FolderTreeNode } from "@grove/core";
 import { useEffect, useMemo, useState } from "react";
 
+import {
+  isDescendantFolderPath,
+  moveNoteInFolderWorkspace,
+  renameFolderInWorkspace,
+} from "../model/folderWorkspaceState";
+import type { FolderNavigationNote, FolderWorkspaceState } from "../model/folderWorkspaceState";
 import "./FolderNavigationWorkspace.css";
 
-type NoteListItem = {
-  id: string;
-  title: string;
-  path: NoteFilePath;
-  updatedLabel: string;
-};
+type NoteListItem = FolderNavigationNote;
 
 type FolderNodeProps = {
   node: FolderTreeNode;
@@ -56,20 +55,20 @@ type ActivePaneProps = {
   folderOptions: readonly FolderOption[];
   selectedFolderPath: FolderScope;
   selectedNoteId: string;
-  onMoveSelectedNote: (targetFolderPath: FolderScope) => void;
-  onRenameSelectedFolder: (targetFolderPath: FolderScope) => void;
+  onMoveSelectedNote: (targetFolderPath: FolderScope) => readonly string[];
+  onRenameSelectedFolder: (targetFolderPath: FolderScope) => readonly string[];
 };
 
 type MoveNoteControlProps = {
   folderOptions: readonly FolderOption[];
   selectedNoteFolderPath: FolderScope;
-  onMoveSelectedNote: (targetFolderPath: FolderScope) => void;
+  onMoveSelectedNote: (targetFolderPath: FolderScope) => readonly string[];
   onOperationMessage: (message: string) => void;
 };
 
 type RenameFolderControlProps = {
   selectedFolderPath: FolderScope;
-  onRenameSelectedFolder: (targetFolderPath: FolderScope) => void;
+  onRenameSelectedFolder: (targetFolderPath: FolderScope) => readonly string[];
   onOperationMessage: (message: string) => void;
 };
 
@@ -131,28 +130,6 @@ function flattenFolderTree(folderTree: readonly FolderTreeNode[]): FolderOption[
     { path: node.path, label: node.path },
     ...flattenFolderTree(node.children),
   ]);
-}
-
-function replaceFolderPrefix(
-  folderPath: FolderPath,
-  fromFolderPath: FolderPath,
-  toFolderPath: FolderScope,
-): FolderScope {
-  if (folderPath !== fromFolderPath && !folderPath.startsWith(`${fromFolderPath}/`)) {
-    return folderPath;
-  }
-
-  const suffix = folderPath === fromFolderPath ? "" : folderPath.slice(fromFolderPath.length + 1);
-
-  if (toFolderPath === null) {
-    return suffix === "" ? null : normalizeFolderPath(suffix);
-  }
-
-  return normalizeFolderPath(suffix === "" ? toFolderPath : `${toFolderPath}/${suffix}`);
-}
-
-function isDescendantFolderPath(folderPath: FolderPath, parentFolderPath: FolderPath): boolean {
-  return folderPath.startsWith(`${parentFolderPath}/`);
 }
 
 function getErrorMessage(error: unknown): string {
@@ -314,8 +291,9 @@ function MoveNoteControl({
 
   function moveSelectedNote(): void {
     try {
-      onMoveSelectedNote(normalizeFolderScope(moveTargetPath));
-      onOperationMessage("Moved the note and refreshed folder counts.");
+      const affectedNoteIds = onMoveSelectedNote(normalizeFolderScope(moveTargetPath));
+      const movedNoteCount = affectedNoteIds.length;
+      onOperationMessage(`Moved ${movedNoteCount} note and refreshed folder counts.`);
     } catch (error) {
       onOperationMessage(getErrorMessage(error));
     }
@@ -370,8 +348,10 @@ function RenameFolderControl({
         return;
       }
 
-      onRenameSelectedFolder(targetFolderPath);
-      onOperationMessage("Renamed the folder and refreshed affected note paths.");
+      const affectedNoteIds = onRenameSelectedFolder(targetFolderPath);
+      onOperationMessage(
+        `Renamed the folder and refreshed ${affectedNoteIds.length} affected note paths.`,
+      );
     } catch (error) {
       onOperationMessage(getErrorMessage(error));
     }
@@ -447,15 +427,14 @@ function ActivePane({
 }
 
 export function FolderNavigationWorkspace() {
-  const [notes, setNotes] = useState<readonly NoteListItem[]>(initialNotes);
-  const [explicitFolders, setExplicitFolders] =
-    useState<readonly FolderPath[]>(initialExplicitFolders);
-  const [selectedFolderPath, setSelectedFolderPath] = useState<FolderScope>(null);
+  const [workspaceState, setWorkspaceState] = useState<FolderWorkspaceState>({
+    notes: initialNotes,
+    explicitFolders: initialExplicitFolders,
+    selectedFolderPath: null,
+    expandedFolderPaths: ["Projects", "Projects/Grove"],
+  });
   const [selectedNoteId, setSelectedNoteId] = useState<string>(initialNotes[1]?.id ?? "");
-  const [expandedFolderPaths, setExpandedFolderPaths] = useState<readonly string[]>([
-    "Projects",
-    "Projects/Grove",
-  ]);
+  const { notes, explicitFolders, selectedFolderPath, expandedFolderPaths } = workspaceState;
 
   const folderTree = useMemo(() => {
     return buildFolderTree(
@@ -470,55 +449,49 @@ export function FolderNavigationWorkspace() {
     return filterNotesByFolderScope(notes, selectedFolderPath);
   }, [notes, selectedFolderPath]);
 
+  function applyWorkspaceState(nextState: FolderWorkspaceState): void {
+    setWorkspaceState(nextState);
+  }
+
   function toggleFolder(path: string): void {
-    setExpandedFolderPaths((currentPaths) => {
-      if (currentPaths.includes(path)) {
-        return currentPaths.filter((currentPath) => currentPath !== path);
+    setWorkspaceState((currentState) => {
+      if (currentState.expandedFolderPaths.includes(path)) {
+        return {
+          ...currentState,
+          expandedFolderPaths: currentState.expandedFolderPaths.filter(
+            (currentPath) => currentPath !== path,
+          ),
+        };
       }
 
-      return [...currentPaths, path];
+      return {
+        ...currentState,
+        expandedFolderPaths: [...currentState.expandedFolderPaths, path],
+      };
     });
   }
 
-  function moveSelectedNote(targetFolderPath: FolderScope): void {
-    setNotes((currentNotes) =>
-      currentNotes.map((note) =>
-        note.id === selectedNoteId
-          ? { ...note, path: moveNoteToFolder(note.path, targetFolderPath) }
-          : note,
-      ),
-    );
-    setSelectedFolderPath(targetFolderPath);
+  function selectFolder(path: FolderScope): void {
+    setWorkspaceState((currentState) => ({
+      ...currentState,
+      selectedFolderPath: path,
+    }));
   }
 
-  function renameSelectedFolder(targetFolderPath: FolderScope): void {
+  function moveSelectedNote(targetFolderPath: FolderScope): readonly string[] {
+    const mutation = moveNoteInFolderWorkspace(workspaceState, selectedNoteId, targetFolderPath);
+    applyWorkspaceState(mutation.state);
+    return mutation.affectedNoteIds;
+  }
+
+  function renameSelectedFolder(targetFolderPath: FolderScope): readonly string[] {
     if (selectedFolderPath === null) {
-      return;
+      return [];
     }
 
-    setNotes((currentNotes) =>
-      currentNotes.map((note) => ({
-        ...note,
-        path: renameFolderInNotePath(note.path, selectedFolderPath, targetFolderPath),
-      })),
-    );
-    setExplicitFolders((currentFolders) =>
-      currentFolders.flatMap((folderPath) => {
-        const nextPath = replaceFolderPrefix(folderPath, selectedFolderPath, targetFolderPath);
-        return nextPath === null ? [] : [nextPath];
-      }),
-    );
-    setExpandedFolderPaths((currentPaths) =>
-      currentPaths.flatMap((folderPath) => {
-        const nextPath = replaceFolderPrefix(
-          normalizeFolderPath(folderPath),
-          selectedFolderPath,
-          targetFolderPath,
-        );
-        return nextPath === null ? [] : [nextPath];
-      }),
-    );
-    setSelectedFolderPath(targetFolderPath);
+    const mutation = renameFolderInWorkspace(workspaceState, selectedFolderPath, targetFolderPath);
+    applyWorkspaceState(mutation.state);
+    return mutation.affectedNoteIds;
   }
 
   return (
@@ -528,7 +501,7 @@ export function FolderNavigationWorkspace() {
         folderTree={folderTree}
         selectedFolderPath={selectedFolderPath}
         expandedFolderPaths={expandedFolderPaths}
-        onSelect={setSelectedFolderPath}
+        onSelect={selectFolder}
         onToggle={toggleFolder}
       />
       <NoteList


### PR DESCRIPTION
## Summary
- extract desktop folder move/rename state updates into a feature model helper
- keep notes, explicit empty folders, selected folder, and expanded folder state updated as a single workspace state change
- add Vitest coverage for note moves, folder renames, root moves, and affected-note reporting
- include desktop tests in the workspace `pnpm test` command

## Testing
- pnpm test
- pnpm typecheck
- pnpm --filter @grove/desktop build
- pnpm lint
- pnpm format
- git diff --cached --check

Refs #18
