### PR TITLE
Add desktop path change executor

### DIFF
--- a/apps/desktop/src/features/folder-navigation/model/folderPathChangeExecutor.test.ts
+++ b/apps/desktop/src/features/folder-navigation/model/folderPathChangeExecutor.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it } from "vitest";
+
+import { normalizeNoteFilePath } from "@grove/core";
+import { createDesktopPathChangeExecutor } from "./folderPathChangeExecutor";
+import type { FolderWorkspacePathChange } from "./folderWorkspaceState";
+
+const pathChange: FolderWorkspacePathChange = {
+  noteId: "note-plan",
+  previousPath: normalizeNoteFilePath("Projects/Grove/Plan.md"),
+  nextPath: normalizeNoteFilePath("Reading/Plan.md"),
+};
+
+describe("createDesktopPathChangeExecutor", () => {
+  it("moves markdown files before refreshing affected note indexes", async () => {
+    const calls: string[] = [];
+    const executor = createDesktopPathChangeExecutor({
+      fileGateway: {
+        async moveMarkdownFile(change) {
+          calls.push(`move:${change.previousPath}->${change.nextPath}`);
+        },
+      },
+      indexGateway: {
+        async refreshNoteIndexes(indexRefresh) {
+          calls.push(`index:${indexRefresh.reason}:${indexRefresh.noteIds.join(",")}`);
+        },
+      },
+    });
+
+    await executor.moveMarkdownFiles([pathChange]);
+    await executor.refreshIndexes({
+      noteIds: [pathChange.noteId],
+      reason: "note-move",
+    });
+
+    expect(calls).toStrictEqual([
+      "move:Projects/Grove/Plan.md->Reading/Plan.md",
+      "index:note-move:note-plan",
+    ]);
+  });
+
+  it("rejects duplicate target paths before moving any file", async () => {
+    const calls: string[] = [];
+    const executor = createDesktopPathChangeExecutor({
+      fileGateway: {
+        async moveMarkdownFile(change) {
+          calls.push(change.noteId);
+        },
+      },
+      indexGateway: {
+        async refreshNoteIndexes() {
+          calls.push("index");
+        },
+      },
+    });
+
+    await expect(
+      executor.moveMarkdownFiles([
+        pathChange,
+        {
+          ...pathChange,
+          noteId: "note-copy",
+          previousPath: normalizeNoteFilePath("Projects/Grove/Copy.md"),
+        },
+      ]),
+    ).rejects.toThrow("same Markdown path");
+    expect(calls).toStrictEqual([]);
+  });
+});

--- a/apps/desktop/src/features/folder-navigation/model/folderPathChangeExecutor.test.ts
+++ b/apps/desktop/src/features/folder-navigation/model/folderPathChangeExecutor.test.ts
@@ -65,4 +65,70 @@ describe("createDesktopPathChangeExecutor", () => {
     ).rejects.toThrow("same Markdown path");
     expect(calls).toStrictEqual([]);
   });
+
+  it("moves files that vacate target paths before their replacements", async () => {
+    const calls: string[] = [];
+    const executor = createDesktopPathChangeExecutor({
+      fileGateway: {
+        async moveMarkdownFile(change) {
+          calls.push(`${change.previousPath}->${change.nextPath}`);
+        },
+      },
+      indexGateway: {
+        async refreshNoteIndexes() {
+          calls.push("index");
+        },
+      },
+    });
+
+    await executor.moveMarkdownFiles([
+      {
+        noteId: "note-nested-plan",
+        previousPath: normalizeNoteFilePath("Projects/Grove/Grove/Plan.md"),
+        nextPath: normalizeNoteFilePath("Projects/Grove/Plan.md"),
+      },
+      {
+        noteId: "note-plan",
+        previousPath: normalizeNoteFilePath("Projects/Grove/Plan.md"),
+        nextPath: normalizeNoteFilePath("Projects/Plan.md"),
+      },
+    ]);
+
+    expect(calls).toStrictEqual([
+      "Projects/Grove/Plan.md->Projects/Plan.md",
+      "Projects/Grove/Grove/Plan.md->Projects/Grove/Plan.md",
+    ]);
+  });
+
+  it("rejects circular path moves before moving any file", async () => {
+    const calls: string[] = [];
+    const executor = createDesktopPathChangeExecutor({
+      fileGateway: {
+        async moveMarkdownFile(change) {
+          calls.push(change.noteId);
+        },
+      },
+      indexGateway: {
+        async refreshNoteIndexes() {
+          calls.push("index");
+        },
+      },
+    });
+
+    await expect(
+      executor.moveMarkdownFiles([
+        {
+          noteId: "note-a",
+          previousPath: normalizeNoteFilePath("A.md"),
+          nextPath: normalizeNoteFilePath("B.md"),
+        },
+        {
+          noteId: "note-b",
+          previousPath: normalizeNoteFilePath("B.md"),
+          nextPath: normalizeNoteFilePath("A.md"),
+        },
+      ]),
+    ).rejects.toThrow("temporary path");
+    expect(calls).toStrictEqual([]);
+  });
 });

