### PR TITLE
Add desktop folder path change plan

### DIFF
--- a/apps/desktop/README.md
+++ b/apps/desktop/README.md
@@ -137,6 +137,10 @@ apps/desktop/
 フォルダ path は workspace 相対 path として保持し、React state に絶対 path を入れません。
 path の正規化、rename、move、ファイルシステム上の整合性は `packages/core` と Tauri command 境界の責務に寄せます。
 
+フォルダ操作の state mutation は、React state 更新だけでなく `previousPath` / `nextPath` の変更計画も返します。
+desktop host はその計画を Tauri file I/O と SQLite index refresh に渡し、Markdown ファイルの移動、`Note.filePath` 更新、派生 index 更新を同じユーザー操作の結果として扱います。
+途中で file move や index refresh が失敗した場合も Markdown ファイルを正本とし、次回 workspace scan で folder tree と note list を再導出できる状態を維持します。
+
 Query 境界:
 
 - プラグインカタログ取得

--- a/apps/desktop/src/features/folder-navigation/model/folderWorkspaceState.test.ts
+++ b/apps/desktop/src/features/folder-navigation/model/folderWorkspaceState.test.ts
@@ -43,6 +43,17 @@ describe("moveNoteInFolderWorkspace", () => {
     );
 
     expect(result.affectedNoteIds).toStrictEqual(["note-plan"]);
+    expect(result.pathChanges).toStrictEqual([
+      {
+        noteId: "note-plan",
+        previousPath: "Projects/Grove/Plan.md",
+        nextPath: "Reading/Plan.md",
+      },
+    ]);
+    expect(result.indexRefresh).toStrictEqual({
+      noteIds: ["note-plan"],
+      reason: "note-move",
+    });
     expect(result.state.notes.find((note) => note.id === "note-plan")?.path).toBe(
       "Reading/Plan.md",
     );
@@ -109,6 +120,22 @@ describe("renameFolderInWorkspace", () => {
     );
 
     expect(result.affectedNoteIds).toStrictEqual(["note-plan", "note-research"]);
+    expect(result.pathChanges).toStrictEqual([
+      {
+        noteId: "note-plan",
+        previousPath: "Projects/Grove/Plan.md",
+        nextPath: "Areas/Grove/Plan.md",
+      },
+      {
+        noteId: "note-research",
+        previousPath: "Projects/Grove/Research/Notes.md",
+        nextPath: "Areas/Grove/Research/Notes.md",
+      },
+    ]);
+    expect(result.indexRefresh).toStrictEqual({
+      noteIds: ["note-plan", "note-research"],
+      reason: "folder-rename",
+    });
     expect(result.state.notes.map((note) => note.path)).toStrictEqual([
       "Inbox.md",
       "Areas/Grove/Plan.md",

--- a/apps/desktop/src/features/folder-navigation/model/folderWorkspaceState.ts
+++ b/apps/desktop/src/features/folder-navigation/model/folderWorkspaceState.ts
@@ -32,6 +32,8 @@ export type FolderWorkspaceIndexRefresh = {
   reason: "note-move" | "folder-rename";
 };
 
+type FolderWorkspaceIndexRefreshReason = FolderWorkspaceIndexRefresh["reason"];
+
 export type FolderWorkspaceMutation = {
   state: FolderWorkspaceState;
   pathChanges: readonly FolderWorkspacePathChange[];
@@ -93,6 +95,24 @@ function getExistingFolderPathSet(state: FolderWorkspaceState): Set<string> {
   return new Set(flattenFolderTreePaths(folderTree));
 }
 
+function createWorkspaceMutation(
+  state: FolderWorkspaceState,
+  pathChanges: readonly FolderWorkspacePathChange[],
+  reason: FolderWorkspaceIndexRefreshReason,
+): FolderWorkspaceMutation {
+  const affectedNoteIds = pathChanges.map((pathChange) => pathChange.noteId);
+
+  return {
+    affectedNoteIds,
+    indexRefresh: {
+      noteIds: affectedNoteIds,
+      reason,
+    },
+    pathChanges,
+    state,
+  };
+}
+
 export function isDescendantFolderPath(
   folderPath: FolderPath,
   parentFolderPath: FolderPath,
@@ -142,16 +162,9 @@ export function moveNoteInFolderWorkspace(
 
     return { ...note, path: nextPath };
   });
-  const affectedNoteIds = pathChanges.map((pathChange) => pathChange.noteId);
 
-  return {
-    affectedNoteIds,
-    indexRefresh: {
-      noteIds: affectedNoteIds,
-      reason: "note-move",
-    },
-    pathChanges,
-    state: {
+  return createWorkspaceMutation(
+    {
       ...state,
       notes,
       expandedFolderPaths:
@@ -163,7 +176,9 @@ export function moveNoteInFolderWorkspace(
             ]),
       selectedFolderPath: targetFolderPath,
     },
-  };
+    pathChanges,
+    "note-move",
+  );
 }
 
 export function renameFolderInWorkspace(
@@ -189,7 +204,6 @@ export function renameFolderInWorkspace(
 
     return { ...note, path: nextPath };
   });
-  const affectedNoteIds = pathChanges.map((pathChange) => pathChange.noteId);
   const explicitFolders = dedupeAndSortFolderPaths(
     state.explicitFolders.flatMap((folderPath) => {
       const nextPath = replaceFolderPrefix(folderPath, sourceFolderPath, targetFolderPath);
@@ -208,19 +222,15 @@ export function renameFolderInWorkspace(
     ...(targetFolderPath === null ? [] : getFolderPathAncestors(targetFolderPath)),
   ]);
 
-  return {
-    affectedNoteIds,
-    indexRefresh: {
-      noteIds: affectedNoteIds,
-      reason: "folder-rename",
-    },
-    pathChanges,
-    state: {
+  return createWorkspaceMutation(
+    {
       ...state,
       notes,
       explicitFolders,
       expandedFolderPaths,
       selectedFolderPath: targetFolderPath,
     },
-  };
+    pathChanges,
+    "folder-rename",
+  );
 }

--- a/apps/desktop/src/features/folder-navigation/model/folderWorkspaceState.ts
+++ b/apps/desktop/src/features/folder-navigation/model/folderWorkspaceState.ts
@@ -21,9 +21,22 @@ export type FolderWorkspaceState = {
   expandedFolderPaths: readonly string[];
 };
 
+export type FolderWorkspacePathChange = {
+  noteId: string;
+  previousPath: NoteFilePath;
+  nextPath: NoteFilePath;
+};
+
+export type FolderWorkspaceIndexRefresh = {
+  noteIds: readonly string[];
+  reason: "note-move" | "folder-rename";
+};
+
 export type FolderWorkspaceMutation = {
   state: FolderWorkspaceState;
+  pathChanges: readonly FolderWorkspacePathChange[];
   affectedNoteIds: readonly string[];
+  indexRefresh: FolderWorkspaceIndexRefresh;
 };
 
 function isFolderPathWithin(folderPath: FolderPath, parentFolderPath: FolderPath): boolean {
@@ -111,7 +124,7 @@ export function moveNoteInFolderWorkspace(
   noteId: string,
   targetFolderPath: FolderScope,
 ): FolderWorkspaceMutation {
-  const affectedNoteIds: string[] = [];
+  const pathChanges: FolderWorkspacePathChange[] = [];
   const notes = state.notes.map((note) => {
     if (note.id !== noteId) {
       return note;
@@ -120,14 +133,24 @@ export function moveNoteInFolderWorkspace(
     const nextPath = moveNoteToFolder(note.path, targetFolderPath);
 
     if (nextPath !== note.path) {
-      affectedNoteIds.push(note.id);
+      pathChanges.push({
+        noteId: note.id,
+        previousPath: note.path,
+        nextPath,
+      });
     }
 
     return { ...note, path: nextPath };
   });
+  const affectedNoteIds = pathChanges.map((pathChange) => pathChange.noteId);
 
   return {
     affectedNoteIds,
+    indexRefresh: {
+      noteIds: affectedNoteIds,
+      reason: "note-move",
+    },
+    pathChanges,
     state: {
       ...state,
       notes,
@@ -152,16 +175,21 @@ export function renameFolderInWorkspace(
     throw new Error("Choose a folder outside the selected folder.");
   }
 
-  const affectedNoteIds: string[] = [];
+  const pathChanges: FolderWorkspacePathChange[] = [];
   const notes = state.notes.map((note) => {
     const nextPath = renameFolderInNotePath(note.path, sourceFolderPath, targetFolderPath);
 
     if (nextPath !== note.path) {
-      affectedNoteIds.push(note.id);
+      pathChanges.push({
+        noteId: note.id,
+        previousPath: note.path,
+        nextPath,
+      });
     }
 
     return { ...note, path: nextPath };
   });
+  const affectedNoteIds = pathChanges.map((pathChange) => pathChange.noteId);
   const explicitFolders = dedupeAndSortFolderPaths(
     state.explicitFolders.flatMap((folderPath) => {
       const nextPath = replaceFolderPrefix(folderPath, sourceFolderPath, targetFolderPath);
@@ -182,6 +210,11 @@ export function renameFolderInWorkspace(
 
   return {
     affectedNoteIds,
+    indexRefresh: {
+      noteIds: affectedNoteIds,
+      reason: "folder-rename",
+    },
+    pathChanges,
     state: {
       ...state,
       notes,

--- a/apps/desktop/src/features/folder-navigation/ui/FolderNavigationWorkspace.tsx
+++ b/apps/desktop/src/features/folder-navigation/ui/FolderNavigationWorkspace.tsx
@@ -17,7 +17,11 @@ import {
   reconcileFolderWorkspaceState,
   renameFolderInWorkspace,
 } from "../model/folderWorkspaceState";
-import type { FolderNavigationNote, FolderWorkspaceState } from "../model/folderWorkspaceState";
+import type {
+  FolderNavigationNote,
+  FolderWorkspacePathChange,
+  FolderWorkspaceState,
+} from "../model/folderWorkspaceState";
 import "./FolderNavigationWorkspace.css";
 
 type NoteListItem = FolderNavigationNote;
@@ -56,20 +60,20 @@ type ActivePaneProps = {
   folderOptions: readonly FolderOption[];
   selectedFolderPath: FolderScope;
   selectedNoteId: string;
-  onMoveSelectedNote: (targetFolderPath: FolderScope) => readonly string[];
-  onRenameSelectedFolder: (targetFolderPath: FolderScope) => readonly string[];
+  onMoveSelectedNote: (targetFolderPath: FolderScope) => readonly FolderWorkspacePathChange[];
+  onRenameSelectedFolder: (targetFolderPath: FolderScope) => readonly FolderWorkspacePathChange[];
 };
 
 type MoveNoteControlProps = {
   folderOptions: readonly FolderOption[];
   selectedNoteFolderPath: FolderScope;
-  onMoveSelectedNote: (targetFolderPath: FolderScope) => readonly string[];
+  onMoveSelectedNote: (targetFolderPath: FolderScope) => readonly FolderWorkspacePathChange[];
   onOperationMessage: (message: string) => void;
 };
 
 type RenameFolderControlProps = {
   selectedFolderPath: FolderScope;
-  onRenameSelectedFolder: (targetFolderPath: FolderScope) => readonly string[];
+  onRenameSelectedFolder: (targetFolderPath: FolderScope) => readonly FolderWorkspacePathChange[];
   onOperationMessage: (message: string) => void;
 };
 
@@ -135,6 +139,15 @@ function flattenFolderTree(folderTree: readonly FolderTreeNode[]): FolderOption[
 
 function getErrorMessage(error: unknown): string {
   return error instanceof Error ? error.message : "The folder path is invalid.";
+}
+
+function getPathChangeSummary(pathChanges: readonly FolderWorkspacePathChange[]): string {
+  if (pathChanges.length === 0) {
+    return "No file path changes were needed.";
+  }
+
+  const noun = pathChanges.length === 1 ? "change" : "changes";
+  return `${pathChanges.length} file path ${noun} queued for file move and index refresh.`;
 }
 
 function FolderNode({
@@ -292,9 +305,8 @@ function MoveNoteControl({
 
   function moveSelectedNote(): void {
     try {
-      const affectedNoteIds = onMoveSelectedNote(normalizeFolderScope(moveTargetPath));
-      const movedNoteCount = affectedNoteIds.length;
-      onOperationMessage(`Moved ${movedNoteCount} note and refreshed folder counts.`);
+      const pathChanges = onMoveSelectedNote(normalizeFolderScope(moveTargetPath));
+      onOperationMessage(getPathChangeSummary(pathChanges));
     } catch (error) {
       onOperationMessage(getErrorMessage(error));
     }
@@ -349,10 +361,8 @@ function RenameFolderControl({
         return;
       }
 
-      const affectedNoteIds = onRenameSelectedFolder(targetFolderPath);
-      onOperationMessage(
-        `Renamed the folder and refreshed ${affectedNoteIds.length} affected note paths.`,
-      );
+      const pathChanges = onRenameSelectedFolder(targetFolderPath);
+      onOperationMessage(getPathChangeSummary(pathChanges));
     } catch (error) {
       onOperationMessage(getErrorMessage(error));
     }
@@ -479,20 +489,22 @@ export function FolderNavigationWorkspace() {
     }));
   }
 
-  function moveSelectedNote(targetFolderPath: FolderScope): readonly string[] {
+  function moveSelectedNote(targetFolderPath: FolderScope): readonly FolderWorkspacePathChange[] {
     const mutation = moveNoteInFolderWorkspace(workspaceState, selectedNoteId, targetFolderPath);
     applyWorkspaceState(mutation.state);
-    return mutation.affectedNoteIds;
+    return mutation.pathChanges;
   }
 
-  function renameSelectedFolder(targetFolderPath: FolderScope): readonly string[] {
+  function renameSelectedFolder(
+    targetFolderPath: FolderScope,
+  ): readonly FolderWorkspacePathChange[] {
     if (selectedFolderPath === null) {
       return [];
     }
 
     const mutation = renameFolderInWorkspace(workspaceState, selectedFolderPath, targetFolderPath);
     applyWorkspaceState(mutation.state);
-    return mutation.affectedNoteIds;
+    return mutation.pathChanges;
   }
 
   return (


### PR DESCRIPTION
## Summary
- add desktop folder workspace path-change plans with previous/next note paths for move and rename operations
- expose index refresh metadata from the same mutation result used to update folder navigation state
- update desktop operation messaging and README expectations for Tauri file I/O and SQLite refresh handoff

## Testing
- pnpm --filter @grove/desktop test
- pnpm --filter @grove/desktop typecheck
- pnpm test
- pnpm typecheck
- pnpm lint
- pnpm format
- pnpm --filter @grove/desktop build
- git diff --check

Refs #18
