### PR TITLE
Validate desktop folder path conflicts

### DIFF
--- a/apps/desktop/src/features/folder-navigation/model/folderWorkspaceState.test.ts
+++ b/apps/desktop/src/features/folder-navigation/model/folderWorkspaceState.test.ts
@@ -85,6 +85,27 @@ describe("moveNoteInFolderWorkspace", () => {
     ]);
     expect(result.state.selectedFolderPath).toBe("Projects/Grove/Ideas");
   });
+
+  it("rejects moves that would overwrite an existing note path", () => {
+    expect(() =>
+      moveNoteInFolderWorkspace(
+        {
+          ...workspaceState,
+          notes: [
+            ...workspaceState.notes,
+            {
+              id: "note-reading-plan",
+              title: "Reading Plan",
+              path: normalizeNoteFilePath("Reading/Plan.md"),
+              updatedLabel: "Today",
+            },
+          ],
+        },
+        "note-plan",
+        normalizeFolderPath("Reading"),
+      ),
+    ).toThrow("target Markdown path");
+  });
 });
 
 describe("createPathChangeOperation", () => {
@@ -307,5 +328,26 @@ describe("renameFolderInWorkspace", () => {
         normalizeFolderPath("Projects/Grove/Research"),
       ),
     ).toThrow("outside the selected folder");
+  });
+
+  it("rejects folder renames that would overwrite an existing note path", () => {
+    expect(() =>
+      renameFolderInWorkspace(
+        {
+          ...workspaceState,
+          notes: [
+            ...workspaceState.notes,
+            {
+              id: "note-area-plan",
+              title: "Area Plan",
+              path: normalizeNoteFilePath("Areas/Grove/Plan.md"),
+              updatedLabel: "Today",
+            },
+          ],
+        },
+        normalizeFolderPath("Projects/Grove"),
+        normalizeFolderPath("Areas/Grove"),
+      ),
+    ).toThrow("target Markdown path");
   });
 });

--- a/apps/desktop/src/features/folder-navigation/model/folderWorkspaceState.test.ts
+++ b/apps/desktop/src/features/folder-navigation/model/folderWorkspaceState.test.ts
@@ -320,6 +320,47 @@ describe("renameFolderInWorkspace", () => {
     expect(result.state.selectedFolderPath).toBeNull();
   });
 