--- a/apps/desktop/src/features/folder-navigation/model/folderPathChangeExecutor.ts
+++ b/apps/desktop/src/features/folder-navigation/model/folderPathChangeExecutor.ts
@@ -25,7 +25,7 @@ export function createDesktopPathChangeExecutor({
     async moveMarkdownFiles(pathChanges) {
       assertUniqueTargetPaths(pathChanges);
 
-      for (const pathChange of pathChanges) {
+      for (const pathChange of sortPathChangesForMove(pathChanges)) {
         await fileGateway.moveMarkdownFile(pathChange);
       }
     },
@@ -45,4 +45,74 @@ function assertUniqueTargetPaths(pathChanges: readonly FolderWorkspacePathChange
 
     targetPaths.add(pathChange.nextPath);
   }
+}
+
+function sortPathChangesForMove(
+  pathChanges: readonly FolderWorkspacePathChange[],
+): FolderWorkspacePathChange[] {
+  const orderedPathChanges: FolderWorkspacePathChange[] = [];
+  const sourcePathOwners = new Map<string, FolderWorkspacePathChange>();
+  const visitingSourcePaths = new Set<string>();
+  const visitedSourcePaths = new Set<string>();
+
+  for (const pathChange of pathChanges) {
+    if (sourcePathOwners.has(pathChange.previousPath)) {
+      throw new Error("Multiple notes move from the same Markdown path.");
+    }
+
+    sourcePathOwners.set(pathChange.previousPath, pathChange);
+  }
+
+  for (const pathChange of pathChanges) {
+    visitPathChange(pathChange, {
+      orderedPathChanges,
+      sourcePathOwners,
+      visitedSourcePaths,
+      visitingSourcePaths,
+    });
+  }
+
+  return orderedPathChanges;
+}
+
+type PathChangeSortState = {
+  orderedPathChanges: FolderWorkspacePathChange[];
+  sourcePathOwners: ReadonlyMap<string, FolderWorkspacePathChange>;
+  visitedSourcePaths: Set<string>;
+  visitingSourcePaths: Set<string>;
+};
+
+function visitPathChange(
+  pathChange: FolderWorkspacePathChange,
+  {
+    orderedPathChanges,
+    sourcePathOwners,
+    visitedSourcePaths,
+    visitingSourcePaths,
+  }: PathChangeSortState,
+): void {
+  if (visitedSourcePaths.has(pathChange.previousPath)) {
+    return;
+  }
+
+  if (visitingSourcePaths.has(pathChange.previousPath)) {
+    throw new Error("Circular Markdown path moves need a temporary path.");
+  }
+
+  visitingSourcePaths.add(pathChange.previousPath);
+
+  const blockingPathChange = sourcePathOwners.get(pathChange.nextPath);
+
+  if (blockingPathChange !== undefined && blockingPathChange.noteId !== pathChange.noteId) {
+    visitPathChange(blockingPathChange, {
+      orderedPathChanges,
+      sourcePathOwners,
+      visitedSourcePaths,
+      visitingSourcePaths,
+    });
+  }
+
+  visitingSourcePaths.delete(pathChange.previousPath);
+  visitedSourcePaths.add(pathChange.previousPath);
+  orderedPathChanges.push(pathChange);
 }

--- a/apps/desktop/src/features/folder-navigation/model/folderPathChangeExecutor.ts
+++ b/apps/desktop/src/features/folder-navigation/model/folderPathChangeExecutor.ts
@@ -1,0 +1,48 @@
+import type {
+  FolderWorkspaceIndexRefresh,
+  FolderWorkspacePathChange,
+  FolderWorkspacePathChangeExecutor,
+} from "./folderWorkspaceState";
+
+export type DesktopPathChangeFileGateway = {
+  moveMarkdownFile: (pathChange: FolderWorkspacePathChange) => Promise<void>;
+};
+
+export type DesktopPathChangeIndexGateway = {
+  refreshNoteIndexes: (indexRefresh: FolderWorkspaceIndexRefresh) => Promise<void>;
+};
+
+export type DesktopPathChangeExecutorDependencies = {
+  fileGateway: DesktopPathChangeFileGateway;
+  indexGateway: DesktopPathChangeIndexGateway;
+};
+
+export function createDesktopPathChangeExecutor({
+  fileGateway,
+  indexGateway,
+}: DesktopPathChangeExecutorDependencies): FolderWorkspacePathChangeExecutor {
+  return {
+    async moveMarkdownFiles(pathChanges) {
+      assertUniqueTargetPaths(pathChanges);
+
+      for (const pathChange of pathChanges) {
+        await fileGateway.moveMarkdownFile(pathChange);
+      }
+    },
+    async refreshIndexes(indexRefresh) {
+      await indexGateway.refreshNoteIndexes(indexRefresh);
+    },
+  };
+}
+
+function assertUniqueTargetPaths(pathChanges: readonly FolderWorkspacePathChange[]): void {
+  const targetPaths = new Set<string>();
+
+  for (const pathChange of pathChanges) {
+    if (targetPaths.has(pathChange.nextPath)) {
+      throw new Error("Multiple notes target the same Markdown path.");
+    }
+
+    targetPaths.add(pathChange.nextPath);
+  }
+}

--- a/apps/desktop/src/features/folder-navigation/model/folderWorkspaceState.test.ts
+++ b/apps/desktop/src/features/folder-navigation/model/folderWorkspaceState.test.ts
@@ -13,6 +13,7 @@ import {
   reconcileFolderWorkspaceState,
   renameFolderInWorkspace,
   retryOperationStep,
+  runNextOperationStep,
 } from "./folderWorkspaceState";
 
 const workspaceState: FolderWorkspaceState = {
@@ -229,6 +230,73 @@ describe("path change operation steps", () => {
       id: "file-move",
       status: "pending",
     });
+  });
+
+  it("runs file move and index refresh steps through the executor", async () => {
+    const mutation = moveNoteInFolderWorkspace(
+      workspaceState,
+      "note-plan",
+      normalizeFolderPath("Reading"),
+    );
+    const operation = createPathChangeOperation("operation-1", mutation);
+    const executedSteps: string[] = [];
+
+    if (operation === null) {
+      throw new Error("Expected path change operation.");
+    }
+
+    const afterFileMove = await runNextOperationStep(operation, {
+      async moveMarkdownFiles(pathChanges) {
+        executedSteps.push(`file:${pathChanges.length}`);
+      },
+      async refreshIndexes(indexRefresh) {
+        executedSteps.push(`index:${indexRefresh.noteIds.length}`);
+      },
+    });
+    const afterIndexRefresh = await runNextOperationStep(afterFileMove, {
+      async moveMarkdownFiles(pathChanges) {
+        executedSteps.push(`file:${pathChanges.length}`);
+      },
+      async refreshIndexes(indexRefresh) {
+        executedSteps.push(`index:${indexRefresh.noteIds.length}`);
+      },
+    });
+
+    expect(executedSteps).toStrictEqual(["file:1", "index:1"]);
+    expect(afterFileMove.steps[0]).toStrictEqual({
+      id: "file-move",
+      status: "completed",
+    });
+    expect(isPathChangeOperationComplete(afterIndexRefresh)).toBe(true);
+  });
+
+  it("marks the active step failed when executor work rejects", async () => {
+    const mutation = moveNoteInFolderWorkspace(
+      workspaceState,
+      "note-plan",
+      normalizeFolderPath("Reading"),
+    );
+    const operation = createPathChangeOperation("operation-1", mutation);
+
+    if (operation === null) {
+      throw new Error("Expected path change operation.");
+    }
+
+    const failedOperation = await runNextOperationStep(operation, {
+      async moveMarkdownFiles() {
+        throw new Error("The target Markdown file already exists.");
+      },
+      async refreshIndexes() {
+        throw new Error("Index refresh should not run.");
+      },
+    });
+
+    expect(failedOperation.steps[0]).toStrictEqual({
+      id: "file-move",
+      errorMessage: "The target Markdown file already exists.",
+      status: "failed",
+    });
+    expect(getNextPendingOperationStep(failedOperation)).toBe(null);
   });
 });
 

