### PR TITLE
Add desktop path change queue

### DIFF
--- a/apps/desktop/src/features/folder-navigation/model/folderWorkspaceState.test.ts
+++ b/apps/desktop/src/features/folder-navigation/model/folderWorkspaceState.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from "vitest";
 import { normalizeFolderPath, normalizeNoteFilePath } from "@grove/core";
 import type { FolderWorkspaceState } from "./folderWorkspaceState";
 import {
+  createPathChangeOperation,
   moveNoteInFolderWorkspace,
   reconcileFolderWorkspaceState,
   renameFolderInWorkspace,
@@ -77,6 +78,49 @@ describe("moveNoteInFolderWorkspace", () => {
       "Projects/Grove/Research",
     ]);
     expect(result.state.selectedFolderPath).toBe("Projects/Grove/Ideas");
+  });
+});
+
+describe("createPathChangeOperation", () => {
+  it("creates a pending file and index operation for changed note paths", () => {
+    const mutation = moveNoteInFolderWorkspace(
+      workspaceState,
+      "note-plan",
+      normalizeFolderPath("Reading"),
+    );
+
+    expect(createPathChangeOperation("operation-1", mutation)).toStrictEqual({
+      id: "operation-1",
+      reason: "note-move",
+      affectedNoteIds: ["note-plan"],
+      pathChanges: [
+        {
+          noteId: "note-plan",
+          previousPath: "Projects/Grove/Plan.md",
+          nextPath: "Reading/Plan.md",
+        },
+      ],
+      steps: [
+        {
+          id: "file-move",
+          status: "pending",
+        },
+        {
+          id: "index-refresh",
+          status: "pending",
+        },
+      ],
+    });
+  });
+
+  it("does not create an operation when paths are unchanged", () => {
+    const mutation = moveNoteInFolderWorkspace(
+      workspaceState,
+      "note-plan",
+      normalizeFolderPath("Projects/Grove"),
+    );
+
+    expect(createPathChangeOperation("operation-1", mutation)).toBeNull();
   });
 });
 

--- a/apps/desktop/src/features/folder-navigation/model/folderWorkspaceState.test.ts
+++ b/apps/desktop/src/features/folder-navigation/model/folderWorkspaceState.test.ts
@@ -3,10 +3,16 @@ import { describe, expect, it } from "vitest";
 import { normalizeFolderPath, normalizeNoteFilePath } from "@grove/core";
 import type { FolderWorkspaceState } from "./folderWorkspaceState";
 import {
+  completeNextOperationStep,
   createPathChangeOperation,
+  failNextOperationStep,
+  getFailedOperationSteps,
+  getNextPendingOperationStep,
+  isPathChangeOperationComplete,
   moveNoteInFolderWorkspace,
   reconcileFolderWorkspaceState,
   renameFolderInWorkspace,
+  retryOperationStep,
 } from "./folderWorkspaceState";
 
 const workspaceState: FolderWorkspaceState = {
@@ -121,6 +127,87 @@ describe("createPathChangeOperation", () => {
     );
 
     expect(createPathChangeOperation("operation-1", mutation)).toBeNull();
+  });
+});
+
+describe("path change operation steps", () => {
+  it("completes file moves before index refreshes", () => {
+    const mutation = moveNoteInFolderWorkspace(
+      workspaceState,
+      "note-plan",
+      normalizeFolderPath("Reading"),
+    );
+    const operation = createPathChangeOperation("operation-1", mutation);
+
+    if (operation === null) {
+      throw new Error("Expected path change operation.");
+    }
+
+    const afterFileMove = completeNextOperationStep([operation], "operation-1")[0];
+
+    expect(afterFileMove?.steps).toStrictEqual([
+      {
+        id: "file-move",
+        status: "completed",
+      },
+      {
+        id: "index-refresh",
+        status: "pending",
+      },
+    ]);
+    expect(
+      afterFileMove === undefined ? null : getNextPendingOperationStep(afterFileMove)?.id,
+    ).toBe("index-refresh");
+
+    const afterIndexRefresh = completeNextOperationStep([afterFileMove], "operation-1")[0];
+
+    expect(
+      afterIndexRefresh === undefined ? false : isPathChangeOperationComplete(afterIndexRefresh),
+    ).toBe(true);
+  });
+
+  it("blocks later steps until a failed step is retried", () => {
+    const mutation = renameFolderInWorkspace(
+      workspaceState,
+      normalizeFolderPath("Projects/Grove"),
+      normalizeFolderPath("Areas/Grove"),
+    );
+    const operation = createPathChangeOperation("operation-1", mutation);
+
+    if (operation === null) {
+      throw new Error("Expected path change operation.");
+    }
+
+    const failedOperations = failNextOperationStep(
+      [operation],
+      "operation-1",
+      "The target Markdown file already exists.",
+    );
+    const failedOperation = failedOperations[0];
+
+    expect(
+      failedOperation === undefined ? null : getNextPendingOperationStep(failedOperation),
+    ).toBe(null);
+    expect(
+      failedOperation === undefined ? [] : getFailedOperationSteps(failedOperation),
+    ).toStrictEqual([
+      {
+        id: "file-move",
+        errorMessage: "The target Markdown file already exists.",
+        status: "failed",
+      },
+    ]);
+
+    const retryOperations = retryOperationStep(failedOperations, "operation-1", "file-move");
+    const retryOperation = retryOperations[0];
+
+    expect(
+      retryOperation === undefined ? null : getNextPendingOperationStep(retryOperation)?.id,
+    ).toBe("file-move");
+    expect(retryOperation?.steps[0]).toStrictEqual({
+      id: "file-move",
+      status: "pending",
+    });
   });
 });
 

