### PR TITLE
Connect desktop path change commands

### DIFF
--- a/apps/desktop/src-tauri/Cargo.lock
+++ b/apps/desktop/src-tauri/Cargo.lock
@@ -1155,9 +1155,12 @@ dependencies = [
 name = "grove"
 version = "0.1.0"
 dependencies = [
+ "anyhow",
  "serde",
+ "serde_json",
  "tauri",
  "tauri-build",
+ "tokio",
 ]
 
 [[package]]

--- a/apps/desktop/src-tauri/Cargo.toml
+++ b/apps/desktop/src-tauri/Cargo.toml
@@ -13,4 +13,4 @@ anyhow = "1"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 tauri = { version = "2.0.0", features = [] }
-tokio = { version = "1", features = ["fs", "io-util"] }
+tokio = { version = "1", features = ["fs", "io-util", "rt"] }

--- a/apps/desktop/src-tauri/Cargo.toml
+++ b/apps/desktop/src-tauri/Cargo.toml
@@ -9,5 +9,8 @@ edition = "2021"
 tauri-build = { version = "2.0.0", features = [] }
 
 [dependencies]
+anyhow = "1"
 serde = { version = "1", features = ["derive"] }
+serde_json = "1"
 tauri = { version = "2.0.0", features = [] }
+tokio = { version = "1", features = ["fs", "io-util"] }

--- a/apps/desktop/src-tauri/src/main.rs
+++ b/apps/desktop/src-tauri/src/main.rs
@@ -123,6 +123,20 @@ fn resolve_markdown_path(workspace_root: &Path, path: &str) -> Result<PathBuf, C
 }
 
 fn validate_markdown_path(path: &str) -> Result<(), CommandError> {
+    if has_windows_drive_prefix(path) {
+        return Err(CommandError::new(
+            "invalid_markdown_path",
+            "Markdown file paths must not include a drive prefix.",
+        ));
+    }
+
+    if path.contains('\\') {
+        return Err(CommandError::new(
+            "invalid_markdown_path",
+            "Markdown file paths must use workspace separators.",
+        ));
+    }
+
     let markdown_path = Path::new(path);
 
     if markdown_path.components().next().is_none() {
@@ -153,6 +167,12 @@ fn validate_markdown_path(path: &str) -> Result<(), CommandError> {
     }
 
     Ok(())
+}
+
+fn has_windows_drive_prefix(path: &str) -> bool {
+    let path_bytes = path.as_bytes();
+
+    path_bytes.len() >= 2 && path_bytes[0].is_ascii_alphabetic() && path_bytes[1] == b':'
 }
 
 async fn move_file_without_overwrite(previous_path: &Path, next_path: &Path) -> anyhow::Result<()> {
@@ -223,6 +243,20 @@ mod tests {
     #[test]
     fn rejects_paths_that_escape_the_workspace() {
         let error = validate_markdown_path("../Plan.md").unwrap_err();
+
+        assert_eq!(error.code, "invalid_markdown_path");
+    }
+
+    #[test]
+    fn rejects_paths_with_drive_prefixes() {
+        let error = validate_markdown_path("C:/Projects/Grove/Plan.md").unwrap_err();
+
+        assert_eq!(error.code, "invalid_markdown_path");
+    }
+
+    #[test]
+    fn rejects_paths_with_backslashes() {
+        let error = validate_markdown_path("Projects\\Grove\\Plan.md").unwrap_err();
 
         assert_eq!(error.code, "invalid_markdown_path");
     }

--- a/apps/desktop/src-tauri/src/main.rs
+++ b/apps/desktop/src-tauri/src/main.rs
@@ -141,10 +141,10 @@ fn validate_markdown_path(path: &str) -> Result<(), CommandError> {
         }
     }
 
-    if markdown_path
+    if !markdown_path
         .extension()
         .and_then(|extension| extension.to_str())
-        != Some("md")
+        .is_some_and(|extension| extension.eq_ignore_ascii_case("md"))
     {
         return Err(CommandError::new(
             "invalid_markdown_path",
@@ -213,6 +213,11 @@ mod tests {
     #[test]
     fn accepts_workspace_relative_markdown_paths() {
         assert!(validate_markdown_path("Projects/Grove/Plan.md").is_ok());
+    }
+
+    #[test]
+    fn accepts_markdown_paths_with_uppercase_extensions() {
+        assert!(validate_markdown_path("Projects/Grove/Plan.MD").is_ok());
     }
 
     #[test]

--- a/apps/desktop/src-tauri/src/main.rs
+++ b/apps/desktop/src-tauri/src/main.rs
@@ -1,7 +1,231 @@
 #![cfg_attr(not(debug_assertions), windows_subsystem = "windows")]
 
+use std::{
+    path::{Component, Path, PathBuf},
+    time::{SystemTime, UNIX_EPOCH},
+};
+
+use serde::{Deserialize, Serialize};
+use tauri::Manager;
+use tokio::io::AsyncWriteExt;
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct MarkdownPathChange {
+    note_id: String,
+    previous_path: String,
+    next_path: String,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct IndexRefreshRequest {
+    note_ids: Vec<String>,
+    reason: IndexRefreshReason,
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+#[serde(rename_all = "kebab-case")]
+enum IndexRefreshReason {
+    NoteMove,
+    FolderRename,
+}
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct IndexRefreshSidecarEntry {
+    note_ids: Vec<String>,
+    reason: IndexRefreshReason,
+    queued_at_unix_ms: u128,
+}
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct CommandError {
+    code: &'static str,
+    message: String,
+}
+
+impl CommandError {
+    fn new(code: &'static str, message: impl Into<String>) -> Self {
+        Self {
+            code,
+            message: message.into(),
+        }
+    }
+}
+
+#[tauri::command]
+async fn move_markdown_file(
+    app_handle: tauri::AppHandle,
+    change: MarkdownPathChange,
+) -> Result<(), CommandError> {
+    if change.note_id.trim().is_empty() {
+        return Err(CommandError::new(
+            "invalid_note_id",
+            "A note id is required to move a Markdown file.",
+        ));
+    }
+
+    let workspace_root = default_workspace_root(&app_handle)?;
+    let previous_path = resolve_markdown_path(&workspace_root, &change.previous_path)?;
+    let next_path = resolve_markdown_path(&workspace_root, &change.next_path)?;
+
+    move_file_without_overwrite(&previous_path, &next_path)
+        .await
+        .map_err(|error| CommandError::new("file_move_failed", error.to_string()))
+}
+
+#[tauri::command]
+async fn refresh_note_indexes(
+    app_handle: tauri::AppHandle,
+    refresh: IndexRefreshRequest,
+) -> Result<(), CommandError> {
+    if refresh
+        .note_ids
+        .iter()
+        .any(|note_id| note_id.trim().is_empty())
+    {
+        return Err(CommandError::new(
+            "invalid_note_id",
+            "Index refresh requests cannot contain an empty note id.",
+        ));
+    }
+
+    append_index_refresh_sidecar_entry(&app_handle, refresh)
+        .await
+        .map_err(|error| CommandError::new("index_refresh_failed", error.to_string()))
+}
+
 fn main() {
-    if let Err(error) = tauri::Builder::default().run(tauri::generate_context!()) {
+    if let Err(error) = tauri::Builder::default()
+        .invoke_handler(tauri::generate_handler![
+            move_markdown_file,
+            refresh_note_indexes
+        ])
+        .run(tauri::generate_context!())
+    {
         eprintln!("failed to run Grove desktop app: {error}");
+    }
+}
+
+fn default_workspace_root(app_handle: &tauri::AppHandle) -> Result<PathBuf, CommandError> {
+    app_handle
+        .path()
+        .app_data_dir()
+        .map(|path| path.join("workspaces").join("default"))
+        .map_err(|error| CommandError::new("workspace_root_unavailable", error.to_string()))
+}
+
+fn resolve_markdown_path(workspace_root: &Path, path: &str) -> Result<PathBuf, CommandError> {
+    validate_markdown_path(path)?;
+    Ok(workspace_root.join(path))
+}
+
+fn validate_markdown_path(path: &str) -> Result<(), CommandError> {
+    let markdown_path = Path::new(path);
+
+    if markdown_path.components().next().is_none() {
+        return Err(CommandError::new(
+            "invalid_markdown_path",
+            "Markdown file paths cannot be empty.",
+        ));
+    }
+
+    for component in markdown_path.components() {
+        if !matches!(component, Component::Normal(_)) {
+            return Err(CommandError::new(
+                "invalid_markdown_path",
+                "Markdown file paths must stay inside the workspace.",
+            ));
+        }
+    }
+
+    if markdown_path
+        .extension()
+        .and_then(|extension| extension.to_str())
+        != Some("md")
+    {
+        return Err(CommandError::new(
+            "invalid_markdown_path",
+            "Only Markdown files can be moved by folder path changes.",
+        ));
+    }
+
+    Ok(())
+}
+
+async fn move_file_without_overwrite(previous_path: &Path, next_path: &Path) -> anyhow::Result<()> {
+    if !tokio::fs::try_exists(previous_path).await? {
+        anyhow::bail!(
+            "The source Markdown file does not exist: {}",
+            previous_path.display()
+        );
+    }
+
+    if tokio::fs::try_exists(next_path).await? {
+        anyhow::bail!(
+            "The target Markdown file already exists: {}",
+            next_path.display()
+        );
+    }
+
+    if let Some(parent_path) = next_path.parent() {
+        tokio::fs::create_dir_all(parent_path).await?;
+    }
+
+    tokio::fs::rename(previous_path, next_path).await?;
+    Ok(())
+}
+
+async fn append_index_refresh_sidecar_entry(
+    app_handle: &tauri::AppHandle,
+    refresh: IndexRefreshRequest,
+) -> anyhow::Result<()> {
+    let app_data_dir = app_handle.path().app_data_dir()?;
+    tokio::fs::create_dir_all(&app_data_dir).await?;
+
+    let sidecar_path = app_data_dir.join("index-refresh-requests.jsonl");
+    let queued_at_unix_ms = SystemTime::now().duration_since(UNIX_EPOCH)?.as_millis();
+    let entry = IndexRefreshSidecarEntry {
+        note_ids: refresh.note_ids,
+        reason: refresh.reason,
+        queued_at_unix_ms,
+    };
+    let mut line = serde_json::to_vec(&entry)?;
+    line.push(b'\n');
+
+    let mut file = tokio::fs::OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(sidecar_path)
+        .await?;
+    file.write_all(&line).await?;
+    file.flush().await?;
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::validate_markdown_path;
+
+    #[test]
+    fn accepts_workspace_relative_markdown_paths() {
+        assert!(validate_markdown_path("Projects/Grove/Plan.md").is_ok());
+    }
+
+    #[test]
+    fn rejects_paths_that_escape_the_workspace() {
+        let error = validate_markdown_path("../Plan.md").unwrap_err();
+
+        assert_eq!(error.code, "invalid_markdown_path");
+    }
+
+    #[test]
+    fn rejects_non_markdown_paths() {
+        let error = validate_markdown_path("Projects/Grove/Plan.txt").unwrap_err();
+
+        assert_eq!(error.code, "invalid_markdown_path");
     }
 }

--- a/apps/desktop/src-tauri/src/main.rs
+++ b/apps/desktop/src-tauri/src/main.rs
@@ -177,6 +177,10 @@ fn has_windows_drive_prefix(path: &str) -> bool {
 
 async fn move_file_without_overwrite(previous_path: &Path, next_path: &Path) -> anyhow::Result<()> {
     if !tokio::fs::try_exists(previous_path).await? {
+        if tokio::fs::try_exists(next_path).await? {
+            return Ok(());
+        }
+
         anyhow::bail!(
             "The source Markdown file does not exist: {}",
             previous_path.display()
@@ -228,7 +232,35 @@ async fn append_index_refresh_sidecar_entry(
 
 #[cfg(test)]
 mod tests {
-    use super::validate_markdown_path;
+    use std::{
+        path::PathBuf,
+        time::{SystemTime, UNIX_EPOCH},
+    };
+
+    use super::{move_file_without_overwrite, validate_markdown_path};
+
+    fn run_async<F>(future: F) -> F::Output
+    where
+        F: std::future::Future,
+    {
+        tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .expect("test runtime should build")
+            .block_on(future)
+    }
+
+    fn unique_test_dir(test_name: &str) -> PathBuf {
+        let timestamp = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("system clock should be after unix epoch")
+            .as_nanos();
+
+        std::env::temp_dir().join(format!(
+            "grove-{test_name}-{}-{timestamp}",
+            std::process::id()
+        ))
+    }
 
     #[test]
     fn accepts_workspace_relative_markdown_paths() {
@@ -266,5 +298,64 @@ mod tests {
         let error = validate_markdown_path("Projects/Grove/Plan.txt").unwrap_err();
 
         assert_eq!(error.code, "invalid_markdown_path");
+    }
+
+    #[test]
+    fn moves_files_without_overwriting_targets() {
+        run_async(async {
+            let workspace_dir = unique_test_dir("moves-files-without-overwriting-targets");
+            let previous_path = workspace_dir.join("Projects").join("Plan.md");
+            let next_path = workspace_dir.join("Reading").join("Plan.md");
+            tokio::fs::create_dir_all(previous_path.parent().expect("source parent")).await?;
+            tokio::fs::write(&previous_path, "plan").await?;
+
+            move_file_without_overwrite(&previous_path, &next_path).await?;
+
+            assert!(!tokio::fs::try_exists(&previous_path).await?);
+            assert_eq!(tokio::fs::read_to_string(&next_path).await?, "plan");
+            tokio::fs::remove_dir_all(&workspace_dir).await?;
+            anyhow::Ok(())
+        })
+        .expect("file move should succeed");
+    }
+
+    #[test]
+    fn treats_already_moved_files_as_successful_for_retries() {
+        run_async(async {
+            let workspace_dir = unique_test_dir("treats-already-moved-files-as-successful");
+            let previous_path = workspace_dir.join("Projects").join("Plan.md");
+            let next_path = workspace_dir.join("Reading").join("Plan.md");
+            tokio::fs::create_dir_all(next_path.parent().expect("target parent")).await?;
+            tokio::fs::write(&next_path, "plan").await?;
+
+            move_file_without_overwrite(&previous_path, &next_path).await?;
+
+            assert_eq!(tokio::fs::read_to_string(&next_path).await?, "plan");
+            tokio::fs::remove_dir_all(&workspace_dir).await?;
+            anyhow::Ok(())
+        })
+        .expect("already moved file should be idempotent");
+    }
+
+    #[test]
+    fn rejects_existing_targets_when_source_still_exists() {
+        run_async(async {
+            let workspace_dir = unique_test_dir("rejects-existing-targets");
+            let previous_path = workspace_dir.join("Projects").join("Plan.md");
+            let next_path = workspace_dir.join("Reading").join("Plan.md");
+            tokio::fs::create_dir_all(previous_path.parent().expect("source parent")).await?;
+            tokio::fs::create_dir_all(next_path.parent().expect("target parent")).await?;
+            tokio::fs::write(&previous_path, "source").await?;
+            tokio::fs::write(&next_path, "target").await?;
+
+            let error = move_file_without_overwrite(&previous_path, &next_path)
+                .await
+                .expect_err("existing target should be rejected");
+
+            assert!(error.to_string().contains("already exists"));
+            tokio::fs::remove_dir_all(&workspace_dir).await?;
+            anyhow::Ok(())
+        })
+        .expect("target collision test should run");
     }
 }

--- a/apps/desktop/src/features/folder-navigation/ui/FolderNavigationWorkspace.tsx
+++ b/apps/desktop/src/features/folder-navigation/ui/FolderNavigationWorkspace.tsx
@@ -11,6 +11,7 @@ import {
 import type { FolderScope, FolderTreeNode } from "@grove/core";
 import { useEffect, useMemo, useRef, useState } from "react";
 
+import { moveMarkdownFile, refreshNoteIndexes } from "../../../shared";
 import {
   createPathChangeOperation,
   getFailedOperationSteps,
@@ -134,19 +135,12 @@ const initialExplicitFolders = [
   normalizeFolderPath("Reading"),
 ] as const;
 
-const simulatedPathChangeGatewayMessage =
-  "Local file moves and index refreshes are simulated until desktop gateways are connected.";
-
 const desktopPathChangeExecutor = createDesktopPathChangeExecutor({
   fileGateway: {
-    async moveMarkdownFile() {
-      return Promise.resolve();
-    },
+    moveMarkdownFile,
   },
   indexGateway: {
-    async refreshNoteIndexes() {
-      return Promise.resolve();
-    },
+    refreshNoteIndexes,
   },
 });
 
@@ -479,7 +473,6 @@ function ActivePane({
           onOperationMessage={setOperationMessage}
         />
         <p className="folder-navigation__muted">{operationMessage}</p>
-        <p className="folder-navigation__muted">{simulatedPathChangeGatewayMessage}</p>
       </div>
     </section>
   );

--- a/apps/desktop/src/shared/api/commands.test.ts
+++ b/apps/desktop/src/shared/api/commands.test.ts
@@ -1,0 +1,65 @@
+import { invoke } from "@tauri-apps/api/core";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { moveMarkdownFile, refreshNoteIndexes } from "./commands";
+
+vi.mock("@tauri-apps/api/core", () => ({
+  invoke: vi.fn(),
+}));
+
+const invokeMock = vi.mocked(invoke);
+
+describe("desktop command wrappers", () => {
+  beforeEach(() => {
+    invokeMock.mockReset();
+  });
+
+  it("invokes the Markdown file move command with the expected payload", async () => {
+    invokeMock.mockResolvedValue(undefined);
+
+    await moveMarkdownFile({
+      noteId: "note-plan",
+      previousPath: "Projects/Grove/Plan.md",
+      nextPath: "Reading/Plan.md",
+    });
+
+    expect(invokeMock).toHaveBeenCalledWith("move_markdown_file", {
+      change: {
+        noteId: "note-plan",
+        previousPath: "Projects/Grove/Plan.md",
+        nextPath: "Reading/Plan.md",
+      },
+    });
+  });
+
+  it("invokes the note index refresh command with the expected payload", async () => {
+    invokeMock.mockResolvedValue(undefined);
+
+    await refreshNoteIndexes({
+      noteIds: ["note-plan"],
+      reason: "note-move",
+    });
+
+    expect(invokeMock).toHaveBeenCalledWith("refresh_note_indexes", {
+      refresh: {
+        noteIds: ["note-plan"],
+        reason: "note-move",
+      },
+    });
+  });
+
+  it("preserves structured Tauri command messages when a command fails", async () => {
+    invokeMock.mockRejectedValue({
+      code: "file_move_failed",
+      message: "The target Markdown file already exists.",
+    });
+
+    await expect(
+      moveMarkdownFile({
+        noteId: "note-plan",
+        previousPath: "Projects/Grove/Plan.md",
+        nextPath: "Reading/Plan.md",
+      }),
+    ).rejects.toThrow("The target Markdown file already exists.");
+  });
+});

--- a/apps/desktop/src/shared/api/commands.ts
+++ b/apps/desktop/src/shared/api/commands.ts
@@ -1,0 +1,24 @@
+import { invoke } from "@tauri-apps/api/core";
+
+export type MoveMarkdownFileCommand = {
+  noteId: string;
+  previousPath: string;
+  nextPath: string;
+};
+
+export type RefreshNoteIndexesCommand = {
+  noteIds: readonly string[];
+  reason: "note-move" | "folder-rename";
+};
+
+export async function moveMarkdownFile(command: MoveMarkdownFileCommand): Promise<void> {
+  await invoke("move_markdown_file", {
+    change: command,
+  });
+}
+
+export async function refreshNoteIndexes(command: RefreshNoteIndexesCommand): Promise<void> {
+  await invoke("refresh_note_indexes", {
+    refresh: command,
+  });
+}

--- a/apps/desktop/src/shared/api/commands.ts
+++ b/apps/desktop/src/shared/api/commands.ts
@@ -12,13 +12,42 @@ export type RefreshNoteIndexesCommand = {
 };
 
 export async function moveMarkdownFile(command: MoveMarkdownFileCommand): Promise<void> {
-  await invoke("move_markdown_file", {
-    change: command,
-  });
+  await invokeCommand("move_markdown_file", { change: command });
 }
 
 export async function refreshNoteIndexes(command: RefreshNoteIndexesCommand): Promise<void> {
-  await invoke("refresh_note_indexes", {
-    refresh: command,
-  });
+  await invokeCommand("refresh_note_indexes", { refresh: command });
+}
+
+async function invokeCommand(commandName: string, payload: Record<string, unknown>): Promise<void> {
+  try {
+    await invoke(commandName, payload);
+  } catch (error) {
+    throw new Error(getCommandErrorMessage(error));
+  }
+}
+
+function getCommandErrorMessage(error: unknown): string {
+  if (error instanceof Error) {
+    return error.message;
+  }
+
+  if (typeof error === "string") {
+    return error;
+  }
+
+  if (isCommandErrorPayload(error)) {
+    return error.message;
+  }
+
+  return "The desktop command failed.";
+}
+
+function isCommandErrorPayload(error: unknown): error is { message: string } {
+  return (
+    typeof error === "object" &&
+    error !== null &&
+    "message" in error &&
+    typeof error.message === "string"
+  );
 }

--- a/apps/desktop/src/shared/index.ts
+++ b/apps/desktop/src/shared/index.ts
@@ -1,1 +1,3 @@
+export { moveMarkdownFile, refreshNoteIndexes } from "./api/commands";
+export type { MoveMarkdownFileCommand, RefreshNoteIndexesCommand } from "./api/commands";
 export { ShellCard } from "./ui/ShellCard";


### PR DESCRIPTION
## Summary
- add typed desktop command wrappers for Markdown file moves and note index refresh requests
- register Tauri commands that validate workspace-relative Markdown paths, move files with async I/O, and avoid target overwrites
- record index refresh requests to an app-data JSONL sidecar until the SQLite index implementation is available
- connect the folder path-change queue to the desktop command gateways instead of simulated promises

## Testing
- pnpm --filter @grove/desktop typecheck
- pnpm --filter @grove/desktop test
- pnpm --filter @grove/desktop build
- cargo test --manifest-path apps/desktop/src-tauri/Cargo.toml
- pnpm lint
- pnpm format
- git diff --check

Refs #18