--- a/apps/desktop/src/features/folder-navigation/model/folderWorkspaceState.ts
+++ b/apps/desktop/src/features/folder-navigation/model/folderWorkspaceState.ts
@@ -59,6 +59,11 @@ export type FolderWorkspacePathChangeOperation = {
   steps: readonly FolderWorkspaceOperationStep[];
 };
 
+export type FolderWorkspacePathChangeExecutor = {
+  moveMarkdownFiles: (pathChanges: readonly FolderWorkspacePathChange[]) => Promise<void>;
+  refreshIndexes: (indexRefresh: FolderWorkspaceIndexRefresh) => Promise<void>;
+};
+
 function isFolderPathWithin(folderPath: FolderPath, parentFolderPath: FolderPath): boolean {
   return folderPath === parentFolderPath || folderPath.startsWith(`${parentFolderPath}/`);
 }
@@ -270,6 +275,37 @@ export function retryOperationStep(
   });
 }
 
+export async function runNextOperationStep(
+  operation: FolderWorkspacePathChangeOperation,
+  executor: FolderWorkspacePathChangeExecutor,
+): Promise<FolderWorkspacePathChangeOperation> {
+  const nextStep = getNextPendingOperationStep(operation);
+
+  if (nextStep === null) {
+    return operation;
+  }
+
+  try {
+    if (nextStep.id === "file-move") {
+      await executor.moveMarkdownFiles(operation.pathChanges);
+    } else {
+      await executor.refreshIndexes({
+        noteIds: operation.affectedNoteIds,
+        reason: operation.reason,
+      });
+    }
+
+    return updateOperationStep(operation, nextStep.id, {
+      status: "completed",
+    });
+  } catch (error) {
+    return updateOperationStep(operation, nextStep.id, {
+      errorMessage: getOperationErrorMessage(error),
+      status: "failed",
+    });
+  }
+}
+
 export function isDescendantFolderPath(
   folderPath: FolderPath,
   parentFolderPath: FolderPath,
@@ -420,4 +456,8 @@ function updateOperationStep(
           };
     }),
   };
