### PR TITLE
Add desktop path change cleanup

### DIFF
--- a/apps/desktop/src/features/folder-navigation/model/folderWorkspaceState.test.ts
+++ b/apps/desktop/src/features/folder-navigation/model/folderWorkspaceState.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from "vitest";
 import { normalizeFolderPath, normalizeNoteFilePath } from "@grove/core";
 import type { FolderWorkspaceState } from "./folderWorkspaceState";
 import {
+  clearCompletedPathChangeOperations,
   completeNextOperationStep,
   createPathChangeOperation,
   failNextOperationStep,
@@ -319,6 +320,45 @@ describe("path change operation steps", () => {
       id: "file-move",
       status: "pending",
     });
+  });
+
+  it("clears completed operations while keeping failed and pending work visible", () => {
+    const mutation = moveNoteInFolderWorkspace(
+      workspaceState,
+      "note-plan",
+      normalizeFolderPath("Reading"),
+    );
+    const completedOperation = createPathChangeOperation("operation-complete", mutation);
+    const pendingOperation = createPathChangeOperation("operation-pending", mutation);
+    const failedOperation = createPathChangeOperation("operation-failed", mutation);
+
+    if (completedOperation === null || pendingOperation === null || failedOperation === null) {
+      throw new Error("Expected path change operations.");
+    }
+
+    const completedOperations = completeNextOperationStep(
+      completeNextOperationStep([completedOperation], "operation-complete"),
+      "operation-complete",
+    );
+    const failedOperations = failNextOperationStep(
+      [failedOperation],
+      "operation-failed",
+      "File move failed.",
+    );
+    const completedOperationAfterSteps = completedOperations[0];
+    const failedOperationAfterStep = failedOperations[0];
+
+    if (completedOperationAfterSteps === undefined || failedOperationAfterStep === undefined) {
+      throw new Error("Expected updated path change operations.");
+    }
+
+    expect(
+      clearCompletedPathChangeOperations([
+        pendingOperation,
+        completedOperationAfterSteps,
+        failedOperationAfterStep,
+      ]).map((operation) => operation.id),
+    ).toStrictEqual(["operation-pending", "operation-failed"]);
   });
 
   it("runs file move and index refresh steps through the executor", async () => {

--- a/apps/desktop/src/features/folder-navigation/model/folderWorkspaceState.ts
+++ b/apps/desktop/src/features/folder-navigation/model/folderWorkspaceState.ts
@@ -215,6 +215,12 @@ export function isPathChangeOperationComplete(
   return operation.steps.every((step) => step.status === "completed");
 }
 
+export function clearCompletedPathChangeOperations(
+  operations: readonly FolderWorkspacePathChangeOperation[],
+): FolderWorkspacePathChangeOperation[] {
+  return operations.filter((operation) => !isPathChangeOperationComplete(operation));
+}
+
 export function getNextRunnablePathChangeOperationId(
   operations: readonly FolderWorkspacePathChangeOperation[],
   runningOperationIds: readonly string[],

--- a/apps/desktop/src/features/folder-navigation/ui/FolderNavigationWorkspace.css
+++ b/apps/desktop/src/features/folder-navigation/ui/FolderNavigationWorkspace.css
@@ -37,6 +37,19 @@
   margin: 0 0 1rem;
 }
 
+.folder-navigation__queue-heading {
+  align-items: center;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  justify-content: space-between;
+  margin-bottom: 1rem;
+}
+
+.folder-navigation__queue-heading .folder-navigation__heading {
+  margin: 0;
+}
+
 .folder-navigation__root-button,
 .folder-navigation__folder-button {
   align-items: center;

--- a/apps/desktop/src/features/folder-navigation/ui/FolderNavigationWorkspace.tsx
+++ b/apps/desktop/src/features/folder-navigation/ui/FolderNavigationWorkspace.tsx
@@ -13,6 +13,7 @@ import { useEffect, useMemo, useRef, useState } from "react";
 
 import { moveMarkdownFile, refreshNoteIndexes } from "../../../shared";
 import {
+  clearCompletedPathChangeOperations,
   createPathChangeOperation,
   getFailedOperationSteps,
   getNextPendingOperationStep,
@@ -93,6 +94,7 @@ type RenameFolderControlProps = {
 type PathChangeQueueProps = {
   operations: readonly FolderWorkspacePathChangeOperation[];
   runningOperationIds: readonly string[];
+  onClearCompletedOperations: () => void;
   onRunNextStep: (operationId: string) => void;
   onRetryStep: (operationId: string, stepId: FolderWorkspaceOperationStepId) => void;
 };
@@ -481,13 +483,26 @@ function ActivePane({
 function PathChangeQueue({
   operations,
   runningOperationIds,
+  onClearCompletedOperations,
   onRunNextStep,
   onRetryStep,
 }: PathChangeQueueProps) {
+  const completedOperationCount = operations.filter(isPathChangeOperationComplete).length;
+
   return (
     <section className="folder-navigation__queue" aria-label="Pending path changes">
       <p className="folder-navigation__eyebrow">Local operations</p>
-      <h2 className="folder-navigation__heading">Path change queue</h2>
+      <div className="folder-navigation__queue-heading">
+        <h2 className="folder-navigation__heading">Path change queue</h2>
+        <button
+          type="button"
+          className="folder-navigation__secondary-action"
+          onClick={onClearCompletedOperations}
+          disabled={completedOperationCount === 0}
+        >
+          Clear completed
+        </button>
+      </div>
       {operations.length > 0 ? (
         <ol className="folder-navigation__operations">
           {operations.map((operation) => {
@@ -649,6 +664,10 @@ export function FolderNavigationWorkspace() {
     );
   }
 
+  function clearCompletedPathChanges(): void {
+    setPathChangeOperations(clearCompletedPathChangeOperations);
+  }
+
   async function runNextPathChangeStep(operationId: string): Promise<void> {
     const operation = pathChangeOperations.find((currentOperation) => {
       return currentOperation.id === operationId;
@@ -743,6 +762,7 @@ export function FolderNavigationWorkspace() {
       <PathChangeQueue
         operations={pathChangeOperations}
         runningOperationIds={runningOperationIds}
+        onClearCompletedOperations={clearCompletedPathChanges}
         onRunNextStep={(operationId) => {
           void runNextPathChangeStep(operationId);
         }}


### PR DESCRIPTION
## Summary
- add a desktop folder-navigation model helper to remove completed path-change operations while keeping failed and pending work visible
- add a Path change queue action for clearing completed operations
- cover cleanup behavior with a regression test

## Review
- checked that failed operations remain visible for retry and pending operations stay queued
- checked that cleanup only affects completed file-move/index-refresh operations

## Testing
- pnpm --filter @grove/desktop test
- pnpm --filter @grove/desktop typecheck
- pnpm --filter @grove/desktop build
- pnpm lint
- pnpm format
- pnpm test
- pnpm typecheck
- git diff --check
- git diff --cached --check

Closes #18
