### PR TITLE
Run desktop path changes in background

### DIFF
--- a/apps/desktop/src/features/folder-navigation/model/folderWorkspaceState.test.ts
+++ b/apps/desktop/src/features/folder-navigation/model/folderWorkspaceState.test.ts
@@ -8,6 +8,7 @@ import {
   failNextOperationStep,
   getFailedOperationSteps,
   getNextPendingOperationStep,
+  getNextRunnablePathChangeOperationId,
   isPathChangeOperationComplete,
   moveNoteInFolderWorkspace,
   reconcileFolderWorkspaceState,
@@ -153,6 +154,94 @@ describe("createPathChangeOperation", () => {
 });
 
 describe("path change operation steps", () => {
+  it("selects the oldest runnable operation when the queue is idle", () => {
+    const firstMutation = moveNoteInFolderWorkspace(
+      workspaceState,
+      "note-plan",
+      normalizeFolderPath("Reading"),
+    );
+    const secondMutation = renameFolderInWorkspace(
+      workspaceState,
+      normalizeFolderPath("Projects/Grove"),
+      normalizeFolderPath("Areas/Grove"),
+    );
+    const firstOperation = createPathChangeOperation("operation-1", firstMutation);
+    const secondOperation = createPathChangeOperation("operation-2", secondMutation);
+
+    if (firstOperation === null || secondOperation === null) {
+      throw new Error("Expected path change operations.");
+    }
+
+    expect(getNextRunnablePathChangeOperationId([secondOperation, firstOperation], [])).toBe(
+      "operation-1",
+    );
+  });
+
+  it("waits for running operations and completed or failed queue heads", () => {
+    const mutation = moveNoteInFolderWorkspace(
+      workspaceState,
+      "note-plan",
+      normalizeFolderPath("Reading"),
+    );
+    const operation = createPathChangeOperation("operation-1", mutation);
+
+    if (operation === null) {
+      throw new Error("Expected path change operation.");
+    }
+
+    const completeOperation = completeNextOperationStep(
+      completeNextOperationStep([operation], "operation-1"),
+      "operation-1",
+    )[0];
+    const failedOperation = failNextOperationStep(
+      [operation],
+      "operation-1",
+      "File move failed.",
+    )[0];
+
+    if (completeOperation === undefined || failedOperation === undefined) {
+      throw new Error("Expected updated path change operations.");
+    }
+
+    expect(getNextRunnablePathChangeOperationId([operation], ["operation-1"])).toBeNull();
+    expect(
+      getNextRunnablePathChangeOperationId([completeOperation, failedOperation], []),
+    ).toBeNull();
+  });
+
+  it("keeps newer operations blocked while an older operation failed", () => {
+    const firstMutation = moveNoteInFolderWorkspace(
+      workspaceState,
+      "note-plan",
+      normalizeFolderPath("Reading"),
+    );
+    const secondMutation = renameFolderInWorkspace(
+      workspaceState,
+      normalizeFolderPath("Projects/Grove"),
+      normalizeFolderPath("Areas/Grove"),
+    );
+    const firstOperation = createPathChangeOperation("operation-1", firstMutation);
+    const secondOperation = createPathChangeOperation("operation-2", secondMutation);
+
+    if (firstOperation === null || secondOperation === null) {
+      throw new Error("Expected path change operations.");
+    }
+
+    const failedFirstOperation = failNextOperationStep(
+      [firstOperation],
+      "operation-1",
+      "File move failed.",
+    )[0];
+
+    if (failedFirstOperation === undefined) {
+      throw new Error("Expected failed path change operation.");
+    }
+
+    expect(
+      getNextRunnablePathChangeOperationId([secondOperation, failedFirstOperation], []),
+    ).toBeNull();
+  });
+
   it("completes file moves before index refreshes", () => {
     const mutation = moveNoteInFolderWorkspace(
       workspaceState,

--- a/apps/desktop/src/features/folder-navigation/model/folderWorkspaceState.ts
+++ b/apps/desktop/src/features/folder-navigation/model/folderWorkspaceState.ts
@@ -215,6 +215,27 @@ export function isPathChangeOperationComplete(
   return operation.steps.every((step) => step.status === "completed");
 }
 
+export function getNextRunnablePathChangeOperationId(
+  operations: readonly FolderWorkspacePathChangeOperation[],
+  runningOperationIds: readonly string[],
+): string | null {
+  if (runningOperationIds.length > 0) {
+    return null;
+  }
+
+  for (const operation of [...operations].reverse()) {
+    if (isPathChangeOperationComplete(operation)) {
+      continue;
+    }
+
+    const nextStep = getNextPendingOperationStep(operation);
+
+    return nextStep === null ? null : operation.id;
+  }
+
+  return null;
+}
+
 export function completeNextOperationStep(
   operations: readonly FolderWorkspacePathChangeOperation[],
   operationId: string,

--- a/apps/desktop/src/features/folder-navigation/ui/FolderNavigationWorkspace.tsx
+++ b/apps/desktop/src/features/folder-navigation/ui/FolderNavigationWorkspace.tsx
@@ -15,6 +15,7 @@ import {
   createPathChangeOperation,
   getFailedOperationSteps,
   getNextPendingOperationStep,
+  getNextRunnablePathChangeOperationId,
   isDescendantFolderPath,
   isPathChangeOperationComplete,
   moveNoteInFolderWorkspace,
@@ -451,7 +452,7 @@ function ActivePane({
 }: ActivePaneProps) {
   const selectedNote = notes.find((note) => note.id === selectedNoteId) ?? notes[0];
   const [operationMessage, setOperationMessage] = useState<string>(
-    "Path changes refresh the folder tree and note list immediately. Local file work is simulated.",
+    "Path changes refresh the folder tree and note list immediately. File and index work runs in the background.",
   );
 
   return (
@@ -708,6 +709,19 @@ export function FolderNavigationWorkspace() {
     queuePathChangeOperation(mutation);
     return mutation;
   }
+
+  useEffect(() => {
+    const nextRunnableOperationId = getNextRunnablePathChangeOperationId(
+      pathChangeOperations,
+      runningOperationIds,
+    );
+
+    if (nextRunnableOperationId === null) {
+      return;
+    }
+
+    void runNextPathChangeStep(nextRunnableOperationId);
+  }, [pathChangeOperations, runNextPathChangeStep, runningOperationIds]);
 
   return (
     <section className="folder-navigation">


### PR DESCRIPTION
## Summary
- add desktop path change queue selection for the next runnable operation
- run queued file move and index refresh steps in the background when the queue is idle
- keep newer operations blocked when an older operation has failed until it is retried

## Testing
- pnpm --filter @grove/desktop test
- pnpm --filter @grove/desktop typecheck
- pnpm test
- pnpm typecheck
- pnpm lint
- pnpm format
- pnpm --filter @grove/desktop build
- git diff --check

Refs #18