### PR TITLE
Implement desktop workspace Markdown scan

### DIFF
--- a/apps/desktop/src-tauri/src/main.rs
+++ b/apps/desktop/src-tauri/src/main.rs
@@ -7,7 +7,7 @@ use std::{
 
 use serde::{Deserialize, Serialize};
 use tauri::Manager;
-use tokio::io::AsyncWriteExt;
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
 
 #[derive(Debug, Deserialize)]
 #[serde(rename_all = "camelCase")]
@@ -37,6 +37,14 @@ struct IndexRefreshSidecarEntry {
     note_ids: Vec<String>,
     reason: IndexRefreshReason,
     queued_at_unix_ms: u128,
+}
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct ScannedMarkdownNote {
+    path: String,
+    title: String,
+    updated_at_unix_ms: u128,
 }
 
 #[derive(Debug, Serialize)]
@@ -97,11 +105,27 @@ async fn refresh_note_indexes(
         .map_err(|error| CommandError::new("index_refresh_failed", error.to_string()))
 }
 
+#[tauri::command]
+async fn scan_markdown_workspace(
+    app_handle: tauri::AppHandle,
+) -> Result<Vec<ScannedMarkdownNote>, CommandError> {
+    let workspace_root = default_workspace_root(&app_handle)?;
+
+    tokio::fs::create_dir_all(&workspace_root)
+        .await
+        .map_err(|error| CommandError::new("workspace_scan_failed", error.to_string()))?;
+
+    scan_markdown_files(&workspace_root)
+        .await
+        .map_err(|error| CommandError::new("workspace_scan_failed", error.to_string()))
+}
+
 fn main() {
     if let Err(error) = tauri::Builder::default()
         .invoke_handler(tauri::generate_handler![
             move_markdown_file,
-            refresh_note_indexes
+            refresh_note_indexes,
+            scan_markdown_workspace
         ])
         .run(tauri::generate_context!())
     {
@@ -175,6 +199,124 @@ fn has_windows_drive_prefix(path: &str) -> bool {
     path_bytes.len() >= 2 && path_bytes[0].is_ascii_alphabetic() && path_bytes[1] == b':'
 }
 
+async fn scan_markdown_files(workspace_root: &Path) -> anyhow::Result<Vec<ScannedMarkdownNote>> {
+    let mut pending_dirs = vec![workspace_root.to_path_buf()];
+    let mut notes = Vec::new();
+
+    while let Some(directory) = pending_dirs.pop() {
+        let mut entries = tokio::fs::read_dir(&directory).await?;
+
+        while let Some(entry) = entries.next_entry().await? {
+            let file_type = entry.file_type().await?;
+            let path = entry.path();
+
+            if file_type.is_dir() {
+                pending_dirs.push(path);
+                continue;
+            }
+
+            if !file_type.is_file() || !is_markdown_path(&path) {
+                continue;
+            }
+
+            let relative_path = get_workspace_relative_markdown_path(workspace_root, &path)?;
+            let metadata = entry.metadata().await?;
+            let updated_at_unix_ms = metadata.modified()?.duration_since(UNIX_EPOCH)?.as_millis();
+            let title = read_note_title(&path).await?;
+
+            notes.push(ScannedMarkdownNote {
+                path: relative_path,
+                title,
+                updated_at_unix_ms,
+            });
+        }
+    }
+
+    notes.sort_by(|left, right| left.path.to_lowercase().cmp(&right.path.to_lowercase()));
+    Ok(notes)
+}
+
+fn get_workspace_relative_markdown_path(
+    workspace_root: &Path,
+    markdown_path: &Path,
+) -> anyhow::Result<String> {
+    let relative_path = markdown_path.strip_prefix(workspace_root)?;
+    let path = relative_path_to_workspace_path(relative_path)?;
+
+    validate_markdown_path(&path)
+        .map_err(|error| anyhow::anyhow!("{}: {}", error.code, error.message))?;
+
+    Ok(path)
+}
+
+fn relative_path_to_workspace_path(relative_path: &Path) -> anyhow::Result<String> {
+    let mut segments = Vec::new();
+
+    for component in relative_path.components() {
+        match component {
+            Component::Normal(segment) => segments.push(segment.to_string_lossy().into_owned()),
+            _ => anyhow::bail!("Markdown scan results must stay inside the workspace."),
+        }
+    }
+
+    if segments.is_empty() {
+        anyhow::bail!("Markdown scan results must include a file name.");
+    }
+
+    Ok(segments.join("/"))
+}
+
+fn is_markdown_path(path: &Path) -> bool {
+    path.extension()
+        .and_then(|extension| extension.to_str())
+        .is_some_and(|extension| extension.eq_ignore_ascii_case("md"))
+}
+
+async fn read_note_title(path: &Path) -> anyhow::Result<String> {
+    let fallback_title = path
+        .file_stem()
+        .and_then(|file_stem| file_stem.to_str())
+        .unwrap_or("Untitled")
+        .trim()
+        .to_string();
+
+    let mut file = tokio::fs::File::open(path).await?;
+    let mut content = String::new();
+    file.read_to_string(&mut content).await?;
+
+    Ok(find_first_markdown_heading(&content).unwrap_or(fallback_title))
+}
+
+fn find_first_markdown_heading(content: &str) -> Option<String> {
+    for line in content.lines() {
+        let trimmed_line = line.trim_start();
+        let heading_marker_len = trimmed_line
+            .chars()
+            .take_while(|character| *character == '#')
+            .count();
+
+        if heading_marker_len == 0 || heading_marker_len > 6 {
+            continue;
+        }
+
+        let heading_body = &trimmed_line[heading_marker_len..];
+
+        if !heading_body.starts_with(char::is_whitespace) {
+            continue;
+        }
+
+        let title = heading_body.trim().trim_end_matches('#').trim();
+
+        if title.is_empty() {
+            continue;
+        }
+
+        return Some(title.to_string());
+    }
+
+    None
+}
+
 async fn move_file_without_overwrite(previous_path: &Path, next_path: &Path) -> anyhow::Result<()> {
     if !tokio::fs::try_exists(previous_path).await? {
         if tokio::fs::try_exists(next_path).await? {
@@ -237,7 +379,10 @@ mod tests {
         time::{SystemTime, UNIX_EPOCH},
     };
 
-    use super::{move_file_without_overwrite, validate_markdown_path};
+    use super::{
+        find_first_markdown_heading, get_workspace_relative_markdown_path,
+        move_file_without_overwrite, scan_markdown_files, validate_markdown_path,
+    };
 
     fn run_async<F>(future: F) -> F::Output
     where
@@ -298,6 +443,61 @@ mod tests {
         let error = validate_markdown_path("Projects/Grove/Plan.txt").unwrap_err();
 
         assert_eq!(error.code, "invalid_markdown_path");
+    }
+
+    #[test]
+    fn derives_workspace_relative_markdown_paths() {
+        let workspace_dir = PathBuf::from("/workspace");
+        let markdown_path = workspace_dir.join("Projects").join("Grove").join("Plan.md");
+
+        let path = get_workspace_relative_markdown_path(&workspace_dir, &markdown_path)
+            .expect("relative Markdown path should be derived");
+
+        assert_eq!(path, "Projects/Grove/Plan.md");
+    }
+
+    #[test]
+    fn rejects_scan_paths_outside_the_workspace() {
+        let workspace_dir = PathBuf::from("/workspace");
+        let markdown_path = PathBuf::from("/other").join("Plan.md");
+
+        let error = get_workspace_relative_markdown_path(&workspace_dir, &markdown_path)
+            .expect_err("outside paths should be rejected");
+
+        assert!(error.to_string().contains("prefix"));
+    }
+
+    #[test]
+    fn reads_first_markdown_heading_as_title() {
+        let title = find_first_markdown_heading("#tag\n\n## Project plan ##\nbody")
+            .expect("heading should be found");
+
+        assert_eq!(title, "Project plan");
+    }
+
+    #[test]
+    fn scans_markdown_files_and_ignores_other_files() {
+        run_async(async {
+            let workspace_dir = unique_test_dir("scans-markdown-files");
+            let plan_path = workspace_dir.join("Projects").join("Plan.md");
+            let notes_path = workspace_dir.join("Inbox.MD");
+            let text_path = workspace_dir.join("Projects").join("Draft.txt");
+            tokio::fs::create_dir_all(plan_path.parent().expect("plan parent")).await?;
+            tokio::fs::write(&plan_path, "# Plan\nbody").await?;
+            tokio::fs::write(&notes_path, "no heading").await?;
+            tokio::fs::write(&text_path, "# Draft").await?;
+
+            let notes = scan_markdown_files(&workspace_dir).await?;
+
+            assert_eq!(notes.len(), 2);
+            assert_eq!(notes[0].path, "Inbox.MD");
+            assert_eq!(notes[0].title, "Inbox");
+            assert_eq!(notes[1].path, "Projects/Plan.md");
+            assert_eq!(notes[1].title, "Plan");
+            tokio::fs::remove_dir_all(&workspace_dir).await?;
+            anyhow::Ok(())
+        })
+        .expect("workspace scan should succeed");
     }
 
     #[test]

--- a/apps/desktop/src-tauri/src/main.rs
+++ b/apps/desktop/src-tauri/src/main.rs
@@ -221,7 +221,7 @@ async fn scan_markdown_files(workspace_root: &Path) -> anyhow::Result<Vec<Scanne
 
             let relative_path = get_workspace_relative_markdown_path(workspace_root, &path)?;
             let metadata = entry.metadata().await?;
-            let updated_at_unix_ms = metadata.modified()?.duration_since(UNIX_EPOCH)?.as_millis();
+            let updated_at_unix_ms = system_time_to_unix_ms(metadata.modified()?);
             let title = read_note_title(&path).await?;
 
             notes.push(ScannedMarkdownNote {
@@ -270,6 +270,11 @@ fn is_markdown_path(path: &Path) -> bool {
     path.extension()
         .and_then(|extension| extension.to_str())
         .is_some_and(|extension| extension.eq_ignore_ascii_case("md"))
+}
+
+fn system_time_to_unix_ms(time: SystemTime) -> u128 {
+    time.duration_since(UNIX_EPOCH)
+        .map_or(0, |duration| duration.as_millis())
 }
 
 async fn read_note_title(path: &Path) -> anyhow::Result<String> {
@@ -325,7 +330,11 @@ fn strip_closing_heading_marker(title: &str) -> &str {
         return trimmed_title;
     }
 
-    if without_hashes.chars().next_back().is_some_and(char::is_whitespace) {
+    if without_hashes
+        .chars()
+        .next_back()
+        .is_some_and(char::is_whitespace)
+    {
         return without_hashes.trim_end();
     }
 
@@ -391,12 +400,13 @@ async fn append_index_refresh_sidecar_entry(
 mod tests {
     use std::{
         path::PathBuf,
-        time::{SystemTime, UNIX_EPOCH},
+        time::{Duration, SystemTime, UNIX_EPOCH},
     };
 
     use super::{
         find_first_markdown_heading, get_workspace_relative_markdown_path,
-        move_file_without_overwrite, scan_markdown_files, validate_markdown_path,
+        move_file_without_overwrite, scan_markdown_files, system_time_to_unix_ms,
+        validate_markdown_path,
     };
 
     fn run_async<F>(future: F) -> F::Output
@@ -495,6 +505,13 @@ mod tests {
         let title = find_first_markdown_heading("# C#").expect("heading should be found");
 
         assert_eq!(title, "C#");
+    }
+
+    #[test]
+    fn clamps_pre_epoch_scan_timestamps_to_zero() {
+        let updated_at_unix_ms = system_time_to_unix_ms(UNIX_EPOCH - Duration::from_millis(1));
+
+        assert_eq!(updated_at_unix_ms, 0);
     }
 
     #[test]

--- a/apps/desktop/src-tauri/src/main.rs
+++ b/apps/desktop/src-tauri/src/main.rs
@@ -305,7 +305,7 @@ fn find_first_markdown_heading(content: &str) -> Option<String> {
             continue;
         }
 
-        let title = heading_body.trim().trim_end_matches('#').trim();
+        let title = strip_closing_heading_marker(heading_body.trim());
 
         if title.is_empty() {
             continue;
@@ -315,6 +315,21 @@ fn find_first_markdown_heading(content: &str) -> Option<String> {
     }
 
     None
+}
+
+fn strip_closing_heading_marker(title: &str) -> &str {
+    let trimmed_title = title.trim_end();
+    let without_hashes = trimmed_title.trim_end_matches('#');
+
+    if without_hashes.len() == trimmed_title.len() {
+        return trimmed_title;
+    }
+
+    if without_hashes.chars().next_back().is_some_and(char::is_whitespace) {
+        return without_hashes.trim_end();
+    }
+
+    trimmed_title
 }
 
 async fn move_file_without_overwrite(previous_path: &Path, next_path: &Path) -> anyhow::Result<()> {
@@ -473,6 +488,13 @@ mod tests {
             .expect("heading should be found");
 
         assert_eq!(title, "Project plan");
+    }
+
+    #[test]
+    fn keeps_hash_characters_that_are_part_of_the_heading_title() {
+        let title = find_first_markdown_heading("# C#").expect("heading should be found");
+
+        assert_eq!(title, "C#");
     }
 
     #[test]

--- a/apps/desktop/src/features/folder-navigation/model/workspaceScan.test.ts
+++ b/apps/desktop/src/features/folder-navigation/model/workspaceScan.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from "vitest";
+
+import { mapScannedMarkdownNotes } from "./workspaceScan";
+
+describe("mapScannedMarkdownNotes", () => {
+  it("normalizes scan results into folder navigation notes", () => {
+    expect(
+      mapScannedMarkdownNotes([
+        {
+          path: "Projects\\Grove//Plan.md",
+          title: " Workspace plan ",
+          updatedAtUnixMs: Date.UTC(2026, 3, 15),
+        },
+      ]),
+    ).toStrictEqual([
+      {
+        id: "Projects/Grove/Plan.md",
+        path: "Projects/Grove/Plan.md",
+        title: "Workspace plan",
+        updatedLabel: "Apr 15",
+      },
+    ]);
+  });
+
+  it("falls back to the file name when the scanned title is blank", () => {
+    expect(
+      mapScannedMarkdownNotes([
+        {
+          path: "Inbox.md",
+          title: " ",
+          updatedAtUnixMs: Date.UTC(2026, 0, 2),
+        },
+      ]),
+    ).toMatchObject([
+      {
+        id: "Inbox.md",
+        title: "Inbox",
+      },
+    ]);
+  });
+
+  it("rejects scan results that are not workspace-relative Markdown paths", () => {
+    expect(() =>
+      mapScannedMarkdownNotes([
+        {
+          path: "/Users/me/Notes/Plan.md",
+          title: "Plan",
+          updatedAtUnixMs: Date.UTC(2026, 3, 15),
+        },
+      ]),
+    ).toThrow("absolute");
+  });
+});

--- a/apps/desktop/src/features/folder-navigation/model/workspaceScan.ts
+++ b/apps/desktop/src/features/folder-navigation/model/workspaceScan.ts
@@ -1,0 +1,44 @@
+import { compareWorkspacePaths, normalizeNoteFilePath } from "@grove/core";
+import type { ScannedMarkdownNote } from "../../../shared";
+
+import type { FolderNavigationNote } from "./folderWorkspaceState";
+
+const DATE_FORMATTER = new Intl.DateTimeFormat("en", {
+  month: "short",
+  day: "numeric",
+});
+
+export function mapScannedMarkdownNotes(
+  scannedNotes: readonly ScannedMarkdownNote[],
+): FolderNavigationNote[] {
+  return scannedNotes
+    .map(mapScannedMarkdownNote)
+    .sort((left, right) => compareWorkspacePaths(left.path, right.path));
+}
+
+function mapScannedMarkdownNote(scannedNote: ScannedMarkdownNote): FolderNavigationNote {
+  const path = normalizeNoteFilePath(scannedNote.path);
+  const title = scannedNote.title.trim() || getFallbackTitle(path);
+
+  return {
+    id: path,
+    path,
+    title,
+    updatedLabel: formatUpdatedLabel(scannedNote.updatedAtUnixMs),
+  };
+}
+
+function getFallbackTitle(path: string): string {
+  const fileName = path.split("/").at(-1) ?? "Untitled";
+  return fileName.replace(/\.md$/i, "").trim() || "Untitled";
+}
+
+function formatUpdatedLabel(updatedAtUnixMs: number): string {
+  const updatedAt = new Date(updatedAtUnixMs);
+
+  if (Number.isNaN(updatedAt.getTime())) {
+    return "Unknown";
+  }
+
+  return DATE_FORMATTER.format(updatedAt);
+}

--- a/apps/desktop/src/features/folder-navigation/ui/FolderNavigationWorkspace.tsx
+++ b/apps/desktop/src/features/folder-navigation/ui/FolderNavigationWorkspace.tsx
@@ -1,17 +1,17 @@
 import {
   appName,
   buildFolderTree,
+  compareWorkspacePaths,
   getFolderDisplayName,
   getFolderPathForNote,
   isNoteInFolderScope,
   normalizeFolderPath,
   normalizeFolderScope,
-  normalizeNoteFilePath,
 } from "@grove/core";
 import type { FolderScope, FolderTreeNode } from "@grove/core";
 import { useEffect, useMemo, useRef, useState } from "react";
 
-import { moveMarkdownFile, refreshNoteIndexes } from "../../../shared";
+import { moveMarkdownFile, refreshNoteIndexes, scanMarkdownWorkspace } from "../../../shared";
 import {
   clearCompletedPathChangeOperations,
   createPathChangeOperation,
@@ -27,6 +27,7 @@ import {
   runNextOperationStep,
 } from "../model/folderWorkspaceState";
 import { createDesktopPathChangeExecutor } from "../model/folderPathChangeExecutor";
+import { mapScannedMarkdownNotes } from "../model/workspaceScan";
 import type {
   FolderNavigationNote,
   FolderWorkspaceMutation,
@@ -61,6 +62,7 @@ type NoteListProps = {
   selectedFolderPath: FolderScope;
   scopedNotes: readonly NoteListItem[];
   selectedNoteId: string;
+  scanState: WorkspaceScanState;
   onSelectNote: (noteId: string) => void;
 };
 
@@ -99,43 +101,17 @@ type PathChangeQueueProps = {
   onRetryStep: (operationId: string, stepId: FolderWorkspaceOperationStepId) => void;
 };
 
-const initialNotes: readonly NoteListItem[] = [
-  {
-    id: "note-inbox",
-    title: "Daily capture",
-    path: normalizeNoteFilePath("Inbox.md"),
-    updatedLabel: "Today",
-  },
-  {
-    id: "note-plan",
-    title: "Grove workspace plan",
-    path: normalizeNoteFilePath("Projects/Grove/Workspace Plan.md"),
-    updatedLabel: "Yesterday",
-  },
-  {
-    id: "note-research",
-    title: "Folder navigation notes",
-    path: normalizeNoteFilePath("Projects/Grove/Research/Folder Navigation.md"),
-    updatedLabel: "Apr 12",
-  },
-  {
-    id: "note-sync",
-    title: "Sync provider questions",
-    path: normalizeNoteFilePath("Projects/Sync/Provider Questions.md"),
-    updatedLabel: "Apr 10",
-  },
-  {
-    id: "note-archive",
-    title: "Launch retrospective",
-    path: normalizeNoteFilePath("Archive/2026/Launch Retro.md"),
-    updatedLabel: "Apr 8",
-  },
-];
+type WorkspaceScanState = {
+  status: "loading" | "ready" | "failed";
+  errorMessage: string | null;
+};
 
-const initialExplicitFolders = [
-  normalizeFolderPath("Projects/Grove/Ideas"),
-  normalizeFolderPath("Reading"),
-] as const;
+const initialWorkspaceState: FolderWorkspaceState = {
+  notes: [],
+  explicitFolders: [],
+  selectedFolderPath: null,
+  expandedFolderPaths: [],
+};
 
 const desktopPathChangeExecutor = createDesktopPathChangeExecutor({
   fileGateway: {
@@ -191,6 +167,46 @@ function getOperationStepLabel(stepId: FolderWorkspaceOperationStep["id"]): stri
 
 function getOperationStepStatusClass(step: FolderWorkspaceOperationStep): string {
   return `folder-navigation__status folder-navigation__status--${step.status}`;
+}
+
+function getExpandedFolderPathsForNotes(notes: readonly NoteListItem[]): string[] {
+  const folderPaths = new Set<string>();
+
+  for (const note of notes) {
+    const folderPath = getFolderPathForNote(note.path);
+
+    if (folderPath === null) {
+      continue;
+    }
+
+    const segments = folderPath.split("/");
+
+    for (let index = 1; index <= segments.length; index += 1) {
+      folderPaths.add(normalizeFolderPath(segments.slice(0, index).join("/")));
+    }
+  }
+
+  return [...folderPaths].sort(compareWorkspacePaths);
+}
+
+function getScanErrorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : "The Markdown workspace scan failed.";
+}
+
+function WorkspaceScanBanner({ scanState }: { scanState: WorkspaceScanState }) {
+  if (scanState.status === "loading") {
+    return <p className="folder-navigation__muted">Scanning Markdown files...</p>;
+  }
+
+  if (scanState.status === "failed") {
+    return (
+      <p className="folder-navigation__step-error">
+        {scanState.errorMessage ?? "The Markdown workspace scan failed."}
+      </p>
+    );
+  }
+
+  return null;
 }
 
 function FolderNode({
@@ -296,12 +312,14 @@ function NoteList({
   selectedFolderPath,
   scopedNotes,
   selectedNoteId,
+  scanState,
   onSelectNote,
 }: NoteListProps) {
   return (
     <section className="folder-navigation__note-list" aria-label="Notes">
       <p className="folder-navigation__eyebrow">{getFolderLabel(selectedFolderPath)}</p>
       <h2 className="folder-navigation__heading">Notes</h2>
+      <WorkspaceScanBanner scanState={scanState} />
       {scopedNotes.length > 0 ? (
         <ol className="folder-navigation__notes">
           {scopedNotes.map((note) => (
@@ -587,13 +605,12 @@ function PathChangeQueue({
 }
 
 export function FolderNavigationWorkspace() {
-  const [workspaceState, setWorkspaceState] = useState<FolderWorkspaceState>({
-    notes: initialNotes,
-    explicitFolders: initialExplicitFolders,
-    selectedFolderPath: null,
-    expandedFolderPaths: ["Projects", "Projects/Grove"],
+  const [workspaceState, setWorkspaceState] = useState<FolderWorkspaceState>(initialWorkspaceState);
+  const [selectedNoteId, setSelectedNoteId] = useState<string>("");
+  const [scanState, setScanState] = useState<WorkspaceScanState>({
+    status: "loading",
+    errorMessage: null,
   });
-  const [selectedNoteId, setSelectedNoteId] = useState<string>(initialNotes[1]?.id ?? "");
   const [pathChangeOperations, setPathChangeOperations] = useState<
     readonly FolderWorkspacePathChangeOperation[]
   >([]);
@@ -723,6 +740,48 @@ export function FolderNavigationWorkspace() {
   }
 
   useEffect(() => {
+    let canceled = false;
+
+    async function scanWorkspace(): Promise<void> {
+      try {
+        const scannedNotes = await scanMarkdownWorkspace();
+        const notes = mapScannedMarkdownNotes(scannedNotes);
+
+        if (canceled) {
+          return;
+        }
+
+        setWorkspaceState({
+          notes,
+          explicitFolders: [],
+          selectedFolderPath: null,
+          expandedFolderPaths: getExpandedFolderPathsForNotes(notes),
+        });
+        setSelectedNoteId(notes[0]?.id ?? "");
+        setScanState({
+          status: "ready",
+          errorMessage: null,
+        });
+      } catch (error) {
+        if (canceled) {
+          return;
+        }
+
+        setScanState({
+          status: "failed",
+          errorMessage: getScanErrorMessage(error),
+        });
+      }
+    }
+
+    void scanWorkspace();
+
+    return () => {
+      canceled = true;
+    };
+  }, []);
+
+  useEffect(() => {
     const nextRunnableOperationId = getNextRunnablePathChangeOperationId(
       pathChangeOperations,
       runningOperationIds,
@@ -749,6 +808,7 @@ export function FolderNavigationWorkspace() {
         selectedFolderPath={selectedFolderPath}
         scopedNotes={scopedNotes}
         selectedNoteId={selectedNoteId}
+        scanState={scanState}
         onSelectNote={setSelectedNoteId}
       />
       <ActivePane

--- a/apps/desktop/src/features/folder-navigation/ui/FolderNavigationWorkspace.tsx
+++ b/apps/desktop/src/features/folder-navigation/ui/FolderNavigationWorkspace.tsx
@@ -209,6 +209,33 @@ function WorkspaceScanBanner({ scanState }: { scanState: WorkspaceScanState }) {
   return null;
 }
 
+type EmptyNoteListProps = {
+  selectedFolderPath: FolderScope;
+  scanState: WorkspaceScanState;
+};
+
+function EmptyNoteList({ selectedFolderPath, scanState }: EmptyNoteListProps) {
+  if (scanState.status === "loading") {
+    return null;
+  }
+
+  if (scanState.status === "failed") {
+    return (
+      <div className="folder-navigation__empty">
+        <h3 className="folder-navigation__note-title">No notes loaded</h3>
+        <p className="folder-navigation__muted">Fix the scan error and reopen this workspace.</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="folder-navigation__empty">
+      <h3 className="folder-navigation__note-title">No notes here yet</h3>
+      <p className="folder-navigation__muted">Start in {getFolderLabel(selectedFolderPath)}.</p>
+    </div>
+  );
+}
+
 function FolderNode({
   node,
   selectedFolderPath,
@@ -343,10 +370,7 @@ function NoteList({
           ))}
         </ol>
       ) : (
-        <div className="folder-navigation__empty">
-          <h3 className="folder-navigation__note-title">No notes here yet</h3>
-          <p className="folder-navigation__muted">Start in {getFolderLabel(selectedFolderPath)}.</p>
-        </div>
+        <EmptyNoteList selectedFolderPath={selectedFolderPath} scanState={scanState} />
       )}
     </section>
   );

--- a/apps/desktop/src/shared/api/commands.test.ts
+++ b/apps/desktop/src/shared/api/commands.test.ts
@@ -73,6 +73,18 @@ describe("desktop command wrappers", () => {
     await expect(scanMarkdownWorkspace()).rejects.toThrow("invalid note list");
   });
 
+  it("rejects non-finite Markdown workspace scan timestamps", async () => {
+    invokeMock.mockResolvedValue([
+      {
+        path: "Projects/Grove/Plan.md",
+        title: "Plan",
+        updatedAtUnixMs: Number.POSITIVE_INFINITY,
+      },
+    ]);
+
+    await expect(scanMarkdownWorkspace()).rejects.toThrow("invalid note list");
+  });
+
   it("preserves structured Tauri command messages when a command fails", async () => {
     invokeMock.mockRejectedValue({
       code: "file_move_failed",

--- a/apps/desktop/src/shared/api/commands.test.ts
+++ b/apps/desktop/src/shared/api/commands.test.ts
@@ -1,7 +1,7 @@
 import { invoke } from "@tauri-apps/api/core";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-import { moveMarkdownFile, refreshNoteIndexes } from "./commands";
+import { moveMarkdownFile, refreshNoteIndexes, scanMarkdownWorkspace } from "./commands";
 
 vi.mock("@tauri-apps/api/core", () => ({
   invoke: vi.fn(),
@@ -46,6 +46,31 @@ describe("desktop command wrappers", () => {
         reason: "note-move",
       },
     });
+  });
+
+  it("invokes the Markdown workspace scan command", async () => {
+    invokeMock.mockResolvedValue([
+      {
+        path: "Projects/Grove/Plan.md",
+        title: "Workspace plan",
+        updatedAtUnixMs: 1776265200000,
+      },
+    ]);
+
+    await expect(scanMarkdownWorkspace()).resolves.toStrictEqual([
+      {
+        path: "Projects/Grove/Plan.md",
+        title: "Workspace plan",
+        updatedAtUnixMs: 1776265200000,
+      },
+    ]);
+    expect(invokeMock).toHaveBeenCalledWith("scan_markdown_workspace", {});
+  });
+
+  it("rejects invalid Markdown workspace scan results", async () => {
+    invokeMock.mockResolvedValue([{ path: "/Users/me/Notes/Plan.md", title: "Plan" }]);
+
+    await expect(scanMarkdownWorkspace()).rejects.toThrow("invalid note list");
   });
 
   it("preserves structured Tauri command messages when a command fails", async () => {

--- a/apps/desktop/src/shared/api/commands.ts
+++ b/apps/desktop/src/shared/api/commands.ts
@@ -88,6 +88,8 @@ function isScannedMarkdownNote(value: unknown): value is ScannedMarkdownNote {
     "title" in value &&
     typeof value.title === "string" &&
     "updatedAtUnixMs" in value &&
-    typeof value.updatedAtUnixMs === "number"
+    typeof value.updatedAtUnixMs === "number" &&
+    Number.isFinite(value.updatedAtUnixMs) &&
+    value.updatedAtUnixMs >= 0
   );
 }

--- a/apps/desktop/src/shared/api/commands.ts
+++ b/apps/desktop/src/shared/api/commands.ts
@@ -11,6 +11,12 @@ export type RefreshNoteIndexesCommand = {
   reason: "note-move" | "folder-rename";
 };
 
+export type ScannedMarkdownNote = {
+  path: string;
+  title: string;
+  updatedAtUnixMs: number;
+};
+
 export async function moveMarkdownFile(command: MoveMarkdownFileCommand): Promise<void> {
   await invokeCommand("move_markdown_file", { change: command });
 }
@@ -19,9 +25,26 @@ export async function refreshNoteIndexes(command: RefreshNoteIndexesCommand): Pr
   await invokeCommand("refresh_note_indexes", { refresh: command });
 }
 
+export async function scanMarkdownWorkspace(): Promise<ScannedMarkdownNote[]> {
+  const result = await invokeCommandResult("scan_markdown_workspace", {});
+
+  if (!isScannedMarkdownNotes(result)) {
+    throw new Error("The desktop scan command returned an invalid note list.");
+  }
+
+  return result;
+}
+
 async function invokeCommand(commandName: string, payload: Record<string, unknown>): Promise<void> {
+  await invokeCommandResult(commandName, payload);
+}
+
+async function invokeCommandResult(
+  commandName: string,
+  payload: Record<string, unknown>,
+): Promise<unknown> {
   try {
-    await invoke(commandName, payload);
+    return await invoke(commandName, payload);
   } catch (error) {
     throw new Error(getCommandErrorMessage(error));
   }
@@ -49,5 +72,22 @@ function isCommandErrorPayload(error: unknown): error is { message: string } {
     error !== null &&
     "message" in error &&
     typeof error.message === "string"
+  );
+}
+
+function isScannedMarkdownNotes(value: unknown): value is ScannedMarkdownNote[] {
+  return Array.isArray(value) && value.every(isScannedMarkdownNote);
+}
+
+function isScannedMarkdownNote(value: unknown): value is ScannedMarkdownNote {
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    "path" in value &&
+    typeof value.path === "string" &&
+    "title" in value &&
+    typeof value.title === "string" &&
+    "updatedAtUnixMs" in value &&
+    typeof value.updatedAtUnixMs === "number"
   );
 }

--- a/apps/desktop/src/shared/index.ts
+++ b/apps/desktop/src/shared/index.ts
@@ -1,3 +1,4 @@
-export { moveMarkdownFile, refreshNoteIndexes } from "./api/commands";
+export { moveMarkdownFile, refreshNoteIndexes, scanMarkdownWorkspace } from "./api/commands";
 export type { MoveMarkdownFileCommand, RefreshNoteIndexesCommand } from "./api/commands";
+export type { ScannedMarkdownNote } from "./api/commands";
 export { ShellCard } from "./ui/ShellCard";


### PR DESCRIPTION
## Summary
- add a Tauri command that scans the default desktop workspace for Markdown files and returns workspace-relative note metadata
- expose a typed desktop command wrapper and validate scan result payloads
- connect folder navigation state to real scan results with loading, empty, and error states

## Testing
- pnpm --filter @grove/desktop test
- pnpm --filter @grove/desktop typecheck
- pnpm --filter @grove/desktop build
- cargo test (apps/desktop/src-tauri)
- pnpm lint
- pnpm format
- git diff --check

Refs #46
