### PR TITLE
Add desktop plugin host validation

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -13,6 +13,7 @@
   },
   "dependencies": {
     "@grove/core": "workspace:*",
+    "@grove/plugin-api": "workspace:*",
     "@tanstack/react-router": "^1.168.21",
     "@tauri-apps/api": "^2.0.0",
     "react": "^19.0.0",

--- a/apps/desktop/src/features/plugin-host/index.ts
+++ b/apps/desktop/src/features/plugin-host/index.ts
@@ -1,4 +1,3 @@
-export { FolderNavigationWorkspace } from "./folder-navigation";
 export {
   activatePluginHostRecord,
   createDiscoveredPluginHostRecord,
@@ -9,11 +8,11 @@ export {
   validatePluginManifest,
   validatePluginProvides,
   verifyPluginHostRecord,
-} from "./plugin-host";
+} from "./model/pluginHost";
 export type {
   PluginHostActivationResult,
   PluginHostLifecycleState,
   PluginHostRecord,
   PluginHostValidationIssue,
   PluginHostValidationResult,
-} from "./plugin-host";
+} from "./model/pluginHost";

--- a/apps/desktop/src/features/plugin-host/model/pluginHost.test.ts
+++ b/apps/desktop/src/features/plugin-host/model/pluginHost.test.ts
@@ -1,0 +1,274 @@
+import { describe, expect, it } from "vitest";
+
+import type {
+  GrovePlugin,
+  PluginHostServices,
+  PluginManifest,
+  PluginProvides,
+} from "@grove/plugin-api";
+import {
+  activatePluginHostRecord,
+  createDiscoveredPluginHostRecord,
+  createPermissionedPluginHostServices,
+  disablePluginHostRecord,
+  enablePluginHostRecord,
+  PluginPermissionError,
+  validatePluginManifest,
+  validatePluginProvides,
+  verifyPluginHostRecord,
+} from "./pluginHost";
+
+const syncManifest: PluginManifest = {
+  id: "sync-r2",
+  name: "Cloudflare R2 Sync",
+  version: "0.1.0",
+  apiVersion: 1,
+  entry: "./src/index.ts",
+  capabilities: ["syncProvider"],
+  permissions: ["network", "secrets:read"],
+};
+
+const services: PluginHostServices = {
+  settings: {
+    get: async () => undefined,
+    set: async () => undefined,
+    delete: async () => undefined,
+  },
+  secrets: {
+    get: async () => "secret",
+    set: async () => undefined,
+    delete: async () => undefined,
+  },
+  network: {
+    request: async () => ({
+      status: 200,
+      headers: {},
+      body: new Uint8Array([1, 2, 3]),
+    }),
+  },
+  workspace: {
+    read: async () => new Uint8Array([4, 5, 6]),
+    write: async () => undefined,
+    list: async () => [],
+    delete: async () => undefined,
+  },
+};
+
+const syncProvider: PluginProvides = {
+  syncProvider: {
+    id: "r2",
+    name: "Cloudflare R2",
+    upload: async () => undefined,
+    download: async () => new Uint8Array(),
+    list: async () => [],
+    delete: async () => undefined,
+    isAvailable: async () => true,
+  },
+};
+
+describe("validatePluginManifest", () => {
+  it("accepts a supported manifest", () => {
+    expect(validatePluginManifest(syncManifest)).toStrictEqual({
+      ok: true,
+      manifest: syncManifest,
+      issues: [],
+    });
+  });
+
+  it("rejects unsupported api versions, package escapes, and unknown values", () => {
+    const result = validatePluginManifest({
+      id: "sync-r2",
+      name: "Cloudflare R2 Sync",
+      version: "0.1.0",
+      apiVersion: 2,
+      entry: "../dist/index.js",
+      capabilities: ["syncProvider", "syncProvider", "unsafeCapability"],
+      permissions: ["network", "filesystem"],
+    });
+
+    expect(result.ok).toBe(false);
+
+    if (result.ok) {
+      throw new Error("Expected manifest validation to fail.");
+    }
+
+    expect(result.issues).toEqual(
+      expect.arrayContaining([
+        {
+          field: "apiVersion",
+          message: "apiVersion must be 1.",
+        },
+        {
+          field: "entry",
+          message: "entry must stay inside the plugin package.",
+        },
+        {
+          field: "capabilities",
+          message: "capabilities must not contain duplicates.",
+        },
+        {
+          field: "capabilities",
+          message: "Unsupported capability: unsafeCapability.",
+        },
+        {
+          field: "permissions",
+          message: "Unsupported permission: filesystem.",
+        },
+      ]),
+    );
+  });
+});
+
+describe("plugin host lifecycle", () => {
+  it("moves a valid manifest from verified to enabled to active", async () => {
+    const discovered = createDiscoveredPluginHostRecord("sync-r2");
+    const verified = verifyPluginHostRecord(discovered, syncManifest);
+    const enabled = enablePluginHostRecord(verified);
+    const plugin: GrovePlugin = {
+      id: "sync-r2",
+      name: "Cloudflare R2 Sync",
+      activate: async () => syncProvider,
+    };
+
+    const result = await activatePluginHostRecord(enabled, plugin, services);
+
+    expect(discovered.state).toBe("discovered");
+    expect(verified.state).toBe("verified");
+    expect(enabled.state).toBe("enabled");
+    expect(result.ok).toBe(true);
+    expect(result.record.state).toBe("active");
+    expect(result.record.provides?.syncProvider?.id).toBe("r2");
+  });
+
+  it("records invalid manifests as errors without throwing", () => {
+    const record = verifyPluginHostRecord(createDiscoveredPluginHostRecord("broken"), {
+      id: "broken",
+      apiVersion: 1,
+      entry: "./src/index.ts",
+      capabilities: [],
+      permissions: [],
+    });
+
+    expect(record.state).toBe("error");
+    expect(record.errorMessage).toBe("Plugin manifest is invalid.");
+    expect(record.issues).toEqual(
+      expect.arrayContaining([
+        {
+          field: "name",
+          message: "name must be a non-empty string.",
+        },
+      ]),
+    );
+  });
+
+  it("returns enabled or active records to verified when disabled", () => {
+    const enabled = enablePluginHostRecord(
+      verifyPluginHostRecord(createDiscoveredPluginHostRecord("sync-r2"), syncManifest),
+    );
+
+    expect(disablePluginHostRecord(enabled)).toMatchObject({
+      id: "sync-r2",
+      state: "verified",
+      manifest: syncManifest,
+    });
+  });
+});
+
+describe("validatePluginProvides", () => {
+  it("rejects missing and undeclared capability registrations", () => {
+    expect(validatePluginProvides(syncManifest, {})).toStrictEqual([
+      {
+        field: "capabilities",
+        message: "Declared capability was not registered: syncProvider.",
+      },
+    ]);
+
+    expect(
+      validatePluginProvides(
+        {
+          ...syncManifest,
+          capabilities: [],
+        },
+        syncProvider,
+      ),
+    ).toStrictEqual([
+      {
+        field: "capabilities",
+        message: "Registered capability was not declared: syncProvider.",
+      },
+    ]);
+  });
+});
+
+describe("permissioned plugin host services", () => {
+  it("allows services covered by manifest permissions", async () => {
+    const permissionedServices = createPermissionedPluginHostServices(syncManifest, services);
+
+    await expect(
+      permissionedServices.network.request({ url: "https://example.com" }),
+    ).resolves.toMatchObject({
+      status: 200,
+    });
+    await expect(permissionedServices.secrets.get("token")).resolves.toBe("secret");
+  });
+
+  it("rejects services that were not granted by the manifest", async () => {
+    const permissionedServices = createPermissionedPluginHostServices(syncManifest, services);
+
+    await expect(permissionedServices.settings.get("theme")).rejects.toStrictEqual(
+      new PluginPermissionError("settings:read"),
+    );
+    await expect(
+      permissionedServices.workspace.write("note.md", new Uint8Array()),
+    ).rejects.toStrictEqual(new PluginPermissionError("workspace:write"));
+  });
+});
+
+describe("activatePluginHostRecord", () => {
+  it("rejects manifest and registration mismatches as host errors", async () => {
+    const enabled = enablePluginHostRecord(
+      verifyPluginHostRecord(createDiscoveredPluginHostRecord("sync-r2"), syncManifest),
+    );
+    const plugin: GrovePlugin = {
+      id: "sync-r2",
+      name: "Cloudflare R2 Sync",
+      activate: async () => ({}),
+    };
+
+    const result = await activatePluginHostRecord(enabled, plugin, services);
+
+    expect(result.ok).toBe(false);
+    expect(result.record).toMatchObject({
+      state: "error",
+      errorMessage: "Plugin registrations do not match manifest.",
+      issues: [
+        {
+          field: "capabilities",
+          message: "Declared capability was not registered: syncProvider.",
+        },
+      ],
+    });
+  });
+
+  it("turns plugin activation failures into error records", async () => {
+    const enabled = enablePluginHostRecord(
+      verifyPluginHostRecord(createDiscoveredPluginHostRecord("sync-r2"), syncManifest),
+    );
+    const plugin: GrovePlugin = {
+      id: "sync-r2",
+      name: "Cloudflare R2 Sync",
+      activate: async (context) => {
+        await context.services.settings.get("theme");
+        return syncProvider;
+      },
+    };
+
+    const result = await activatePluginHostRecord(enabled, plugin, services);
+
+    expect(result.ok).toBe(false);
+    expect(result.record).toMatchObject({
+      state: "error",
+      errorMessage: "Plugin permission required: settings:read",
+    });
+  });
+});

