### PR TITLE
Add desktop folder state reconciliation

### DIFF
--- a/apps/desktop/src/features/folder-navigation/model/folderWorkspaceState.test.ts
+++ b/apps/desktop/src/features/folder-navigation/model/folderWorkspaceState.test.ts
@@ -2,7 +2,11 @@ import { describe, expect, it } from "vitest";
 
 import { normalizeFolderPath, normalizeNoteFilePath } from "@grove/core";
 import type { FolderWorkspaceState } from "./folderWorkspaceState";
-import { moveNoteInFolderWorkspace, renameFolderInWorkspace } from "./folderWorkspaceState";
+import {
+  moveNoteInFolderWorkspace,
+  reconcileFolderWorkspaceState,
+  renameFolderInWorkspace,
+} from "./folderWorkspaceState";
 
 const workspaceState: FolderWorkspaceState = {
   notes: [
@@ -44,6 +48,55 @@ describe("moveNoteInFolderWorkspace", () => {
     );
     expect(result.state.selectedFolderPath).toBe("Reading");
     expect(result.state.explicitFolders).toStrictEqual(workspaceState.explicitFolders);
+  });
+
+  it("expands ancestors when a note moves into a nested folder", () => {
+    const result = moveNoteInFolderWorkspace(
+      workspaceState,
+      "note-root",
+      normalizeFolderPath("Projects/Grove/Ideas"),
+    );
+
+    expect(result.state.notes.find((note) => note.id === "note-root")?.path).toBe(
+      "Projects/Grove/Ideas/Inbox.md",
+    );
+    expect(result.state.expandedFolderPaths).toStrictEqual([
+      "Projects",
+      "Projects/Grove",
+      "Projects/Grove/Research",
+    ]);
+    expect(result.state.selectedFolderPath).toBe("Projects/Grove/Ideas");
+  });
+});
+
+describe("reconcileFolderWorkspaceState", () => {
+  it("moves stale folder selection back to the workspace root after a folder disappears", () => {
+    const result = reconcileFolderWorkspaceState({
+      ...workspaceState,
+      notes: workspaceState.notes.filter((note) => !note.path.startsWith("Projects/Grove/")),
+      explicitFolders: [normalizeFolderPath("Reading")],
+      selectedFolderPath: normalizeFolderPath("Projects/Grove"),
+      expandedFolderPaths: ["Projects", "Projects/Grove", "Projects/Grove/Research", "Reading"],
+    });
+
+    expect(result.selectedFolderPath).toBeNull();
+    expect(result.expandedFolderPaths).toStrictEqual(["Reading"]);
+  });
+
+  it("keeps selection for an explicit empty folder that still exists", () => {
+    const result = reconcileFolderWorkspaceState({
+      ...workspaceState,
+      notes: [],
+      selectedFolderPath: normalizeFolderPath("Projects/Grove/Ideas"),
+      expandedFolderPaths: ["Projects", "Projects/Grove", "Projects/Grove/Ideas"],
+    });
+
+    expect(result.selectedFolderPath).toBe("Projects/Grove/Ideas");
+    expect(result.expandedFolderPaths).toStrictEqual([
+      "Projects",
+      "Projects/Grove",
+      "Projects/Grove/Ideas",
+    ]);
   });
 });
 

--- a/apps/desktop/src/features/folder-navigation/model/folderWorkspaceState.ts
+++ b/apps/desktop/src/features/folder-navigation/model/folderWorkspaceState.ts
@@ -1,10 +1,11 @@
 import {
+  buildFolderTree,
   compareWorkspacePaths,
   moveNoteToFolder,
   normalizeFolderPath,
   renameFolderInNotePath,
 } from "@grove/core";
-import type { FolderPath, FolderScope, NoteFilePath } from "@grove/core";
+import type { FolderPath, FolderScope, FolderTreeNode, NoteFilePath } from "@grove/core";
 
 export type FolderNavigationNote = {
   id: string;
@@ -66,11 +67,43 @@ function getFolderPathAncestors(folderPath: FolderPath): FolderPath[] {
   return ancestors;
 }
 
+function flattenFolderTreePaths(folderTree: readonly FolderTreeNode[]): FolderPath[] {
+  return folderTree.flatMap((node) => [node.path, ...flattenFolderTreePaths(node.children)]);
+}
+
+function getExistingFolderPathSet(state: FolderWorkspaceState): Set<string> {
+  const folderTree = buildFolderTree(
+    state.notes.map((note) => note.path),
+    state.explicitFolders,
+  );
+
+  return new Set(flattenFolderTreePaths(folderTree));
+}
+
 export function isDescendantFolderPath(
   folderPath: FolderPath,
   parentFolderPath: FolderPath,
 ): boolean {
   return folderPath.startsWith(`${parentFolderPath}/`);
+}
+
+export function reconcileFolderWorkspaceState(state: FolderWorkspaceState): FolderWorkspaceState {
+  const existingFolderPaths = getExistingFolderPathSet(state);
+  const selectedFolderPath =
+    state.selectedFolderPath !== null && existingFolderPaths.has(state.selectedFolderPath)
+      ? state.selectedFolderPath
+      : null;
+  const expandedFolderPaths = dedupeExpandedFolderPaths(
+    state.expandedFolderPaths
+      .map((folderPath) => normalizeFolderPath(folderPath))
+      .filter((folderPath) => existingFolderPaths.has(folderPath)),
+  );
+
+  return {
+    ...state,
+    expandedFolderPaths,
+    selectedFolderPath,
+  };
 }
 
 export function moveNoteInFolderWorkspace(
@@ -98,6 +131,13 @@ export function moveNoteInFolderWorkspace(
     state: {
       ...state,
       notes,
+      expandedFolderPaths:
+        targetFolderPath === null
+          ? state.expandedFolderPaths
+          : dedupeExpandedFolderPaths([
+              ...state.expandedFolderPaths,
+              ...getFolderPathAncestors(targetFolderPath),
+            ]),
       selectedFolderPath: targetFolderPath,
     },
   };

--- a/apps/desktop/src/features/folder-navigation/ui/FolderNavigationWorkspace.tsx
+++ b/apps/desktop/src/features/folder-navigation/ui/FolderNavigationWorkspace.tsx
@@ -14,6 +14,7 @@ import { useEffect, useMemo, useState } from "react";
 import {
   isDescendantFolderPath,
   moveNoteInFolderWorkspace,
+  reconcileFolderWorkspaceState,
   renameFolderInWorkspace,
 } from "../model/folderWorkspaceState";
 import type { FolderNavigationNote, FolderWorkspaceState } from "../model/folderWorkspaceState";
@@ -450,7 +451,7 @@ export function FolderNavigationWorkspace() {
   }, [notes, selectedFolderPath]);
 
   function applyWorkspaceState(nextState: FolderWorkspaceState): void {
-    setWorkspaceState(nextState);
+    setWorkspaceState(reconcileFolderWorkspaceState(nextState));
   }
 
   function toggleFolder(path: string): void {


### PR DESCRIPTION
## Summary
- add desktop folder workspace state reconciliation for stale selected and expanded folder paths after path changes or reloads
- keep explicit empty folders valid while falling back vanished folder selections to the workspace root
- expand ancestor folders when moving a note into a nested folder so the selected target stays reachable

## Testing
- pnpm --filter @grove/desktop test
- pnpm --filter @grove/desktop typecheck
- pnpm --filter @grove/desktop build
- pnpm test
- pnpm typecheck
- pnpm lint
- pnpm format
- git diff --check

Refs #18