+  it("allows parent folder renames when notes vacate each other's old paths", () => {
+    const result = renameFolderInWorkspace(
+      {
+        ...workspaceState,
+        notes: [
+          {
+            id: "note-nested-plan",
+            title: "Nested Plan",
+            path: normalizeNoteFilePath("Projects/Grove/Grove/Plan.md"),
+            updatedLabel: "Today",
+          },
+          {
+            id: "note-plan",
+            title: "Plan",
+            path: normalizeNoteFilePath("Projects/Grove/Plan.md"),
+            updatedLabel: "Yesterday",
+          },
+        ],
+      },
+      normalizeFolderPath("Projects/Grove"),
+      normalizeFolderPath("Projects"),
+    );
+
+    expect(result.pathChanges).toStrictEqual([
+      {
+        noteId: "note-nested-plan",
+        previousPath: "Projects/Grove/Grove/Plan.md",
+        nextPath: "Projects/Grove/Plan.md",
+      },
+      {
+        noteId: "note-plan",
+        previousPath: "Projects/Grove/Plan.md",
+        nextPath: "Projects/Plan.md",
+      },
+    ]);
+    expect(result.state.notes.map((note) => note.path)).toStrictEqual([
+      "Projects/Grove/Plan.md",
+      "Projects/Plan.md",
+    ]);
+  });
+
   it("rejects moving a folder into its own descendant", () => {
     expect(() =>
       renameFolderInWorkspace(

--- a/apps/desktop/src/features/folder-navigation/model/folderWorkspaceState.ts
+++ b/apps/desktop/src/features/folder-navigation/model/folderWorkspaceState.ts
@@ -139,21 +139,26 @@ function assertPathChangesDoNotConflict(
     return;
   }
 
-  const pathOwners = new Map<NoteFilePath, string>();
+  const pathChangesByNoteId = new Map<string, FolderWorkspacePathChange>();
+  const finalPathOwners = new Map<NoteFilePath, string[]>();
+
+  for (const pathChange of pathChanges) {
+    pathChangesByNoteId.set(pathChange.noteId, pathChange);
+  }
 
   for (const note of notes) {
-    pathOwners.set(note.path, note.id);
+    const finalPath = pathChangesByNoteId.get(note.id)?.nextPath ?? note.path;
+    const ownerIds = finalPathOwners.get(finalPath) ?? [];
+
+    finalPathOwners.set(finalPath, [...ownerIds, note.id]);
   }
 
   for (const pathChange of pathChanges) {
-    const existingOwnerId = pathOwners.get(pathChange.nextPath);
+    const ownerIds = finalPathOwners.get(pathChange.nextPath) ?? [];
 
-    if (existingOwnerId !== undefined && existingOwnerId !== pathChange.noteId) {
+    if (ownerIds.some((ownerId) => ownerId !== pathChange.noteId)) {
       throw new Error("A note already uses the target Markdown path.");
     }
-
-    pathOwners.delete(pathChange.previousPath);
-    pathOwners.set(pathChange.nextPath, pathChange.noteId);
   }
 }
 

--- a/apps/desktop/src/features/folder-navigation/model/folderWorkspaceState.ts
+++ b/apps/desktop/src/features/folder-navigation/model/folderWorkspaceState.ts
@@ -131,6 +131,32 @@ function createWorkspaceMutation(
   };
 }
 
+function assertPathChangesDoNotConflict(
+  notes: readonly FolderNavigationNote[],
+  pathChanges: readonly FolderWorkspacePathChange[],
+): void {
+  if (pathChanges.length === 0) {
+    return;
+  }
+
+  const pathOwners = new Map<NoteFilePath, string>();
+
+  for (const note of notes) {
+    pathOwners.set(note.path, note.id);
+  }
+
+  for (const pathChange of pathChanges) {
+    const existingOwnerId = pathOwners.get(pathChange.nextPath);
+
+    if (existingOwnerId !== undefined && existingOwnerId !== pathChange.noteId) {
+      throw new Error("A note already uses the target Markdown path.");
+    }
+
+    pathOwners.delete(pathChange.previousPath);
+    pathOwners.set(pathChange.nextPath, pathChange.noteId);
+  }
+}
+
 export function createPathChangeOperation(
   id: string,
   mutation: FolderWorkspaceMutation,
@@ -288,6 +314,7 @@ export function moveNoteInFolderWorkspace(
 
     return { ...note, path: nextPath };
   });
+  assertPathChangesDoNotConflict(state.notes, pathChanges);
 
   return createWorkspaceMutation(
     {
@@ -330,6 +357,8 @@ export function renameFolderInWorkspace(
 
     return { ...note, path: nextPath };
   });
+  assertPathChangesDoNotConflict(state.notes, pathChanges);
+
   const explicitFolders = dedupeAndSortFolderPaths(
     state.explicitFolders.flatMap((folderPath) => {
       const nextPath = replaceFolderPrefix(folderPath, sourceFolderPath, targetFolderPath);


### PR DESCRIPTION
## Summary
- add desktop path conflict validation before note move and folder rename mutations are accepted
- prevent queued local file/index work from being created when a target Markdown path is already owned by another note
- add regression coverage for note move and folder rename collisions

## Testing
- pnpm --filter @grove/desktop test
- pnpm --filter @grove/desktop typecheck
- pnpm --filter @grove/desktop build
- pnpm test
- pnpm typecheck
- pnpm lint
- pnpm format
- git diff --check

Refs #18