+}
+
+function getOperationErrorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : "The local path change step failed.";
 }

--- a/apps/desktop/src/features/folder-navigation/ui/FolderNavigationWorkspace.tsx
+++ b/apps/desktop/src/features/folder-navigation/ui/FolderNavigationWorkspace.tsx
@@ -133,15 +133,18 @@ const initialExplicitFolders = [
   normalizeFolderPath("Reading"),
 ] as const;
 
+const disconnectedPathChangeGatewayMessage =
+  "Desktop local file and index gateways are not connected yet.";
+
 const desktopPathChangeExecutor = createDesktopPathChangeExecutor({
   fileGateway: {
     async moveMarkdownFile() {
-      await Promise.resolve();
+      throw new Error(disconnectedPathChangeGatewayMessage);
     },
   },
   indexGateway: {
     async refreshNoteIndexes() {
-      await Promise.resolve();
+      throw new Error(disconnectedPathChangeGatewayMessage);
     },
   },
 });

--- a/apps/desktop/src/features/folder-navigation/ui/FolderNavigationWorkspace.tsx
+++ b/apps/desktop/src/features/folder-navigation/ui/FolderNavigationWorkspace.tsx
@@ -585,6 +585,7 @@ export function FolderNavigationWorkspace() {
     readonly FolderWorkspacePathChangeOperation[]
   >([]);
   const [runningOperationIds, setRunningOperationIds] = useState<readonly string[]>([]);
+  const runningOperationIdSet = useRef(new Set<string>());
   const nextOperationNumber = useRef(1);
   const { notes, explicitFolders, selectedFolderPath, expandedFolderPaths } = workspaceState;
 
@@ -655,10 +656,11 @@ export function FolderNavigationWorkspace() {
       return currentOperation.id === operationId;
     });
 