--- a/apps/desktop/src/features/folder-navigation/model/folderWorkspaceState.ts
+++ b/apps/desktop/src/features/folder-navigation/model/folderWorkspaceState.ts
@@ -34,11 +34,24 @@ export type FolderWorkspaceIndexRefresh = {
 
 type FolderWorkspaceIndexRefreshReason = FolderWorkspaceIndexRefresh["reason"];
 
+export type FolderWorkspaceOperationStep = {
+  id: "file-move" | "index-refresh";
+  status: "pending";
+};
+
 export type FolderWorkspaceMutation = {
   state: FolderWorkspaceState;
   pathChanges: readonly FolderWorkspacePathChange[];
   affectedNoteIds: readonly string[];
   indexRefresh: FolderWorkspaceIndexRefresh;
+};
+
+export type FolderWorkspacePathChangeOperation = {
+  id: string;
+  reason: FolderWorkspaceIndexRefreshReason;
+  pathChanges: readonly FolderWorkspacePathChange[];
+  affectedNoteIds: readonly string[];
+  steps: readonly FolderWorkspaceOperationStep[];
 };
 
 function isFolderPathWithin(folderPath: FolderPath, parentFolderPath: FolderPath): boolean {
@@ -110,6 +123,32 @@ function createWorkspaceMutation(
     },
     pathChanges,
     state,
+  };
+}
+
+export function createPathChangeOperation(
+  id: string,
+  mutation: FolderWorkspaceMutation,
+): FolderWorkspacePathChangeOperation | null {
+  if (mutation.pathChanges.length === 0) {
+    return null;
+  }
+
+  return {
+    id,
+    affectedNoteIds: mutation.affectedNoteIds,
+    pathChanges: mutation.pathChanges,
+    reason: mutation.indexRefresh.reason,
+    steps: [
+      {
+        id: "file-move",
+        status: "pending",
+      },
+      {
+        id: "index-refresh",
+        status: "pending",
+      },
+    ],
   };
 }
 

--- a/apps/desktop/src/features/folder-navigation/model/folderWorkspaceState.ts
+++ b/apps/desktop/src/features/folder-navigation/model/folderWorkspaceState.ts
@@ -34,9 +34,14 @@ export type FolderWorkspaceIndexRefresh = {
 
 type FolderWorkspaceIndexRefreshReason = FolderWorkspaceIndexRefresh["reason"];
 
+export type FolderWorkspaceOperationStepId = "file-move" | "index-refresh";
+
+export type FolderWorkspaceOperationStepStatus = "pending" | "completed" | "failed";
+
 export type FolderWorkspaceOperationStep = {
-  id: "file-move" | "index-refresh";
-  status: "pending";
+  id: FolderWorkspaceOperationStepId;
+  status: FolderWorkspaceOperationStepStatus;
+  errorMessage?: string;
 };
 
 export type FolderWorkspaceMutation = {
@@ -150,6 +155,88 @@ export function createPathChangeOperation(
       },
     ],
   };