--- a/apps/desktop/src/features/plugin-host/model/pluginHost.test.ts
+++ b/apps/desktop/src/features/plugin-host/model/pluginHost.test.ts
@@ -117,6 +117,32 @@ describe("validatePluginManifest", () => {
       ]),
     );
   });
+
+  it("rejects absolute and URL entry paths", () => {
+    const entries = [
+      "/tmp/plugin.js",
+      "\\\\server\\plugin.js",
+      "C:\\plugin.js",
+      "https://example.com/plugin.js",
+    ];
+
+    for (const entry of entries) {
+      const result = validatePluginManifest({
+        ...syncManifest,
+        entry,
+      });
+
+      expect(result).toMatchObject({
+        ok: false,
+        issues: [
+          {
+            field: "entry",
+            message: "entry must stay inside the plugin package.",
+          },
+        ],
+      });
+    }
+  });
 });
 
 describe("plugin host lifecycle", () => {
@@ -161,6 +187,25 @@ describe("plugin host lifecycle", () => {
     );
   });
 
+  it("rejects manifests that do not match the discovered plugin id", () => {
+    const record = verifyPluginHostRecord(createDiscoveredPluginHostRecord("sync-r2"), {
+      ...syncManifest,
+      id: "other-plugin",
+    });
+
+    expect(record).toStrictEqual({
+      id: "sync-r2",
+      state: "error",
+      errorMessage: "Plugin manifest id does not match discovered plugin id.",
+      issues: [
+        {
+          field: "id",
+          message: "id must match the discovered plugin id.",
+        },
+      ],
+    });
+  });
+
   it("returns enabled or active records to verified when disabled", () => {
     const enabled = enablePluginHostRecord(
       verifyPluginHostRecord(createDiscoveredPluginHostRecord("sync-r2"), syncManifest),
@@ -195,6 +240,23 @@ describe("validatePluginProvides", () => {
       {
         field: "capabilities",
         message: "Registered capability was not declared: syncProvider.",
+      },
+    ]);
+  });
+
+  it("rejects invalid capability registrations", () => {
+    const invalidProvides = {
+      syncProvider: {
+        id: "r2",
+        name: "Cloudflare R2",
+        upload: async () => undefined,
+      },
+    } as unknown as PluginProvides;
+
+    expect(validatePluginProvides(syncManifest, invalidProvides)).toStrictEqual([
+      {
+        field: "capabilities",
+        message: "Registered capability is invalid: syncProvider.",
       },
     ]);
   });

--- a/apps/desktop/src/features/plugin-host/model/pluginHost.test.ts
+++ b/apps/desktop/src/features/plugin-host/model/pluginHost.test.ts
@@ -220,6 +220,27 @@ describe("plugin host lifecycle", () => {
 });
 
 describe("validatePluginProvides", () => {
+  it("rejects non-object and unsupported capability registrations", () => {
+    expect(validatePluginProvides(syncManifest, null)).toStrictEqual([
+      {
+        field: "capabilities",
+        message: "Plugin registrations must be an object.",
+      },
+    ]);
+
+    expect(
+      validatePluginProvides(syncManifest, {
+        ...syncProvider,
+        filesystemProvider: {},
+      }),
+    ).toStrictEqual([
+      {
+        field: "capabilities",
+        message: "Unsupported registered capability: filesystemProvider.",
+      },
+    ]);
+  });
+
   it("rejects missing and undeclared capability registrations", () => {
     expect(validatePluginProvides(syncManifest, {})).toStrictEqual([
       {
@@ -307,6 +328,31 @@ describe("activatePluginHostRecord", () => {
         {
           field: "capabilities",
           message: "Declared capability was not registered: syncProvider.",
+        },
+      ],
+    });
+  });
+
+  it("rejects non-object activation results as host errors", async () => {
+    const enabled = enablePluginHostRecord(
+      verifyPluginHostRecord(createDiscoveredPluginHostRecord("sync-r2"), syncManifest),
+    );
+    const plugin: GrovePlugin = {
+      id: "sync-r2",
+      name: "Cloudflare R2 Sync",
+      activate: async () => null as unknown as PluginProvides,
+    };
+
+    const result = await activatePluginHostRecord(enabled, plugin, services);
+
+    expect(result.ok).toBe(false);
+    expect(result.record).toMatchObject({
+      state: "error",
+      errorMessage: "Plugin registrations do not match manifest.",
+      issues: [
+        {
+          field: "capabilities",
+          message: "Plugin registrations must be an object.",
         },
       ],
     });

--- a/apps/desktop/src/features/plugin-host/model/pluginHost.ts
+++ b/apps/desktop/src/features/plugin-host/model/pluginHost.ts
@@ -124,7 +124,12 @@ function validateEntry(input: Record<string, unknown>, issues: PluginHostValidat
     return;
   }
 
-  if (entry.startsWith("/") || entry.includes("..")) {
+  if (
+    entry.startsWith("/") ||
+    entry.startsWith("\\") ||
+    entry.includes("..") ||
+    /^[A-Za-z][A-Za-z0-9+.-]*:/.test(entry)
+  ) {
     issues.push({
       field: "entry",
       message: "entry must stay inside the plugin package.",
@@ -269,6 +274,20 @@ export function verifyPluginHostRecord(
     };
   }
 
+  if (validation.manifest.id !== record.id) {
+    return {
+      id: record.id,
+      state: "error",
+      errorMessage: "Plugin manifest id does not match discovered plugin id.",
+      issues: [
+        {
+          field: "id",
+          message: "id must match the discovered plugin id.",
+        },
+      ],
+    };
+  }
+
   return {
     id: validation.manifest.id,
     state: "verified",
@@ -324,9 +343,38 @@ export function validatePluginProvides(
         message: `Registered capability was not declared: ${capability}.`,
       });
     }
+
+    if (isRegistered && !isValidCapabilityRegistration(capability, provides[capability])) {
+      issues.push({
+        field: "capabilities",
+        message: `Registered capability is invalid: ${capability}.`,
+      });
+    }
   }
 
   return issues;
+}
+
+function hasFunction(value: Record<string, unknown>, field: string): boolean {
+  return typeof value[field] === "function";
+}
+
+function isValidCapabilityRegistration(capability: PluginCapability, value: unknown): boolean {
+  if (!isRecord(value) || !isNonEmptyString(value.id) || !isNonEmptyString(value.name)) {
+    return false;
+  }
+
+  if (capability === "syncProvider") {
+    return (
+      hasFunction(value, "upload") &&
+      hasFunction(value, "download") &&
+      hasFunction(value, "list") &&
+      hasFunction(value, "delete") &&
+      hasFunction(value, "isAvailable")
+    );
+  }
+
+  return hasFunction(value, "isAvailable") && hasFunction(value, "generate");
 }
 
 function assertPermission(manifest: PluginManifest, permission: PluginPermission): void {

--- a/apps/desktop/src/features/plugin-host/model/pluginHost.ts
+++ b/apps/desktop/src/features/plugin-host/model/pluginHost.ts
@@ -1,0 +1,464 @@
+import type {
+  GrovePlugin,
+  PluginCapability,
+  PluginHostServices,
+  PluginManifest,
+  PluginPermission,
+  PluginProvides,
+} from "@grove/plugin-api";
+
+const supportedApiVersion = 1;
+
+const supportedCapabilities = ["syncProvider", "aiProvider"] satisfies PluginCapability[];
+const supportedPermissions = [
+  "network",
+  "settings:read",
+  "settings:write",
+  "secrets:read",
+  "secrets:write",
+  "workspace:read",
+  "workspace:write",
+] satisfies PluginPermission[];
+
+const capabilitySet = new Set<string>(supportedCapabilities);
+const permissionSet = new Set<string>(supportedPermissions);
+
+export type PluginHostLifecycleState = "discovered" | "verified" | "enabled" | "active" | "error";
+
+export type PluginHostValidationIssue = {
+  field: string;
+  message: string;
+};
+
+export type PluginHostValidationResult =
+  | {
+      ok: true;
+      manifest: PluginManifest;
+      issues: readonly [];
+    }
+  | {
+      ok: false;
+      issues: readonly PluginHostValidationIssue[];
+    };
+
+export type PluginHostRecord = {
+  id: string;
+  state: PluginHostLifecycleState;
+  manifest?: PluginManifest;
+  provides?: PluginProvides;
+  errorMessage?: string;
+  issues: readonly PluginHostValidationIssue[];
+};
+
+export type PluginHostActivationResult =
+  | {
+      ok: true;
+      record: PluginHostRecord & {
+        state: "active";
+        manifest: PluginManifest;
+        provides: PluginProvides;
+      };
+    }
+  | {
+      ok: false;
+      record: PluginHostRecord & {
+        state: "error";
+      };
+    };
+
+export class PluginPermissionError extends Error {
+  readonly permission: PluginPermission;
+
+  constructor(permission: PluginPermission) {
+    super(`Plugin permission required: ${permission}`);
+    this.name = "PluginPermissionError";
+    this.permission = permission;
+  }
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function isNonEmptyString(value: unknown): value is string {
+  return typeof value === "string" && value.trim().length > 0;
+}
+
+function isStringArray(value: unknown): value is string[] {
+  return Array.isArray(value) && value.every((entry) => typeof entry === "string");
+}
+
+function hasDuplicates(entries: readonly string[]): boolean {
+  return new Set(entries).size !== entries.length;
+}
+
+function isPluginCapability(value: string): value is PluginCapability {
+  return capabilitySet.has(value);
+}
+
+function isPluginPermission(value: string): value is PluginPermission {
+  return permissionSet.has(value);
+}
+
+function validateStringField(
+  input: Record<string, unknown>,
+  field: keyof PluginManifest,
+  issues: PluginHostValidationIssue[],
+): void {
+  if (!isNonEmptyString(input[field])) {
+    issues.push({
+      field,
+      message: `${field} must be a non-empty string.`,
+    });
+  }
+}
+
+function validateEntry(input: Record<string, unknown>, issues: PluginHostValidationIssue[]): void {
+  const entry = input.entry;
+
+  if (!isNonEmptyString(entry)) {
+    issues.push({
+      field: "entry",
+      message: "entry must be a non-empty string.",
+    });
+    return;
+  }
+
+  if (entry.startsWith("/") || entry.includes("..")) {
+    issues.push({
+      field: "entry",
+      message: "entry must stay inside the plugin package.",
+    });
+  }
+}
+
+function validateApiVersion(
+  input: Record<string, unknown>,
+  issues: PluginHostValidationIssue[],
+): void {
+  if (input.apiVersion !== supportedApiVersion) {
+    issues.push({
+      field: "apiVersion",
+      message: `apiVersion must be ${supportedApiVersion}.`,
+    });
+  }
+}
+
+function validateEnumArray(
+  input: Record<string, unknown>,
+  field: "capabilities" | "permissions",
+  knownValueLabel: string,
+  isKnownValue: (value: string) => boolean,
+  issues: PluginHostValidationIssue[],
+): void {
+  const value = input[field];
+
+  if (!isStringArray(value)) {
+    issues.push({
+      field,
+      message: `${field} must be an array of ${knownValueLabel}.`,
+    });
+    return;
+  }
+
+  if (hasDuplicates(value)) {
+    issues.push({
+      field,
+      message: `${field} must not contain duplicates.`,
+    });
+  }
+
+  for (const entry of value) {
+    if (!isKnownValue(entry)) {
+      issues.push({
+        field,
+        message: `Unsupported ${knownValueLabel}: ${entry}.`,
+      });
+    }
+  }
+}
+
+function validateOptionalStringField(
+  input: Record<string, unknown>,
+  field: "description" | "author",
+  issues: PluginHostValidationIssue[],
+): void {
+  const value = input[field];
+
+  if (value !== undefined && typeof value !== "string") {
+    issues.push({
+      field,
+      message: `${field} must be a string when present.`,
+    });
+  }
+}
+
+function toManifest(input: Record<string, unknown>): PluginManifest {
+  return {
+    id: input.id as string,
+    name: input.name as string,
+    version: input.version as string,
+    apiVersion: supportedApiVersion,
+    entry: input.entry as string,
+    capabilities: (input.capabilities as string[]).filter(isPluginCapability),
+    permissions: (input.permissions as string[]).filter(isPluginPermission),
+    ...(typeof input.description === "string" ? { description: input.description } : {}),
+    ...(typeof input.author === "string" ? { author: input.author } : {}),
+  };
+}
+
+export function validatePluginManifest(input: unknown): PluginHostValidationResult {
+  const issues: PluginHostValidationIssue[] = [];
+
+  if (!isRecord(input)) {
+    return {
+      ok: false,
+      issues: [
+        {
+          field: "manifest",
+          message: "Plugin manifest must be an object.",
+        },
+      ],
+    };
+  }
+
+  validateStringField(input, "id", issues);
+  validateStringField(input, "name", issues);
+  validateStringField(input, "version", issues);
+  validateApiVersion(input, issues);
+  validateEntry(input, issues);
+  validateEnumArray(input, "capabilities", "capability", isPluginCapability, issues);
+  validateEnumArray(input, "permissions", "permission", isPluginPermission, issues);
+  validateOptionalStringField(input, "description", issues);
+  validateOptionalStringField(input, "author", issues);
+
+  if (issues.length > 0) {
+    return {
+      ok: false,
+      issues,
+    };
+  }
+
+  return {
+    ok: true,
+    manifest: toManifest(input),
+    issues: [],
+  };
+}
+
+export function createDiscoveredPluginHostRecord(id: string): PluginHostRecord {
+  return {
+    id,
+    state: "discovered",
+    issues: [],
+  };
+}
+
+export function verifyPluginHostRecord(
+  record: PluginHostRecord,
+  manifestInput: unknown,
+): PluginHostRecord {
+  const validation = validatePluginManifest(manifestInput);
+
+  if (!validation.ok) {
+    return {
+      id: record.id,
+      state: "error",
+      errorMessage: "Plugin manifest is invalid.",
+      issues: validation.issues,
+    };
+  }
+
+  return {
+    id: validation.manifest.id,
+    state: "verified",
+    manifest: validation.manifest,
+    issues: [],
+  };
+}
+
+export function enablePluginHostRecord(record: PluginHostRecord): PluginHostRecord {
+  if (record.state !== "verified" || record.manifest === undefined) {
+    return record;
+  }
+
+  return {
+    ...record,
+    state: "enabled",
+  };
+}
+
+export function disablePluginHostRecord(record: PluginHostRecord): PluginHostRecord {
+  if (record.state !== "enabled" && record.state !== "active") {
+    return record;
+  }
+
+  return {
+    id: record.id,
+    state: "verified",
+    manifest: record.manifest,
+    issues: [],
+  };
+}
+
+export function validatePluginProvides(
+  manifest: PluginManifest,
+  provides: PluginProvides,
+): readonly PluginHostValidationIssue[] {
+  const issues: PluginHostValidationIssue[] = [];
+
+  for (const capability of supportedCapabilities) {
+    const isDeclared = manifest.capabilities.includes(capability);
+    const isRegistered = provides[capability] !== undefined;
+
+    if (isDeclared && !isRegistered) {
+      issues.push({
+        field: "capabilities",
+        message: `Declared capability was not registered: ${capability}.`,
+      });
+    }
+
+    if (!isDeclared && isRegistered) {
+      issues.push({
+        field: "capabilities",
+        message: `Registered capability was not declared: ${capability}.`,
+      });
+    }
+  }
+
+  return issues;
+}
+
+function assertPermission(manifest: PluginManifest, permission: PluginPermission): void {
+  if (!manifest.permissions.includes(permission)) {
+    throw new PluginPermissionError(permission);
+  }
+}
+
+export function createPermissionedPluginHostServices(
+  manifest: PluginManifest,
+  services: PluginHostServices,
+): PluginHostServices {
+  return {
+    settings: {
+      get: async (key) => {
+        assertPermission(manifest, "settings:read");
+        return services.settings.get(key);
+      },
+      set: async (key, value) => {
+        assertPermission(manifest, "settings:write");
+        return services.settings.set(key, value);
+      },
+      delete: async (key) => {
+        assertPermission(manifest, "settings:write");
+        return services.settings.delete(key);
+      },
+    },
+    secrets: {
+      get: async (key) => {
+        assertPermission(manifest, "secrets:read");
+        return services.secrets.get(key);
+      },
+      set: async (key, value) => {
+        assertPermission(manifest, "secrets:write");
+        return services.secrets.set(key, value);
+      },
+      delete: async (key) => {
+        assertPermission(manifest, "secrets:write");
+        return services.secrets.delete(key);
+      },
+    },
+    network: {
+      request: async (request) => {
+        assertPermission(manifest, "network");
+        return services.network.request(request);
+      },
+    },
+    workspace: {
+      read: async (path) => {
+        assertPermission(manifest, "workspace:read");
+        return services.workspace.read(path);
+      },
+      write: async (path, data) => {
+        assertPermission(manifest, "workspace:write");
+        return services.workspace.write(path, data);
+      },
+      list: async (prefix) => {
+        assertPermission(manifest, "workspace:read");
+        return services.workspace.list(prefix);
+      },
+      delete: async (path) => {
+        assertPermission(manifest, "workspace:write");
+        return services.workspace.delete(path);
+      },
+    },
+  };
+}
+
+function toErrorRecord(
+  record: PluginHostRecord,
+  errorMessage: string,
+  issues: readonly PluginHostValidationIssue[] = [],
+): PluginHostRecord & { state: "error" } {
+  return {
+    id: record.id,
+    state: "error",
+    manifest: record.manifest,
+    errorMessage,
+    issues,
+  };
+}
+
+export async function activatePluginHostRecord(
+  record: PluginHostRecord,
+  plugin: GrovePlugin,
+  services: PluginHostServices,
+): Promise<PluginHostActivationResult> {
+  if (record.state !== "enabled" || record.manifest === undefined) {
+    return {
+      ok: false,
+      record: toErrorRecord(record, "Plugin must be enabled before activation."),
+    };
+  }
+
+  if (plugin.id !== record.manifest.id) {
+    return {
+      ok: false,
+      record: toErrorRecord(record, "Plugin id does not match manifest id."),
+    };
+  }
+
+  try {
+    const provides = await plugin.activate({
+      manifest: record.manifest,
+      services: createPermissionedPluginHostServices(record.manifest, services),
+    });
+    const issues = validatePluginProvides(record.manifest, provides);
+
+    if (issues.length > 0) {
+      return {
+        ok: false,
+        record: toErrorRecord(record, "Plugin registrations do not match manifest.", issues),
+      };
+    }
+
+    return {
+      ok: true,
+      record: {
+        id: record.id,
+        state: "active",
+        manifest: record.manifest,
+        provides,
+        issues: [],
+      },
+    };
+  } catch (error) {
+    return {
+      ok: false,
+      record: toErrorRecord(
+        record,
+        error instanceof Error ? error.message : "Plugin activation failed.",
+      ),
+    };
+  }
+}

--- a/apps/desktop/src/features/plugin-host/model/pluginHost.ts
+++ b/apps/desktop/src/features/plugin-host/model/pluginHost.ts
@@ -322,9 +322,27 @@ export function disablePluginHostRecord(record: PluginHostRecord): PluginHostRec
 
 export function validatePluginProvides(
   manifest: PluginManifest,
-  provides: PluginProvides,
+  provides: unknown,
 ): readonly PluginHostValidationIssue[] {
   const issues: PluginHostValidationIssue[] = [];
+
+  if (!isRecord(provides)) {
+    return [
+      {
+        field: "capabilities",
+        message: "Plugin registrations must be an object.",
+      },
+    ];
+  }
+
+  for (const capability of Object.keys(provides)) {
+    if (!isPluginCapability(capability)) {
+      issues.push({
+        field: "capabilities",
+        message: `Unsupported registered capability: ${capability}.`,
+      });
+    }
+  }
 
   for (const capability of supportedCapabilities) {
     const isDeclared = manifest.capabilities.includes(capability);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -32,6 +32,9 @@ importers:
       '@grove/core':
         specifier: workspace:*
         version: link:../../packages/core
+      '@grove/plugin-api':
+        specifier: workspace:*
+        version: link:../../packages/plugin-api
       '@tanstack/react-router':
         specifier: ^1.168.21
         version: 1.168.21(react-dom@19.2.5(react@19.2.5))(react@19.2.5)


### PR DESCRIPTION
## Summary
- add desktop plugin host lifecycle records for discovered, verified, enabled, active, and error states
- validate plugin manifests for required shape, API version, entry path, capabilities, permissions, and duplicate declarations
- enforce activation registration matching and manifest-based permission gates for host services
- add desktop Vitest coverage for manifest validation, lifecycle transitions, registration mismatches, permission checks, and activation failures

## Testing
- pnpm test
- pnpm typecheck
- pnpm lint
- pnpm format
- pnpm --filter @grove/desktop build
- git diff --cached --check

Refs #1