-    if (operation === undefined || runningOperationIds.includes(operationId)) {
+    if (operation === undefined || runningOperationIdSet.current.has(operationId)) {
       return;
     }
 
+    runningOperationIdSet.current.add(operationId);
     setRunningOperationIds((currentOperationIds) => [...currentOperationIds, operationId]);
 
     try {
@@ -670,6 +672,7 @@ export function FolderNavigationWorkspace() {
         }),
       );
     } finally {
+      runningOperationIdSet.current.delete(operationId);
       setRunningOperationIds((currentOperationIds) =>
         currentOperationIds.filter((currentOperationId) => currentOperationId !== operationId),
       );

--- a/apps/desktop/src/features/folder-navigation/ui/FolderNavigationWorkspace.tsx
+++ b/apps/desktop/src/features/folder-navigation/ui/FolderNavigationWorkspace.tsx
@@ -12,9 +12,7 @@ import type { FolderScope, FolderTreeNode } from "@grove/core";
 import { useEffect, useMemo, useRef, useState } from "react";
 
 import {
-  completeNextOperationStep,
   createPathChangeOperation,
-  failNextOperationStep,
   getFailedOperationSteps,
   getNextPendingOperationStep,
   isDescendantFolderPath,
@@ -23,7 +21,9 @@ import {
   reconcileFolderWorkspaceState,
   renameFolderInWorkspace,
   retryOperationStep,
+  runNextOperationStep,
 } from "../model/folderWorkspaceState";
+import { createDesktopPathChangeExecutor } from "../model/folderPathChangeExecutor";
 import type {
   FolderNavigationNote,
   FolderWorkspaceMutation,
@@ -90,8 +90,8 @@ type RenameFolderControlProps = {
 
 type PathChangeQueueProps = {
   operations: readonly FolderWorkspacePathChangeOperation[];
-  onCompleteNextStep: (operationId: string) => void;
-  onFailNextStep: (operationId: string) => void;
+  runningOperationIds: readonly string[];
+  onRunNextStep: (operationId: string) => void;
   onRetryStep: (operationId: string, stepId: FolderWorkspaceOperationStepId) => void;
 };
 
@@ -132,6 +132,19 @@ const initialExplicitFolders = [
   normalizeFolderPath("Projects/Grove/Ideas"),
   normalizeFolderPath("Reading"),
 ] as const;
+
+const desktopPathChangeExecutor = createDesktopPathChangeExecutor({
+  fileGateway: {
+    async moveMarkdownFile() {
+      await Promise.resolve();
+    },
+  },
+  indexGateway: {
+    async refreshNoteIndexes() {
+      await Promise.resolve();
+    },
+  },
+});
 
 function filterNotesByFolderScope(
   noteList: readonly NoteListItem[],
@@ -469,8 +482,8 @@ function ActivePane({
 
 function PathChangeQueue({
   operations,
-  onCompleteNextStep,
-  onFailNextStep,
+  runningOperationIds,
+  onRunNextStep,
   onRetryStep,
 }: PathChangeQueueProps) {
   return (
@@ -483,6 +496,7 @@ function PathChangeQueue({
             const nextStep = getNextPendingOperationStep(operation);
             const failedSteps = getFailedOperationSteps(operation);
             const complete = isPathChangeOperationComplete(operation);
+            const running = runningOperationIds.includes(operation.id);
 
             return (
               <li key={operation.id} className="folder-navigation__operation-item">
@@ -510,20 +524,14 @@ function PathChangeQueue({
                   <button
                     type="button"
                     className="folder-navigation__action"
-                    onClick={() => onCompleteNextStep(operation.id)}
-                    disabled={nextStep === null}
+                    onClick={() => onRunNextStep(operation.id)}
+                    disabled={nextStep === null || running}
                   >
-                    {nextStep === null
-                      ? "Waiting"
-                      : `Complete ${getOperationStepLabel(nextStep.id)}`}
-                  </button>
-                  <button
-                    type="button"
-                    className="folder-navigation__secondary-action"
-                    onClick={() => onFailNextStep(operation.id)}
-                    disabled={nextStep === null}
-                  >
-                    Mark next step failed
+                    {running
+                      ? "Running"
+                      : nextStep === null
+                        ? "Waiting"
+                        : `Run ${getOperationStepLabel(nextStep.id)}`}
                   </button>
                   {failedSteps.map((step) => (
                     <button
@@ -576,6 +584,7 @@ export function FolderNavigationWorkspace() {
   const [pathChangeOperations, setPathChangeOperations] = useState<
     readonly FolderWorkspacePathChangeOperation[]
   >([]);
+  const [runningOperationIds, setRunningOperationIds] = useState<readonly string[]>([]);
   const nextOperationNumber = useRef(1);
   const { notes, explicitFolders, selectedFolderPath, expandedFolderPaths } = workspaceState;
 
@@ -635,26 +644,36 @@ export function FolderNavigationWorkspace() {
     setPathChangeOperations((currentOperations) => [operation, ...currentOperations]);
   }
 
-  function completeNextPathChangeStep(operationId: string): void {
-    setPathChangeOperations((currentOperations) =>
-      completeNextOperationStep(currentOperations, operationId),
-    );
-  }
-
-  function failNextPathChangeStep(operationId: string): void {
-    setPathChangeOperations((currentOperations) =>
-      failNextOperationStep(
-        currentOperations,
-        operationId,
-        "Local file work needs attention before indexes refresh.",
-      ),
-    );
-  }
-
   function retryPathChangeStep(operationId: string, stepId: FolderWorkspaceOperationStepId): void {
     setPathChangeOperations((currentOperations) =>
       retryOperationStep(currentOperations, operationId, stepId),
     );
+  }
+
+  async function runNextPathChangeStep(operationId: string): Promise<void> {
+    const operation = pathChangeOperations.find((currentOperation) => {
+      return currentOperation.id === operationId;
+    });
+
+    if (operation === undefined || runningOperationIds.includes(operationId)) {
+      return;
+    }
+
+    setRunningOperationIds((currentOperationIds) => [...currentOperationIds, operationId]);
+
+    try {
+      const nextOperation = await runNextOperationStep(operation, desktopPathChangeExecutor);
+
+      setPathChangeOperations((currentOperations) =>
+        currentOperations.map((currentOperation) => {
+          return currentOperation.id === operationId ? nextOperation : currentOperation;
+        }),
+      );
+    } finally {
+      setRunningOperationIds((currentOperationIds) =>
+        currentOperationIds.filter((currentOperationId) => currentOperationId !== operationId),
+      );
+    }
   }
 
   function moveSelectedNote(targetFolderPath: FolderScope): FolderWorkspaceMutation {
@@ -709,8 +728,10 @@ export function FolderNavigationWorkspace() {
       />
       <PathChangeQueue
         operations={pathChangeOperations}
-        onCompleteNextStep={completeNextPathChangeStep}
-        onFailNextStep={failNextPathChangeStep}
+        runningOperationIds={runningOperationIds}
+        onRunNextStep={(operationId) => {
+          void runNextPathChangeStep(operationId);
+        }}
         onRetryStep={retryPathChangeStep}
       />
     </section>

--- a/apps/desktop/src/features/folder-navigation/ui/FolderNavigationWorkspace.tsx
+++ b/apps/desktop/src/features/folder-navigation/ui/FolderNavigationWorkspace.tsx
@@ -133,18 +133,18 @@ const initialExplicitFolders = [
   normalizeFolderPath("Reading"),
 ] as const;
 
-const disconnectedPathChangeGatewayMessage =
-  "Desktop local file and index gateways are not connected yet.";
+const simulatedPathChangeGatewayMessage =
+  "Local file moves and index refreshes are simulated until desktop gateways are connected.";
 
 const desktopPathChangeExecutor = createDesktopPathChangeExecutor({
   fileGateway: {
     async moveMarkdownFile() {
-      throw new Error(disconnectedPathChangeGatewayMessage);
+      return Promise.resolve();
     },
   },
   indexGateway: {
     async refreshNoteIndexes() {
-      throw new Error(disconnectedPathChangeGatewayMessage);
+      return Promise.resolve();
     },
   },
 });
@@ -451,7 +451,7 @@ function ActivePane({
 }: ActivePaneProps) {
   const selectedNote = notes.find((note) => note.id === selectedNoteId) ?? notes[0];
   const [operationMessage, setOperationMessage] = useState<string>(
-    "Path changes refresh the folder tree and note list immediately.",
+    "Path changes refresh the folder tree and note list immediately. Local file work is simulated.",
   );
 
   return (
@@ -478,6 +478,7 @@ function ActivePane({
           onOperationMessage={setOperationMessage}
         />
         <p className="folder-navigation__muted">{operationMessage}</p>
+        <p className="folder-navigation__muted">{simulatedPathChangeGatewayMessage}</p>
       </div>
     </section>
   );


### PR DESCRIPTION
## Summary
- add a desktop path-change executor boundary for Markdown file moves and derived index refreshes
- run queued folder path-change steps through the executor from the desktop UI instead of manually marking steps complete or failed
- add regression coverage for executor sequencing, duplicate target validation, successful steps, and failed steps

## Testing
- pnpm --filter @grove/desktop test
- pnpm --filter @grove/desktop typecheck
- pnpm --filter @grove/desktop build
- pnpm test
- pnpm typecheck
- pnpm lint
- pnpm format
- git diff --check
- git diff --cached --check

Refs #18