+}
+
+export function getNextPendingOperationStep(
+  operation: FolderWorkspacePathChangeOperation,
+): FolderWorkspaceOperationStep | null {
+  if (operation.steps.some((step) => step.status === "failed")) {
+    return null;
+  }
+
+  return operation.steps.find((step) => step.status === "pending") ?? null;
+}
+
+export function getFailedOperationSteps(
+  operation: FolderWorkspacePathChangeOperation,
+): FolderWorkspaceOperationStep[] {
+  return operation.steps.filter((step) => step.status === "failed");
+}
+
+export function isPathChangeOperationComplete(
+  operation: FolderWorkspacePathChangeOperation,
+): boolean {
+  return operation.steps.every((step) => step.status === "completed");
+}
+
+export function completeNextOperationStep(
+  operations: readonly FolderWorkspacePathChangeOperation[],
+  operationId: string,
+): FolderWorkspacePathChangeOperation[] {
+  return operations.map((operation) => {
+    if (operation.id !== operationId) {
+      return operation;
+    }
+
+    const nextStep = getNextPendingOperationStep(operation);
+
+    if (nextStep === null) {
+      return operation;
+    }
+
+    return updateOperationStep(operation, nextStep.id, {
+      status: "completed",
+    });
+  });
+}
+
+export function failNextOperationStep(
+  operations: readonly FolderWorkspacePathChangeOperation[],
+  operationId: string,
+  errorMessage: string,
+): FolderWorkspacePathChangeOperation[] {
+  return operations.map((operation) => {
+    if (operation.id !== operationId) {
+      return operation;
+    }
+
+    const nextStep = getNextPendingOperationStep(operation);
+
+    if (nextStep === null) {
+      return operation;
+    }
+
+    return updateOperationStep(operation, nextStep.id, {
+      errorMessage,
+      status: "failed",
+    });
+  });
+}
+
+export function retryOperationStep(
+  operations: readonly FolderWorkspacePathChangeOperation[],
+  operationId: string,
+  stepId: FolderWorkspaceOperationStepId,
+): FolderWorkspacePathChangeOperation[] {
+  return operations.map((operation) => {
+    if (operation.id !== operationId) {
+      return operation;
+    }
+
+    return updateOperationStep(operation, stepId, {
+      status: "pending",
+    });
+  });
 }
 
 export function isDescendantFolderPath(
@@ -272,4 +359,31 @@ export function renameFolderInWorkspace(
     pathChanges,
     "folder-rename",
   );
+}
+
+function updateOperationStep(
+  operation: FolderWorkspacePathChangeOperation,
+  stepId: FolderWorkspaceOperationStepId,
+  nextStepState: Pick<FolderWorkspaceOperationStep, "status"> &
+    Partial<Pick<FolderWorkspaceOperationStep, "errorMessage">>,
+): FolderWorkspacePathChangeOperation {
+  return {
+    ...operation,
+    steps: operation.steps.map((step) => {
+      if (step.id !== stepId) {
+        return step;
+      }
+
+      return nextStepState.errorMessage === undefined
+        ? {
+            id: step.id,
+            status: nextStepState.status,
+          }
+        : {
+            id: step.id,
+            errorMessage: nextStepState.errorMessage,
+            status: nextStepState.status,
+          };
+    }),
+  };
 }

--- a/apps/desktop/src/features/folder-navigation/ui/FolderNavigationWorkspace.css
+++ b/apps/desktop/src/features/folder-navigation/ui/FolderNavigationWorkspace.css
@@ -2,19 +2,21 @@
   background: #f7f8f5;
   color: #17211b;
   display: grid;
-  grid-template-columns: 18rem minmax(20rem, 28rem) minmax(20rem, 1fr);
+  grid-template-columns: 18rem minmax(20rem, 26rem) minmax(20rem, 1fr) minmax(18rem, 24rem);
   min-height: 100vh;
   overflow-x: auto;
 }
 
 .folder-navigation__sidebar,
 .folder-navigation__note-list,
