### PR TITLE
Add plugin API package

### DIFF
--- a/packages/plugin-api/README.md
+++ b/packages/plugin-api/README.md
@@ -1,0 +1,7 @@
+# @grove/plugin-api
+
+TypeScript contract for Grove plugins.
+
+This package defines manifest, capability, permission, activation, and provider types for plugin authors and host-side validation code. Plugins may also import `SyncProvider` from this package, which re-exports the shared storage-agnostic contract from `@grove/core`.
+
+The package intentionally has no runtime host implementation. `definePlugin()` is a typed identity helper that preserves plugin definitions while keeping activation behavior owned by the host app.

--- a/packages/plugin-api/package.json
+++ b/packages/plugin-api/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "@grove/plugin-api",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "exports": {
+    ".": "./src/index.ts"
+  },
+  "scripts": {
+    "test": "vitest run",
+    "typecheck": "tsc -p tsconfig.json"
+  },
+  "dependencies": {
+    "@grove/core": "workspace:*"
+  }
+}

--- a/packages/plugin-api/src/index.test.ts
+++ b/packages/plugin-api/src/index.test.ts
@@ -1,0 +1,94 @@
+import { describe, expect, it } from "vitest";
+
+import { definePlugin, type PluginContext, type PluginManifest } from "./index";
+
+const manifest: PluginManifest = {
+  id: "sync-r2",
+  name: "Cloudflare R2 Sync",
+  version: "0.1.0",
+  apiVersion: 1,
+  entry: "./src/index.ts",
+  capabilities: ["syncProvider"],
+  permissions: ["network", "secrets:read"],
+};
+
+const context = {
+  manifest,
+  services: {
+    settings: {
+      get: async () => undefined,
+      set: async () => undefined,
+      delete: async () => undefined,
+    },
+    secrets: {
+      get: async () => undefined,
+      set: async () => undefined,
+      delete: async () => undefined,
+    },
+    network: {
+      request: async () => ({
+        status: 200,
+        headers: {},
+        body: new Uint8Array(),
+      }),
+    },
+    workspace: {
+      read: async () => new Uint8Array(),
+      write: async () => undefined,
+      list: async () => [],
+      delete: async () => undefined,
+    },
+  },
+} satisfies PluginContext;
+
+describe("definePlugin", () => {
+  it("returns the exact plugin definition", async () => {
+    const plugin = definePlugin({
+      id: "sync-r2",
+      name: "Cloudflare R2 Sync",
+      activate: (_context: PluginContext) => ({
+        syncProvider: {
+          id: "r2",
+          name: "Cloudflare R2",
+          upload: async () => undefined,
+          download: async () => new Uint8Array(),
+          list: async () => [],
+          delete: async () => undefined,
+          isAvailable: async () => true,
+        },
+      }),
+    });
+
+    const provides = await plugin.activate(context);
+
+    expect(plugin.id).toBe("sync-r2");
+    expect(provides.syncProvider?.id).toBe("r2");
+  });
+
+  it("supports ai provider registrations", async () => {
+    const plugin = definePlugin({
+      id: "ai-claude",
+      name: "Claude AI",
+      activate: (_context: PluginContext) => ({
+        aiProvider: {
+          id: "claude",
+          name: "Claude",
+          isAvailable: async () => true,
+          generate: async (_request) => ({
+            text: "Generated note",
+            usage: {
+              inputTokens: 4,
+              outputTokens: 2,
+            },
+          }),
+        },
+      }),
+    });
+
+    const provides = await plugin.activate(context);
+
+    await expect(provides.aiProvider?.generate({ messages: [] })).resolves.toMatchObject({
+      text: "Generated note",
+    });
+  });
+});