-.folder-navigation__pane {
+.folder-navigation__pane,
+.folder-navigation__queue {
   padding: 1.25rem;
 }
 
 .folder-navigation__sidebar,
-.folder-navigation__note-list {
+.folder-navigation__note-list,
+.folder-navigation__pane {
   border-right: 1px solid #dce4dd;
 }
 
@@ -112,16 +114,28 @@
   padding: 0;
 }
 
+.folder-navigation__operations,
+.folder-navigation__steps,
+.folder-navigation__path-changes {
+  display: grid;
+  gap: 0.75rem;
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
 .folder-navigation__note,
 .folder-navigation__empty,
-.folder-navigation__editor {
+.folder-navigation__editor,
+.folder-navigation__operation-item {
   background: #ffffff;
   border: 1px solid #dce4dd;
   border-radius: 8px;
 }
 
 .folder-navigation__note,
-.folder-navigation__empty {
+.folder-navigation__empty,
+.folder-navigation__operation-item {
   padding: 0.875rem;
 }
 
@@ -148,6 +162,11 @@
   margin: 0 0 0.5rem;
 }
 
+.folder-navigation__operation-title {
+  font-size: 1rem;
+  margin: 0 0 0.375rem;
+}
+
 .folder-navigation__muted {
   font-size: 0.875rem;
   line-height: 1.5;
@@ -169,6 +188,40 @@
 .folder-navigation__operation {
   display: grid;
   gap: 0.5rem;
+}
+
+.folder-navigation__operation-item {
+  display: grid;
+  gap: 0.875rem;
+}
+
+.folder-navigation__step {
+  align-items: center;
+  display: flex;
+  gap: 0.75rem;
+  justify-content: space-between;
+}
+
+.folder-navigation__status {
+  background: #eef1ec;
+  border: 1px solid #c8d3ca;
+  border-radius: 999px;
+  color: #39483f;
+  font-size: 0.75rem;
+  padding: 0.125rem 0.5rem;
+  text-transform: uppercase;
+}
+
+.folder-navigation__path-changes {
+  color: #5f6d64;
+  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", monospace;
+  font-size: 0.75rem;
+}
+
+.folder-navigation__path-changes li {
+  display: grid;
+  gap: 0.25rem;
+  overflow-wrap: anywhere;
 }
 
 .folder-navigation__label {
@@ -209,7 +262,8 @@
   }
 
   .folder-navigation__sidebar,
-  .folder-navigation__note-list {
+  .folder-navigation__note-list,
+  .folder-navigation__pane {
     border-bottom: 1px solid #dce4dd;
     border-right: 0;
   }

--- a/apps/desktop/src/features/folder-navigation/ui/FolderNavigationWorkspace.css
+++ b/apps/desktop/src/features/folder-navigation/ui/FolderNavigationWorkspace.css
@@ -196,10 +196,10 @@
 }
 
 .folder-navigation__step {
-  align-items: center;
-  display: flex;
+  align-items: start;
+  display: grid;
   gap: 0.75rem;
-  justify-content: space-between;
+  grid-template-columns: minmax(0, 1fr) auto;
 }
 
 .folder-navigation__status {
@@ -210,6 +210,25 @@
   font-size: 0.75rem;
   padding: 0.125rem 0.5rem;
   text-transform: uppercase;
+}
+
+.folder-navigation__status--completed {
+  background: #ddf3e7;
+  border-color: #1f7a5c;
+  color: #1d5a45;
+}
+
+.folder-navigation__status--failed {
+  background: #ffe8e2;
+  border-color: #c5553c;
+  color: #8f2f1b;
+}
+
+.folder-navigation__step-error {
+  color: #8f2f1b;
+  font-size: 0.75rem;
+  grid-column: 1 / -1;
+  line-height: 1.4;
 }
 
 .folder-navigation__path-changes {
@@ -250,7 +269,26 @@
   width: fit-content;
 }
 
+.folder-navigation__queue-actions {
+  align-items: center;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}
+
+.folder-navigation__secondary-action {
+  background: #ffffff;
+  border: 1px solid #c8d3ca;
+  border-radius: 8px;
+  color: #17211b;
+  cursor: pointer;
+  min-height: 2.25rem;
+  padding: 0 0.875rem;
+  width: fit-content;
+}
+
 .folder-navigation__action:disabled,
+.folder-navigation__secondary-action:disabled,
 .folder-navigation__input:disabled {
   cursor: not-allowed;
   opacity: 0.55;

--- a/apps/desktop/src/features/folder-navigation/ui/FolderNavigationWorkspace.tsx
+++ b/apps/desktop/src/features/folder-navigation/ui/FolderNavigationWorkspace.tsx
@@ -12,15 +12,22 @@ import type { FolderScope, FolderTreeNode } from "@grove/core";
 import { useEffect, useMemo, useRef, useState } from "react";
 
 import {
+  completeNextOperationStep,
   createPathChangeOperation,
+  failNextOperationStep,
+  getFailedOperationSteps,
+  getNextPendingOperationStep,
   isDescendantFolderPath,
+  isPathChangeOperationComplete,
   moveNoteInFolderWorkspace,
   reconcileFolderWorkspaceState,
   renameFolderInWorkspace,
+  retryOperationStep,
 } from "../model/folderWorkspaceState";
 import type {
   FolderNavigationNote,
   FolderWorkspaceMutation,
+  FolderWorkspaceOperationStepId,
   FolderWorkspaceOperationStep,
   FolderWorkspacePathChange,
   FolderWorkspacePathChangeOperation,
@@ -83,6 +90,9 @@ type RenameFolderControlProps = {
 
 type PathChangeQueueProps = {
   operations: readonly FolderWorkspacePathChangeOperation[];
+  onCompleteNextStep: (operationId: string) => void;
+  onFailNextStep: (operationId: string) => void;
+  onRetryStep: (operationId: string, stepId: FolderWorkspaceOperationStepId) => void;
 };
 
 const initialNotes: readonly NoteListItem[] = [
@@ -164,6 +174,10 @@ function getOperationReasonLabel(reason: FolderWorkspacePathChangeOperation["rea
 
 function getOperationStepLabel(stepId: FolderWorkspaceOperationStep["id"]): string {
   return stepId === "file-move" ? "Move Markdown files on disk" : "Refresh derived SQLite indexes";
+}
+
+function getOperationStepStatusClass(step: FolderWorkspaceOperationStep): string {
+  return `folder-navigation__status folder-navigation__status--${step.status}`;
 }
 
 function FolderNode({
@@ -453,42 +467,91 @@ function ActivePane({
   );
 }
 
-function PathChangeQueue({ operations }: PathChangeQueueProps) {
+function PathChangeQueue({
+  operations,
+  onCompleteNextStep,
+  onFailNextStep,
+  onRetryStep,
+}: PathChangeQueueProps) {
   return (
     <section className="folder-navigation__queue" aria-label="Pending path changes">
       <p className="folder-navigation__eyebrow">Local operations</p>
       <h2 className="folder-navigation__heading">Path change queue</h2>
       {operations.length > 0 ? (
         <ol className="folder-navigation__operations">
-          {operations.map((operation) => (
-            <li key={operation.id} className="folder-navigation__operation-item">
-              <div>
-                <h3 className="folder-navigation__operation-title">
-                  {getOperationReasonLabel(operation.reason)}
-                </h3>
-                <p className="folder-navigation__muted">
-                  {operation.pathChanges.length} file path{" "}
-                  {operation.pathChanges.length === 1 ? "change" : "changes"}
-                </p>
-              </div>
-              <ol className="folder-navigation__steps">
-                {operation.steps.map((step) => (
-                  <li key={step.id} className="folder-navigation__step">
-                    <span>{getOperationStepLabel(step.id)}</span>
-                    <span className="folder-navigation__status">{step.status}</span>
-                  </li>
-                ))}
-              </ol>
-              <ol className="folder-navigation__path-changes">
-                {operation.pathChanges.map((pathChange) => (
-                  <li key={`${operation.id}-${pathChange.noteId}`}>
-                    <span>{pathChange.previousPath}</span>
-                    <span>{pathChange.nextPath}</span>
-                  </li>
-                ))}
-              </ol>
-            </li>
-          ))}
+          {operations.map((operation) => {
+            const nextStep = getNextPendingOperationStep(operation);
+            const failedSteps = getFailedOperationSteps(operation);
+            const complete = isPathChangeOperationComplete(operation);
+
+            return (
+              <li key={operation.id} className="folder-navigation__operation-item">
+                <div>
+                  <h3 className="folder-navigation__operation-title">
+                    {getOperationReasonLabel(operation.reason)}
+                  </h3>
+                  <p className="folder-navigation__muted">
+                    {operation.pathChanges.length} file path{" "}
+                    {operation.pathChanges.length === 1 ? "change" : "changes"}
+                  </p>
+                </div>
+                <ol className="folder-navigation__steps">
+                  {operation.steps.map((step) => (
+                    <li key={step.id} className="folder-navigation__step">
+                      <span>{getOperationStepLabel(step.id)}</span>
+                      <span className={getOperationStepStatusClass(step)}>{step.status}</span>
+                      {step.errorMessage === undefined ? null : (
+                        <span className="folder-navigation__step-error">{step.errorMessage}</span>
+                      )}
+                    </li>
+                  ))}
+                </ol>
+                <div className="folder-navigation__queue-actions">
+                  <button
+                    type="button"
+                    className="folder-navigation__action"
+                    onClick={() => onCompleteNextStep(operation.id)}
+                    disabled={nextStep === null}
+                  >
+                    {nextStep === null
+                      ? "Waiting"
+                      : `Complete ${getOperationStepLabel(nextStep.id)}`}
+                  </button>
+                  <button
+                    type="button"
+                    className="folder-navigation__secondary-action"
+                    onClick={() => onFailNextStep(operation.id)}
+                    disabled={nextStep === null}
+                  >
+                    Mark next step failed
+                  </button>
+                  {failedSteps.map((step) => (
+                    <button
+                      key={step.id}
+                      type="button"
+                      className="folder-navigation__secondary-action"
+                      onClick={() => onRetryStep(operation.id, step.id)}
+                    >
+                      Retry {getOperationStepLabel(step.id)}
+                    </button>
+                  ))}
+                  {complete ? (
+                    <span className="folder-navigation__muted">
+                      File move and index refresh are complete.
+                    </span>
+                  ) : null}
+                </div>
+                <ol className="folder-navigation__path-changes">
+                  {operation.pathChanges.map((pathChange) => (
+                    <li key={`${operation.id}-${pathChange.noteId}`}>
+                      <span>{pathChange.previousPath}</span>
+                      <span>{pathChange.nextPath}</span>
+                    </li>
+                  ))}
+                </ol>
+              </li>
+            );
+          })}
         </ol>
       ) : (
         <div className="folder-navigation__empty">
@@ -572,6 +635,28 @@ export function FolderNavigationWorkspace() {
     setPathChangeOperations((currentOperations) => [operation, ...currentOperations]);
   }
 
+  function completeNextPathChangeStep(operationId: string): void {
+    setPathChangeOperations((currentOperations) =>
+      completeNextOperationStep(currentOperations, operationId),
+    );
+  }
+
+  function failNextPathChangeStep(operationId: string): void {
+    setPathChangeOperations((currentOperations) =>
+      failNextOperationStep(
+        currentOperations,
+        operationId,
+        "Local file work needs attention before indexes refresh.",
+      ),
+    );
+  }
+
+  function retryPathChangeStep(operationId: string, stepId: FolderWorkspaceOperationStepId): void {
+    setPathChangeOperations((currentOperations) =>
+      retryOperationStep(currentOperations, operationId, stepId),
+    );
+  }
+
   function moveSelectedNote(targetFolderPath: FolderScope): FolderWorkspaceMutation {
     const mutation = moveNoteInFolderWorkspace(workspaceState, selectedNoteId, targetFolderPath);
     applyWorkspaceState(mutation.state);
@@ -622,7 +707,12 @@ export function FolderNavigationWorkspace() {
         onMoveSelectedNote={moveSelectedNote}
         onRenameSelectedFolder={renameSelectedFolder}
       />
-      <PathChangeQueue operations={pathChangeOperations} />
+      <PathChangeQueue
+        operations={pathChangeOperations}
+        onCompleteNextStep={completeNextPathChangeStep}
+        onFailNextStep={failNextPathChangeStep}
+        onRetryStep={retryPathChangeStep}
+      />
     </section>
   );
 }

--- a/apps/desktop/src/features/folder-navigation/ui/FolderNavigationWorkspace.tsx
+++ b/apps/desktop/src/features/folder-navigation/ui/FolderNavigationWorkspace.tsx
@@ -9,9 +9,10 @@ import {
   normalizeNoteFilePath,
 } from "@grove/core";
 import type { FolderScope, FolderTreeNode } from "@grove/core";
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 
 import {
+  createPathChangeOperation,
   isDescendantFolderPath,
   moveNoteInFolderWorkspace,
   reconcileFolderWorkspaceState,
@@ -19,7 +20,10 @@ import {
 } from "../model/folderWorkspaceState";
 import type {
   FolderNavigationNote,
+  FolderWorkspaceMutation,
+  FolderWorkspaceOperationStep,
   FolderWorkspacePathChange,
+  FolderWorkspacePathChangeOperation,
   FolderWorkspaceState,
 } from "../model/folderWorkspaceState";
 import "./FolderNavigationWorkspace.css";
@@ -60,21 +64,25 @@ type ActivePaneProps = {
   folderOptions: readonly FolderOption[];
   selectedFolderPath: FolderScope;
   selectedNoteId: string;
-  onMoveSelectedNote: (targetFolderPath: FolderScope) => readonly FolderWorkspacePathChange[];
-  onRenameSelectedFolder: (targetFolderPath: FolderScope) => readonly FolderWorkspacePathChange[];
+  onMoveSelectedNote: (targetFolderPath: FolderScope) => FolderWorkspaceMutation;
+  onRenameSelectedFolder: (targetFolderPath: FolderScope) => FolderWorkspaceMutation;
 };
 
 type MoveNoteControlProps = {
   folderOptions: readonly FolderOption[];
   selectedNoteFolderPath: FolderScope;
-  onMoveSelectedNote: (targetFolderPath: FolderScope) => readonly FolderWorkspacePathChange[];
+  onMoveSelectedNote: (targetFolderPath: FolderScope) => FolderWorkspaceMutation;
   onOperationMessage: (message: string) => void;
 };
 
 type RenameFolderControlProps = {
   selectedFolderPath: FolderScope;
-  onRenameSelectedFolder: (targetFolderPath: FolderScope) => readonly FolderWorkspacePathChange[];
+  onRenameSelectedFolder: (targetFolderPath: FolderScope) => FolderWorkspaceMutation;
   onOperationMessage: (message: string) => void;
+};
+
+type PathChangeQueueProps = {
+  operations: readonly FolderWorkspacePathChangeOperation[];
 };
 
 const initialNotes: readonly NoteListItem[] = [
@@ -148,6 +156,14 @@ function getPathChangeSummary(pathChanges: readonly FolderWorkspacePathChange[])
 
   const noun = pathChanges.length === 1 ? "change" : "changes";
   return `${pathChanges.length} file path ${noun} queued for file move and index refresh.`;
+}
+
+function getOperationReasonLabel(reason: FolderWorkspacePathChangeOperation["reason"]): string {
+  return reason === "note-move" ? "Note move" : "Folder rename";
+}
+
+function getOperationStepLabel(stepId: FolderWorkspaceOperationStep["id"]): string {
+  return stepId === "file-move" ? "Move Markdown files on disk" : "Refresh derived SQLite indexes";
 }
 
 function FolderNode({
@@ -305,8 +321,8 @@ function MoveNoteControl({
 
   function moveSelectedNote(): void {
     try {
-      const pathChanges = onMoveSelectedNote(normalizeFolderScope(moveTargetPath));
-      onOperationMessage(getPathChangeSummary(pathChanges));
+      const mutation = onMoveSelectedNote(normalizeFolderScope(moveTargetPath));
+      onOperationMessage(getPathChangeSummary(mutation.pathChanges));
     } catch (error) {
       onOperationMessage(getErrorMessage(error));
     }
@@ -361,8 +377,8 @@ function RenameFolderControl({
         return;
       }
 
-      const pathChanges = onRenameSelectedFolder(targetFolderPath);
-      onOperationMessage(getPathChangeSummary(pathChanges));
+      const mutation = onRenameSelectedFolder(targetFolderPath);
+      onOperationMessage(getPathChangeSummary(mutation.pathChanges));
     } catch (error) {
       onOperationMessage(getErrorMessage(error));
     }
@@ -437,6 +453,55 @@ function ActivePane({
   );
 }
 
+function PathChangeQueue({ operations }: PathChangeQueueProps) {
+  return (
+    <section className="folder-navigation__queue" aria-label="Pending path changes">
+      <p className="folder-navigation__eyebrow">Local operations</p>
+      <h2 className="folder-navigation__heading">Path change queue</h2>
+      {operations.length > 0 ? (
+        <ol className="folder-navigation__operations">
+          {operations.map((operation) => (
+            <li key={operation.id} className="folder-navigation__operation-item">
+              <div>
+                <h3 className="folder-navigation__operation-title">
+                  {getOperationReasonLabel(operation.reason)}
+                </h3>
+                <p className="folder-navigation__muted">
+                  {operation.pathChanges.length} file path{" "}
+                  {operation.pathChanges.length === 1 ? "change" : "changes"}
+                </p>
+              </div>
+              <ol className="folder-navigation__steps">
+                {operation.steps.map((step) => (
+                  <li key={step.id} className="folder-navigation__step">
+                    <span>{getOperationStepLabel(step.id)}</span>
+                    <span className="folder-navigation__status">{step.status}</span>
+                  </li>
+                ))}
+              </ol>
+              <ol className="folder-navigation__path-changes">
+                {operation.pathChanges.map((pathChange) => (
+                  <li key={`${operation.id}-${pathChange.noteId}`}>
+                    <span>{pathChange.previousPath}</span>
+                    <span>{pathChange.nextPath}</span>
+                  </li>
+                ))}
+              </ol>
+            </li>
+          ))}
+        </ol>
+      ) : (
+        <div className="folder-navigation__empty">
+          <h3 className="folder-navigation__note-title">No pending path changes</h3>
+          <p className="folder-navigation__muted">
+            Move a note or rename a folder to queue local file and index work.
+          </p>
+        </div>
+      )}
+    </section>
+  );
+}
+
 export function FolderNavigationWorkspace() {
   const [workspaceState, setWorkspaceState] = useState<FolderWorkspaceState>({
     notes: initialNotes,
@@ -445,6 +510,10 @@ export function FolderNavigationWorkspace() {
     expandedFolderPaths: ["Projects", "Projects/Grove"],
   });
   const [selectedNoteId, setSelectedNoteId] = useState<string>(initialNotes[1]?.id ?? "");
+  const [pathChangeOperations, setPathChangeOperations] = useState<
+    readonly FolderWorkspacePathChangeOperation[]
+  >([]);
+  const nextOperationNumber = useRef(1);
   const { notes, explicitFolders, selectedFolderPath, expandedFolderPaths } = workspaceState;
 
   const folderTree = useMemo(() => {
@@ -489,22 +558,44 @@ export function FolderNavigationWorkspace() {
     }));
   }
 
-  function moveSelectedNote(targetFolderPath: FolderScope): readonly FolderWorkspacePathChange[] {
-    const mutation = moveNoteInFolderWorkspace(workspaceState, selectedNoteId, targetFolderPath);
-    applyWorkspaceState(mutation.state);
-    return mutation.pathChanges;
+  function queuePathChangeOperation(mutation: FolderWorkspaceMutation): void {
+    const operation = createPathChangeOperation(
+      `path-change-${nextOperationNumber.current}`,
+      mutation,
+    );
+
+    if (operation === null) {
+      return;
+    }
+
+    nextOperationNumber.current += 1;
+    setPathChangeOperations((currentOperations) => [operation, ...currentOperations]);
   }
 
-  function renameSelectedFolder(
-    targetFolderPath: FolderScope,
-  ): readonly FolderWorkspacePathChange[] {
+  function moveSelectedNote(targetFolderPath: FolderScope): FolderWorkspaceMutation {
+    const mutation = moveNoteInFolderWorkspace(workspaceState, selectedNoteId, targetFolderPath);
+    applyWorkspaceState(mutation.state);
+    queuePathChangeOperation(mutation);
+    return mutation;
+  }
+
+  function renameSelectedFolder(targetFolderPath: FolderScope): FolderWorkspaceMutation {
     if (selectedFolderPath === null) {
-      return [];
+      return {
+        affectedNoteIds: [],
+        indexRefresh: {
+          noteIds: [],
+          reason: "folder-rename",
+        },
+        pathChanges: [],
+        state: workspaceState,
+      };
     }
 
     const mutation = renameFolderInWorkspace(workspaceState, selectedFolderPath, targetFolderPath);
     applyWorkspaceState(mutation.state);
-    return mutation.pathChanges;
+    queuePathChangeOperation(mutation);
+    return mutation;
   }
 
   return (
@@ -531,6 +622,7 @@ export function FolderNavigationWorkspace() {
         onMoveSelectedNote={moveSelectedNote}
         onRenameSelectedFolder={renameSelectedFolder}
       />
+      <PathChangeQueue operations={pathChangeOperations} />
     </section>
   );
 }


### PR DESCRIPTION
## Summary
- add desktop path change operations for note moves and folder renames
- track file move and derived index refresh steps with pending, completed, and failed states
- expose queue controls for completing, failing, and retrying local path-change steps
- cover operation ordering, failure blocking, and retry behavior with Vitest

## Testing
- pnpm test
- pnpm typecheck
- pnpm --filter @grove/desktop build
- pnpm lint
- pnpm format
- git diff --check

Refs #18