--- a/packages/plugin-api/src/index.ts
+++ b/packages/plugin-api/src/index.ts
@@ -1,0 +1,132 @@
+import type { SyncProvider as CoreSyncProvider } from "@grove/core";
+
+export type PluginApiVersion = 1;
+
+export type PluginCapability = "syncProvider" | "aiProvider";
+
+export type PluginPermission =
+  | "network"
+  | "settings:read"
+  | "settings:write"
+  | "secrets:read"
+  | "secrets:write"
+  | "workspace:read"
+  | "workspace:write";
+
+export type PluginManifest = {
+  id: string;
+  name: string;
+  version: string;
+  apiVersion: PluginApiVersion;
+  entry: string;
+  capabilities: PluginCapability[];
+  permissions: PluginPermission[];
+  description?: string;
+  author?: string;
+};
+
+export type PluginSettingValue = string | number | boolean | null;
+
+export type PluginSettingsService = {
+  get(key: string): Promise<PluginSettingValue | undefined>;
+  set(key: string, value: PluginSettingValue): Promise<void>;
+  delete(key: string): Promise<void>;
+};
+
+export type PluginSecretsService = {
+  get(key: string): Promise<string | undefined>;
+  set(key: string, value: string): Promise<void>;
+  delete(key: string): Promise<void>;
+};
+
+export type PluginNetworkRequest = {
+  url: string;
+  method?: "GET" | "POST" | "PUT" | "PATCH" | "DELETE";
+  headers?: Record<string, string>;
+  body?: Uint8Array | string;
+};
+
+export type PluginNetworkResponse = {
+  status: number;
+  headers: Record<string, string>;
+  body: Uint8Array;
+};
+
+export type PluginNetworkService = {
+  request(request: PluginNetworkRequest): Promise<PluginNetworkResponse>;
+};
+
+export type PluginWorkspaceFileEntry = {
+  path: string;
+  hash: string;
+  updatedAt: Date;
+  size: number;
+};
+
+export type PluginWorkspaceFileService = {
+  read(path: string): Promise<Uint8Array>;
+  write(path: string, data: Uint8Array): Promise<void>;
+  list(prefix?: string): Promise<PluginWorkspaceFileEntry[]>;
+  delete(path: string): Promise<void>;
+};
+
+export type PluginHostServices = {
+  readonly settings: PluginSettingsService;
+  readonly secrets: PluginSecretsService;
+  readonly network: PluginNetworkService;
+  readonly workspace: PluginWorkspaceFileService;
+};
+
+export type PluginContext = {
+  readonly manifest: PluginManifest;
+  readonly services: PluginHostServices;
+};
+
+export type AiMessageRole = "system" | "user" | "assistant";
+
+export type AiMessage = {
+  role: AiMessageRole;
+  content: string;
+};
+
+export type AiGenerationRequest = {
+  messages: AiMessage[];
+  model?: string;
+  temperature?: number;
+  maxOutputTokens?: number;
+};
+
+export type AiGenerationResult = {
+  text: string;
+  model?: string;
+  usage?: {
+    inputTokens: number;
+    outputTokens: number;
+  };
+};
+
+export interface AiProvider {
+  readonly id: string;
+  readonly name: string;
+  isAvailable(): Promise<boolean>;
+  generate(request: AiGenerationRequest): Promise<AiGenerationResult>;
+}
+
+export type SyncProvider = CoreSyncProvider;
+
+export type PluginProvides = {
+  syncProvider?: SyncProvider;
+  aiProvider?: AiProvider;
+};
+
+export type GrovePlugin = {
+  readonly id: string;
+  readonly name: string;
+  readonly manifest?: PluginManifest;
+  activate(context: PluginContext): Promise<PluginProvides> | PluginProvides;
+  deactivate?(): Promise<void> | void;
+};
+
+export function definePlugin<const Plugin extends GrovePlugin>(plugin: Plugin): Plugin {
+  return plugin;
+}

--- a/packages/plugin-api/tsconfig.json
+++ b/packages/plugin-api/tsconfig.json
@@ -1,0 +1,4 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "include": ["src/**/*.ts"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -118,6 +118,12 @@ importers:
         specifier: workspace:*
         version: link:../core
 
+  packages/plugin-api:
+    dependencies:
+      '@grove/core':
+        specifier: workspace:*
+        version: link:../core
+
   packages/sync:
     dependencies:
       '@grove/core':

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -15,6 +15,7 @@
       "@grove/core": ["packages/core/src/index.ts"],
       "@grove/db": ["packages/db/src/index.ts"],
       "@grove/editor": ["packages/editor/src/index.ts"],
+      "@grove/plugin-api": ["packages/plugin-api/src/index.ts"],
       "@grove/sync": ["packages/sync/src/index.ts"]
     }
   }


### PR DESCRIPTION
## Summary
- add `@grove/plugin-api` workspace package for manifest, capability, permission, host context, sync provider, and AI provider contracts
- expose the package through the shared TypeScript path map and workspace lockfile
- add Vitest coverage for `definePlugin`, sync provider registration, and AI provider registration

## Testing
- pnpm --filter @grove/plugin-api test
- pnpm --filter @grove/plugin-api typecheck
- pnpm test
- pnpm typecheck
- pnpm lint
- pnpm format
- pnpm --filter @grove/desktop build
- git diff --check
- git diff --cached --check

Refs #2
