### PR TITLE
Persist desktop note edits

### DIFF
--- a/apps/desktop/src-tauri/src/main.rs
+++ b/apps/desktop/src-tauri/src/main.rs
@@ -339,10 +339,26 @@ async fn write_markdown_file(path: &Path, content: &[u8]) -> anyhow::Result<()> 
         tokio::fs::create_dir_all(parent_path).await?;
     }
 
-    let mut file = tokio::fs::File::create(path).await?;
+    let temporary_path = get_temporary_write_path(path)?;
+    let mut file = tokio::fs::File::create(&temporary_path).await?;
     file.write_all(content).await?;
     file.flush().await?;
+    file.sync_all().await?;
+    drop(file);
+
+    tokio::fs::rename(&temporary_path, path).await?;
     Ok(())
+}
+
+fn get_temporary_write_path(path: &Path) -> anyhow::Result<PathBuf> {
+    let file_name = path
+        .file_name()
+        .and_then(|file_name| file_name.to_str())
+        .ok_or_else(|| anyhow::anyhow!("Markdown file paths must include a file name."))?;
+    let timestamp = SystemTime::now().duration_since(UNIX_EPOCH)?.as_nanos();
+    let temporary_file_name = format!(".{file_name}.{}.{}.tmp", std::process::id(), timestamp);
+
+    Ok(path.with_file_name(temporary_file_name))
 }
 
 async fn summarize_markdown_file(
@@ -473,9 +489,9 @@ mod tests {
     };
 
     use super::{
-        find_first_markdown_heading, get_workspace_relative_markdown_path,
-        move_file_without_overwrite, read_markdown_file, scan_markdown_files,
-        system_time_to_unix_ms, validate_markdown_path, write_markdown_file,
+        find_first_markdown_heading, get_temporary_write_path,
+        get_workspace_relative_markdown_path, move_file_without_overwrite, read_markdown_file,
+        scan_markdown_files, system_time_to_unix_ms, validate_markdown_path, write_markdown_file,
     };
 
     fn run_async<F>(future: F) -> F::Output
@@ -641,6 +657,19 @@ mod tests {
             anyhow::Ok(())
         })
         .expect("Markdown write should succeed");
+    }
+
+    #[test]
+    fn creates_temporary_write_paths_next_to_markdown_files() {
+        let note_path = PathBuf::from("Projects").join("Plan.md");
+        let temporary_path =
+            get_temporary_write_path(&note_path).expect("Temporary path should build");
+
+        assert_eq!(temporary_path.parent(), note_path.parent());
+        assert!(temporary_path
+            .file_name()
+            .and_then(|file_name| file_name.to_str())
+            .is_some_and(|file_name| file_name.starts_with(".Plan.md.")));
     }
 
     #[test]

--- a/apps/desktop/src-tauri/src/main.rs
+++ b/apps/desktop/src-tauri/src/main.rs
@@ -660,6 +660,25 @@ mod tests {
     }
 
     #[test]
+    fn overwrites_existing_markdown_file_content() {
+        run_async(async {
+            let workspace_dir = unique_test_dir("overwrites-existing-markdown-file-content");
+            let note_path = workspace_dir.join("Projects").join("Plan.md");
+
+            write_markdown_file(&note_path, b"# Plan\n\nDraft").await?;
+            write_markdown_file(&note_path, b"# Plan\n\nSaved").await?;
+
+            assert_eq!(
+                tokio::fs::read_to_string(&note_path).await?,
+                "# Plan\n\nSaved"
+            );
+            tokio::fs::remove_dir_all(&workspace_dir).await?;
+            anyhow::Ok(())
+        })
+        .expect("Markdown overwrite should succeed");
+    }
+
+    #[test]
     fn creates_temporary_write_paths_next_to_markdown_files() {
         let note_path = PathBuf::from("Projects").join("Plan.md");
         let temporary_path =

--- a/apps/desktop/src-tauri/src/main.rs
+++ b/apps/desktop/src-tauri/src/main.rs
@@ -369,19 +369,50 @@ fn get_temporary_write_path(path: &Path) -> anyhow::Result<PathBuf> {
     Ok(path.with_file_name(temporary_file_name))
 }
 
+#[cfg(not(windows))]
 async fn replace_file_with_temporary_path(
     temporary_path: &Path,
     path: &Path,
 ) -> anyhow::Result<()> {
-    #[cfg(windows)]
-    {
-        if tokio::fs::try_exists(path).await? {
-            tokio::fs::remove_file(path).await?;
-        }
-    }
-
     tokio::fs::rename(temporary_path, path).await?;
     Ok(())
+}
+
+#[cfg(windows)]
+async fn replace_file_with_temporary_path(
+    temporary_path: &Path,
+    path: &Path,
+) -> anyhow::Result<()> {
+    replace_file_with_backup_on_windows(temporary_path, path).await
+}
+
+#[cfg(windows)]
+async fn replace_file_with_backup_on_windows(
+    temporary_path: &Path,
+    path: &Path,
+) -> anyhow::Result<()> {
+    if !tokio::fs::try_exists(path).await? {
+        tokio::fs::rename(temporary_path, path).await?;
+        return Ok(());
+    }
+
+    if !tokio::fs::metadata(path).await?.is_file() {
+        anyhow::bail!("The target Markdown path is not a file: {}", path.display());
+    }
+
+    let backup_path = get_temporary_write_path(path)?.with_extension("backup");
+    tokio::fs::rename(path, &backup_path).await?;
+
+    match tokio::fs::rename(temporary_path, path).await {
+        Ok(()) => {
+            let _ = tokio::fs::remove_file(&backup_path).await;
+            Ok(())
+        }
+        Err(error) => {
+            let _ = tokio::fs::rename(&backup_path, path).await;
+            Err(error.into())
+        }
+    }
 }
 
 async fn summarize_markdown_file(

--- a/apps/desktop/src-tauri/src/main.rs
+++ b/apps/desktop/src-tauri/src/main.rs
@@ -30,11 +30,19 @@ struct ReadMarkdownNoteRequest {
     path: String,
 }
 
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct WriteMarkdownNoteRequest {
+    path: String,
+    content: String,
+}
+
 #[derive(Debug, Deserialize, Serialize)]
 #[serde(rename_all = "kebab-case")]
 enum IndexRefreshReason {
     NoteMove,
     FolderRename,
+    NoteSave,
 }
 
 #[derive(Debug, Serialize)]
@@ -139,13 +147,31 @@ async fn read_markdown_note(
         .map_err(|error| CommandError::new("note_read_failed", error.to_string()))
 }
 
+#[tauri::command]
+async fn write_markdown_note(
+    app_handle: tauri::AppHandle,
+    note: WriteMarkdownNoteRequest,
+) -> Result<ScannedMarkdownNote, CommandError> {
+    let workspace_root = default_workspace_root(&app_handle)?;
+    let note_path = resolve_markdown_path(&workspace_root, &note.path)?;
+
+    write_markdown_file(&note_path, note.content.as_bytes())
+        .await
+        .map_err(|error| CommandError::new("note_write_failed", error.to_string()))?;
+
+    summarize_markdown_file(&workspace_root, &note_path)
+        .await
+        .map_err(|error| CommandError::new("note_write_failed", error.to_string()))
+}
+
 fn main() {
     if let Err(error) = tauri::Builder::default()
         .invoke_handler(tauri::generate_handler![
             move_markdown_file,
             read_markdown_note,
             refresh_note_indexes,
-            scan_markdown_workspace
+            scan_markdown_workspace,
+            write_markdown_note
         ])
         .run(tauri::generate_context!())
     {
@@ -239,16 +265,7 @@ async fn scan_markdown_files(workspace_root: &Path) -> anyhow::Result<Vec<Scanne
                 continue;
             }
 
-            let relative_path = get_workspace_relative_markdown_path(workspace_root, &path)?;
-            let metadata = entry.metadata().await?;
-            let updated_at_unix_ms = system_time_to_unix_ms(metadata.modified()?);
-            let title = read_note_title(&path).await?;
-
-            notes.push(ScannedMarkdownNote {
-                path: relative_path,
-                title,
-                updated_at_unix_ms,
-            });
+            notes.push(summarize_markdown_file(workspace_root, &path).await?);
         }
     }
 
@@ -315,6 +332,33 @@ async fn read_markdown_file(path: &Path) -> anyhow::Result<String> {
     let mut content = String::new();
     file.read_to_string(&mut content).await?;
     Ok(content)
+}
+
+async fn write_markdown_file(path: &Path, content: &[u8]) -> anyhow::Result<()> {
+    if let Some(parent_path) = path.parent() {
+        tokio::fs::create_dir_all(parent_path).await?;
+    }
+
+    let mut file = tokio::fs::File::create(path).await?;
+    file.write_all(content).await?;
+    file.flush().await?;
+    Ok(())
+}
+
+async fn summarize_markdown_file(
+    workspace_root: &Path,
+    markdown_path: &Path,
+) -> anyhow::Result<ScannedMarkdownNote> {
+    let relative_path = get_workspace_relative_markdown_path(workspace_root, markdown_path)?;
+    let metadata = tokio::fs::metadata(markdown_path).await?;
+    let updated_at_unix_ms = system_time_to_unix_ms(metadata.modified()?);
+    let title = read_note_title(markdown_path).await?;
+
+    Ok(ScannedMarkdownNote {
+        path: relative_path,
+        title,
+        updated_at_unix_ms,
+    })
 }
 
 fn find_first_markdown_heading(content: &str) -> Option<String> {
@@ -431,7 +475,7 @@ mod tests {
     use super::{
         find_first_markdown_heading, get_workspace_relative_markdown_path,
         move_file_without_overwrite, read_markdown_file, scan_markdown_files,
-        system_time_to_unix_ms, validate_markdown_path,
+        system_time_to_unix_ms, validate_markdown_path, write_markdown_file,
     };
 
     fn run_async<F>(future: F) -> F::Output
@@ -579,6 +623,24 @@ mod tests {
             anyhow::Ok(())
         })
         .expect("Markdown read should succeed");
+    }
+
+    #[test]
+    fn writes_markdown_file_content() {
+        run_async(async {
+            let workspace_dir = unique_test_dir("writes-markdown-file-content");
+            let note_path = workspace_dir.join("Projects").join("Plan.md");
+
+            write_markdown_file(&note_path, b"# Plan\n\nSaved").await?;
+
+            assert_eq!(
+                tokio::fs::read_to_string(&note_path).await?,
+                "# Plan\n\nSaved"
+            );
+            tokio::fs::remove_dir_all(&workspace_dir).await?;
+            anyhow::Ok(())
+        })
+        .expect("Markdown write should succeed");
     }
 
     #[test]

--- a/apps/desktop/src-tauri/src/main.rs
+++ b/apps/desktop/src-tauri/src/main.rs
@@ -340,14 +340,22 @@ async fn write_markdown_file(path: &Path, content: &[u8]) -> anyhow::Result<()> 
     }
 
     let temporary_path = get_temporary_write_path(path)?;
-    let mut file = tokio::fs::File::create(&temporary_path).await?;
-    file.write_all(content).await?;
-    file.flush().await?;
-    file.sync_all().await?;
-    drop(file);
+    let write_result = async {
+        let mut file = tokio::fs::File::create(&temporary_path).await?;
+        file.write_all(content).await?;
+        file.flush().await?;
+        file.sync_all().await?;
+        drop(file);
 
-    tokio::fs::rename(&temporary_path, path).await?;
-    Ok(())
+        replace_file_with_temporary_path(&temporary_path, path).await
+    }
+    .await;
+
+    if write_result.is_err() {
+        let _ = tokio::fs::remove_file(&temporary_path).await;
+    }
+
+    write_result
 }
 
 fn get_temporary_write_path(path: &Path) -> anyhow::Result<PathBuf> {
@@ -359,6 +367,21 @@ fn get_temporary_write_path(path: &Path) -> anyhow::Result<PathBuf> {
     let temporary_file_name = format!(".{file_name}.{}.{}.tmp", std::process::id(), timestamp);
 
     Ok(path.with_file_name(temporary_file_name))
+}
+
+async fn replace_file_with_temporary_path(
+    temporary_path: &Path,
+    path: &Path,
+) -> anyhow::Result<()> {
+    #[cfg(windows)]
+    {
+        if tokio::fs::try_exists(path).await? {
+            tokio::fs::remove_file(path).await?;
+        }
+    }
+
+    tokio::fs::rename(temporary_path, path).await?;
+    Ok(())
 }
 
 async fn summarize_markdown_file(
@@ -689,6 +712,31 @@ mod tests {
             .file_name()
             .and_then(|file_name| file_name.to_str())
             .is_some_and(|file_name| file_name.starts_with(".Plan.md.")));
+    }
+
+    #[test]
+    fn removes_temporary_file_when_markdown_write_fails() {
+        run_async(async {
+            let workspace_dir = unique_test_dir("removes-temporary-file-when-write-fails");
+            let note_path = workspace_dir.join("Projects").join("Plan.md");
+            tokio::fs::create_dir_all(&note_path).await?;
+
+            let error = write_markdown_file(&note_path, b"# Plan")
+                .await
+                .expect_err("directory targets should reject file writes");
+            assert!(error.to_string().contains("directory"));
+
+            let mut entries = tokio::fs::read_dir(note_path.parent().expect("note parent")).await?;
+            while let Some(entry) = entries.next_entry().await? {
+                let file_name = entry.file_name();
+                let file_name = file_name.to_string_lossy();
+                assert!(!file_name.starts_with(".Plan.md."));
+            }
+
+            tokio::fs::remove_dir_all(&workspace_dir).await?;
+            anyhow::Ok(())
+        })
+        .expect("temporary cleanup test should run");
     }
 
     #[test]

--- a/apps/desktop/src/features/folder-navigation/model/noteEditBuffer.test.ts
+++ b/apps/desktop/src/features/folder-navigation/model/noteEditBuffer.test.ts
@@ -5,7 +5,8 @@ import {
   createCleanNoteEditBuffer,
   createErroredNoteEditBuffer,
   discardNoteEditDraft,
-  markNoteEditBufferError,
+  markNoteEditBufferSaved,
+  markNoteEditBufferSaveFailed,
   markNoteEditBufferSaving,
   updateNoteEditDraft,
 } from "./noteEditBuffer";
@@ -41,19 +42,33 @@ describe("note edit buffer", () => {
     expect(updateNoteEditDraft(buffer, "# Plan").status).toBe("clean");
   });
 
-  it("tracks saving and error transitions without discarding the draft", () => {
+  it("keeps a failed save dirty without discarding the draft", () => {
     const dirtyBuffer = updateNoteEditDraft(
       createCleanNoteEditBuffer("note-plan", notePath, "# Plan"),
       "# Plan\n\nNext",
     );
     const savingBuffer = markNoteEditBufferSaving(dirtyBuffer);
-    const erroredBuffer = markNoteEditBufferError(savingBuffer, "Disk read failed.");
+    const erroredBuffer = markNoteEditBufferSaveFailed(savingBuffer, "Disk write failed.");
 
     expect(savingBuffer.status).toBe("saving");
     expect(erroredBuffer).toMatchObject({
       draftContent: "# Plan\n\nNext",
-      status: "error",
-      errorMessage: "Disk read failed.",
+      status: "dirty",
+      errorMessage: "Disk write failed.",
+    });
+  });
+
+  it("marks a saved draft clean and updates the loaded content", () => {
+    const dirtyBuffer = updateNoteEditDraft(
+      createCleanNoteEditBuffer("note-plan", notePath, "# Plan"),
+      "# Plan\n\nNext",
+    );
+
+    expect(markNoteEditBufferSaved(dirtyBuffer, "# Plan\n\nNext")).toMatchObject({
+      baseContent: "# Plan\n\nNext",
+      draftContent: "# Plan\n\nNext",
+      status: "clean",
+      errorMessage: null,
     });
   });
 

--- a/apps/desktop/src/features/folder-navigation/model/noteEditBuffer.test.ts
+++ b/apps/desktop/src/features/folder-navigation/model/noteEditBuffer.test.ts
@@ -10,6 +10,7 @@ import {
   markNoteEditBufferSaved,
   markNoteEditBufferSaveFailed,
   markNoteEditBufferSaving,
+  updateNoteEditBufferPath,
   updateNoteEditDraft,
 } from "./noteEditBuffer";
 
@@ -55,6 +56,19 @@ describe("note edit buffer", () => {
     );
 
     expect(updateNoteEditDraft(buffer, "# Plan").status).toBe("clean");
+  });
+
+  it("updates the backing Markdown path without changing loaded content or draft state", () => {
+    const buffer = createDirtyBuffer();
+
+    expect(
+      updateNoteEditBufferPath(buffer, normalizeNoteFilePath("Projects/Moved.md")),
+    ).toMatchObject({
+      path: "Projects/Moved.md",
+      baseContent: "# Plan",
+      draftContent: "# Plan\n\nNext",
+      status: "dirty",
+    });
   });
 
   it("only allows dirty buffers to be saved", () => {

--- a/apps/desktop/src/features/folder-navigation/model/noteEditBuffer.test.ts
+++ b/apps/desktop/src/features/folder-navigation/model/noteEditBuffer.test.ts
@@ -15,6 +15,19 @@ import {
 
 const notePath = normalizeNoteFilePath("Projects/Plan.md");
 
+function createDirtyBuffer() {
+  const buffer = updateNoteEditDraft(
+    createCleanNoteEditBuffer("note-plan", notePath, "# Plan"),
+    "# Plan\n\nNext",
+  );
+
+  if (!canSaveNoteEditBuffer(buffer)) {
+    throw new Error("Expected a dirty edit buffer.");
+  }
+
+  return buffer;
+}
+
 describe("note edit buffer", () => {
   it("creates a clean buffer from loaded Markdown content", () => {
     const buffer = createCleanNoteEditBuffer("note-plan", notePath, "# Plan");
@@ -46,7 +59,7 @@ describe("note edit buffer", () => {
 
   it("only allows dirty buffers to be saved", () => {
     const cleanBuffer = createCleanNoteEditBuffer("note-plan", notePath, "# Plan");
-    const dirtyBuffer = updateNoteEditDraft(cleanBuffer, "# Plan\n\nNext");
+    const dirtyBuffer = createDirtyBuffer();
     const savingBuffer = markNoteEditBufferSaving(dirtyBuffer);
     const erroredBuffer = createErroredNoteEditBuffer("note-plan", notePath, "Disk read failed.");
 
@@ -59,7 +72,7 @@ describe("note edit buffer", () => {
 
   it("blocks workspace changes only while dirty or saving", () => {
     const cleanBuffer = createCleanNoteEditBuffer("note-plan", notePath, "# Plan");
-    const dirtyBuffer = updateNoteEditDraft(cleanBuffer, "# Plan\n\nNext");
+    const dirtyBuffer = createDirtyBuffer();
     const savingBuffer = markNoteEditBufferSaving(dirtyBuffer);
     const erroredBuffer = createErroredNoteEditBuffer("note-plan", notePath, "Disk read failed.");
 
@@ -71,10 +84,7 @@ describe("note edit buffer", () => {
   });
 
   it("keeps a failed save dirty without discarding the draft", () => {
-    const dirtyBuffer = updateNoteEditDraft(
-      createCleanNoteEditBuffer("note-plan", notePath, "# Plan"),
-      "# Plan\n\nNext",
-    );
+    const dirtyBuffer = createDirtyBuffer();
     const savingBuffer = markNoteEditBufferSaving(dirtyBuffer);
     const erroredBuffer = markNoteEditBufferSaveFailed(savingBuffer, "Disk write failed.");
 
@@ -101,9 +111,16 @@ describe("note edit buffer", () => {
   });
 
   it("keeps newer edits dirty when an earlier save completes", () => {
-    const savingBuffer = markNoteEditBufferSaving(
-      updateNoteEditDraft(createCleanNoteEditBuffer("note-plan", notePath, "# Plan"), "# Saved"),
+    const dirtyBuffer = updateNoteEditDraft(
+      createCleanNoteEditBuffer("note-plan", notePath, "# Plan"),
+      "# Saved",
     );
+
+    if (!canSaveNoteEditBuffer(dirtyBuffer)) {
+      throw new Error("Expected a dirty edit buffer.");
+    }
+
+    const savingBuffer = markNoteEditBufferSaving(dirtyBuffer);
     const editedAgainBuffer = updateNoteEditDraft(savingBuffer, "# Saved\n\nMore");
 
     expect(markNoteEditBufferSaved(editedAgainBuffer, "# Saved")).toMatchObject({

--- a/apps/desktop/src/features/folder-navigation/model/noteEditBuffer.test.ts
+++ b/apps/desktop/src/features/folder-navigation/model/noteEditBuffer.test.ts
@@ -72,6 +72,20 @@ describe("note edit buffer", () => {
     });
   });
 
+  it("keeps newer edits dirty when an earlier save completes", () => {
+    const savingBuffer = markNoteEditBufferSaving(
+      updateNoteEditDraft(createCleanNoteEditBuffer("note-plan", notePath, "# Plan"), "# Saved"),
+    );
+    const editedAgainBuffer = updateNoteEditDraft(savingBuffer, "# Saved\n\nMore");
+
+    expect(markNoteEditBufferSaved(editedAgainBuffer, "# Saved")).toMatchObject({
+      baseContent: "# Saved",
+      draftContent: "# Saved\n\nMore",
+      status: "dirty",
+      errorMessage: null,
+    });
+  });
+
   it("creates an errored buffer for failed note reads", () => {
     const buffer = createErroredNoteEditBuffer(
       "note-plan",

--- a/apps/desktop/src/features/folder-navigation/model/noteEditBuffer.test.ts
+++ b/apps/desktop/src/features/folder-navigation/model/noteEditBuffer.test.ts
@@ -2,9 +2,11 @@ import { normalizeNoteFilePath } from "@grove/core";
 import { describe, expect, it } from "vitest";
 
 import {
+  canSaveNoteEditBuffer,
   createCleanNoteEditBuffer,
   createErroredNoteEditBuffer,
   discardNoteEditDraft,
+  isNoteEditBufferBlockingWorkspaceChange,
   markNoteEditBufferSaved,
   markNoteEditBufferSaveFailed,
   markNoteEditBufferSaving,
@@ -40,6 +42,32 @@ describe("note edit buffer", () => {
     );
 
     expect(updateNoteEditDraft(buffer, "# Plan").status).toBe("clean");
+  });
+
+  it("only allows dirty buffers to be saved", () => {
+    const cleanBuffer = createCleanNoteEditBuffer("note-plan", notePath, "# Plan");
+    const dirtyBuffer = updateNoteEditDraft(cleanBuffer, "# Plan\n\nNext");
+    const savingBuffer = markNoteEditBufferSaving(dirtyBuffer);
+    const erroredBuffer = createErroredNoteEditBuffer("note-plan", notePath, "Disk read failed.");
+
+    expect(canSaveNoteEditBuffer(null)).toBe(false);
+    expect(canSaveNoteEditBuffer(cleanBuffer)).toBe(false);
+    expect(canSaveNoteEditBuffer(dirtyBuffer)).toBe(true);
+    expect(canSaveNoteEditBuffer(savingBuffer)).toBe(false);
+    expect(canSaveNoteEditBuffer(erroredBuffer)).toBe(false);
+  });
+
+  it("blocks workspace changes only while dirty or saving", () => {
+    const cleanBuffer = createCleanNoteEditBuffer("note-plan", notePath, "# Plan");
+    const dirtyBuffer = updateNoteEditDraft(cleanBuffer, "# Plan\n\nNext");
+    const savingBuffer = markNoteEditBufferSaving(dirtyBuffer);
+    const erroredBuffer = createErroredNoteEditBuffer("note-plan", notePath, "Disk read failed.");
+
+    expect(isNoteEditBufferBlockingWorkspaceChange(null)).toBe(false);
+    expect(isNoteEditBufferBlockingWorkspaceChange(cleanBuffer)).toBe(false);
+    expect(isNoteEditBufferBlockingWorkspaceChange(dirtyBuffer)).toBe(true);
+    expect(isNoteEditBufferBlockingWorkspaceChange(savingBuffer)).toBe(true);
+    expect(isNoteEditBufferBlockingWorkspaceChange(erroredBuffer)).toBe(false);
   });
 
   it("keeps a failed save dirty without discarding the draft", () => {

--- a/apps/desktop/src/features/folder-navigation/model/noteEditBuffer.ts
+++ b/apps/desktop/src/features/folder-navigation/model/noteEditBuffer.ts
@@ -11,6 +11,10 @@ export type NoteEditBuffer = {
   errorMessage: string | null;
 };
 
+type DirtyNoteEditBuffer = NoteEditBuffer & {
+  status: "dirty";
+};
+
 export function createCleanNoteEditBuffer(
   noteId: string,
   path: NoteFilePath,
@@ -56,6 +60,16 @@ export function markNoteEditBufferSaving(buffer: NoteEditBuffer): NoteEditBuffer
     status: "saving",
     errorMessage: null,
   };
+}
+
+export function canSaveNoteEditBuffer(
+  buffer: NoteEditBuffer | null,
+): buffer is DirtyNoteEditBuffer {
+  return buffer?.status === "dirty";
+}
+
+export function isNoteEditBufferBlockingWorkspaceChange(buffer: NoteEditBuffer | null): boolean {
+  return buffer?.status === "dirty" || buffer?.status === "saving";
 }
 
 export function markNoteEditBufferSaveFailed(

--- a/apps/desktop/src/features/folder-navigation/model/noteEditBuffer.ts
+++ b/apps/desktop/src/features/folder-navigation/model/noteEditBuffer.ts
@@ -54,7 +54,7 @@ export function updateNoteEditDraft(buffer: NoteEditBuffer, draftContent: string
   };
 }
 
-export function markNoteEditBufferSaving(buffer: NoteEditBuffer): NoteEditBuffer {
+export function markNoteEditBufferSaving(buffer: DirtyNoteEditBuffer): NoteEditBuffer {
   return {
     ...buffer,
     status: "saving",

--- a/apps/desktop/src/features/folder-navigation/model/noteEditBuffer.ts
+++ b/apps/desktop/src/features/folder-navigation/model/noteEditBuffer.ts
@@ -58,14 +58,27 @@ export function markNoteEditBufferSaving(buffer: NoteEditBuffer): NoteEditBuffer
   };
 }
 
-export function markNoteEditBufferError(
+export function markNoteEditBufferSaveFailed(
   buffer: NoteEditBuffer,
   errorMessage: string,
 ): NoteEditBuffer {
   return {
     ...buffer,
-    status: "error",
+    status: "dirty",
     errorMessage,
+  };
+}
+
+export function markNoteEditBufferSaved(
+  buffer: NoteEditBuffer,
+  savedContent: string,
+): NoteEditBuffer {
+  return {
+    ...buffer,
+    baseContent: savedContent,
+    draftContent: savedContent,
+    status: "clean",
+    errorMessage: null,
   };
 }
 

--- a/apps/desktop/src/features/folder-navigation/model/noteEditBuffer.ts
+++ b/apps/desktop/src/features/folder-navigation/model/noteEditBuffer.ts
@@ -73,11 +73,12 @@ export function markNoteEditBufferSaved(
   buffer: NoteEditBuffer,
   savedContent: string,
 ): NoteEditBuffer {
+  const status = buffer.draftContent === savedContent ? "clean" : "dirty";
+
   return {
     ...buffer,
     baseContent: savedContent,
-    draftContent: savedContent,
-    status: "clean",
+    status,
     errorMessage: null,
   };
 }

--- a/apps/desktop/src/features/folder-navigation/model/noteEditBuffer.ts
+++ b/apps/desktop/src/features/folder-navigation/model/noteEditBuffer.ts
@@ -54,6 +54,16 @@ export function updateNoteEditDraft(buffer: NoteEditBuffer, draftContent: string
   };
 }
 
+export function updateNoteEditBufferPath(
+  buffer: NoteEditBuffer,
+  path: NoteFilePath,
+): NoteEditBuffer {
+  return {
+    ...buffer,
+    path,
+  };
+}
+
 export function markNoteEditBufferSaving(buffer: DirtyNoteEditBuffer): NoteEditBuffer {
   return {
     ...buffer,

--- a/apps/desktop/src/features/folder-navigation/model/noteSave.test.ts
+++ b/apps/desktop/src/features/folder-navigation/model/noteSave.test.ts
@@ -5,7 +5,11 @@ import type {
   FolderWorkspacePathChangeOperation,
   FolderWorkspaceState,
 } from "./folderWorkspaceState";
-import { applySavedNoteMetadataToWorkspaceState, isNoteSaveBlockedByPathChange } from "./noteSave";
+import {
+  applySavedNoteMetadataToWorkspaceState,
+  isNoteSaveBlockedByPathChange,
+  isNoteSaveKeyboardShortcut,
+} from "./noteSave";
 
 const workspaceState: FolderWorkspaceState = {
   notes: [
@@ -117,5 +121,17 @@ describe("isNoteSaveBlockedByPathChange", () => {
 
     expect(isNoteSaveBlockedByPathChange([pendingOperation], "note-research")).toBe(false);
     expect(isNoteSaveBlockedByPathChange([completedOperation], "note-plan")).toBe(false);
+  });
+});
+
+describe("isNoteSaveKeyboardShortcut", () => {
+  it("matches common save shortcuts", () => {
+    expect(isNoteSaveKeyboardShortcut({ ctrlKey: true, key: "s", metaKey: false })).toBe(true);
+    expect(isNoteSaveKeyboardShortcut({ ctrlKey: false, key: "S", metaKey: true })).toBe(true);
+  });
+
+  it("ignores unrelated key combinations", () => {
+    expect(isNoteSaveKeyboardShortcut({ ctrlKey: false, key: "s", metaKey: false })).toBe(false);
+    expect(isNoteSaveKeyboardShortcut({ ctrlKey: true, key: "p", metaKey: false })).toBe(false);
   });
 });

--- a/apps/desktop/src/features/folder-navigation/model/noteSave.test.ts
+++ b/apps/desktop/src/features/folder-navigation/model/noteSave.test.ts
@@ -1,8 +1,11 @@
 import { normalizeFolderPath, normalizeNoteFilePath } from "@grove/core";
 import { describe, expect, it } from "vitest";
 
-import type { FolderWorkspaceState } from "./folderWorkspaceState";
-import { applySavedNoteMetadataToWorkspaceState } from "./noteSave";
+import type {
+  FolderWorkspacePathChangeOperation,
+  FolderWorkspaceState,
+} from "./folderWorkspaceState";
+import { applySavedNoteMetadataToWorkspaceState, isNoteSaveBlockedByPathChange } from "./noteSave";
 
 const workspaceState: FolderWorkspaceState = {
   notes: [
@@ -72,5 +75,47 @@ describe("applySavedNoteMetadataToWorkspaceState", () => {
       path: "Projects/Grove/Moved.md",
       title: "Updated plan",
     });
+  });
+});
+
+describe("isNoteSaveBlockedByPathChange", () => {
+  const pendingOperation: FolderWorkspacePathChangeOperation = {
+    id: "path-change-1",
+    affectedNoteIds: ["note-plan"],
+    pathChanges: [
+      {
+        noteId: "note-plan",
+        previousPath: normalizeNoteFilePath("Projects/Grove/Plan.md"),
+        nextPath: normalizeNoteFilePath("Archive/Plan.md"),
+      },
+    ],
+    reason: "note-move",
+    steps: [
+      {
+        id: "file-move",
+        status: "pending",
+      },
+      {
+        id: "index-refresh",
+        status: "pending",
+      },
+    ],
+  };
+
+  it("blocks saves while the note has unfinished path changes", () => {
+    expect(isNoteSaveBlockedByPathChange([pendingOperation], "note-plan")).toBe(true);
+  });
+
+  it("allows saves for unrelated notes and completed path changes", () => {
+    const completedOperation: FolderWorkspacePathChangeOperation = {
+      ...pendingOperation,
+      steps: pendingOperation.steps.map((step) => ({
+        ...step,
+        status: "completed",
+      })),
+    };
+
+    expect(isNoteSaveBlockedByPathChange([pendingOperation], "note-research")).toBe(false);
+    expect(isNoteSaveBlockedByPathChange([completedOperation], "note-plan")).toBe(false);
   });
 });

--- a/apps/desktop/src/features/folder-navigation/model/noteSave.test.ts
+++ b/apps/desktop/src/features/folder-navigation/model/noteSave.test.ts
@@ -1,0 +1,76 @@
+import { normalizeFolderPath, normalizeNoteFilePath } from "@grove/core";
+import { describe, expect, it } from "vitest";
+
+import type { FolderWorkspaceState } from "./folderWorkspaceState";
+import { applySavedNoteMetadataToWorkspaceState } from "./noteSave";
+
+const workspaceState: FolderWorkspaceState = {
+  notes: [
+    {
+      id: "note-plan",
+      path: normalizeNoteFilePath("Projects/Grove/Plan.md"),
+      title: "Plan",
+      updatedLabel: "Apr 12",
+    },
+    {
+      id: "note-research",
+      path: normalizeNoteFilePath("Projects/Grove/Research.md"),
+      title: "Research",
+      updatedLabel: "Apr 11",
+    },
+  ],
+  explicitFolders: [normalizeFolderPath("Projects/Grove")],
+  selectedFolderPath: normalizeFolderPath("Projects/Grove"),
+  expandedFolderPaths: ["Projects", "Projects/Grove"],
+};
+
+describe("applySavedNoteMetadataToWorkspaceState", () => {
+  it("updates saved note metadata while keeping the stable note id", () => {
+    const state = applySavedNoteMetadataToWorkspaceState(workspaceState, {
+      noteId: "note-plan",
+      previousPath: normalizeNoteFilePath("Projects/Grove/Plan.md"),
+      savedNote: {
+        path: "Projects/Grove/Plan.md",
+        title: "Updated plan",
+        updatedAtUnixMs: Date.UTC(2026, 3, 15),
+      },
+    });
+
+    expect(state.notes[0]).toStrictEqual({
+      id: "note-plan",
+      path: "Projects/Grove/Plan.md",
+      title: "Updated plan",
+      updatedLabel: "Apr 15",
+    });
+  });
+
+  it("does not overwrite a newer local path for the same note", () => {
+    const movedState: FolderWorkspaceState = {
+      ...workspaceState,
+      notes: workspaceState.notes.map((note) =>
+        note.id === "note-plan"
+          ? {
+              ...note,
+              path: normalizeNoteFilePath("Projects/Grove/Moved.md"),
+            }
+          : note,
+      ),
+    };
+
+    const state = applySavedNoteMetadataToWorkspaceState(movedState, {
+      noteId: "note-plan",
+      previousPath: normalizeNoteFilePath("Projects/Grove/Plan.md"),
+      savedNote: {
+        path: "Projects/Grove/Plan.md",
+        title: "Updated plan",
+        updatedAtUnixMs: Date.UTC(2026, 3, 15),
+      },
+    });
+
+    expect(state.notes[0]).toMatchObject({
+      id: "note-plan",
+      path: "Projects/Grove/Moved.md",
+      title: "Updated plan",
+    });
+  });
+});

--- a/apps/desktop/src/features/folder-navigation/model/noteSave.ts
+++ b/apps/desktop/src/features/folder-navigation/model/noteSave.ts
@@ -46,3 +46,9 @@ export function isNoteSaveBlockedByPathChange(
     return !isPathChangeOperationComplete(operation) && operation.affectedNoteIds.includes(noteId);
   });
 }
+
+export function isNoteSaveKeyboardShortcut(
+  event: Pick<KeyboardEvent, "ctrlKey" | "key" | "metaKey">,
+): boolean {
+  return (event.metaKey || event.ctrlKey) && event.key.toLowerCase() === "s";
+}

--- a/apps/desktop/src/features/folder-navigation/model/noteSave.ts
+++ b/apps/desktop/src/features/folder-navigation/model/noteSave.ts
@@ -1,7 +1,12 @@
 import type { NoteFilePath } from "@grove/core";
 import type { ScannedMarkdownNote } from "../../../shared";
 
-import { reconcileFolderWorkspaceState, type FolderWorkspaceState } from "./folderWorkspaceState";
+import {
+  isPathChangeOperationComplete,
+  reconcileFolderWorkspaceState,
+  type FolderWorkspacePathChangeOperation,
+  type FolderWorkspaceState,
+} from "./folderWorkspaceState";
 import { mapScannedMarkdownNotes } from "./workspaceScan";
 
 export type SavedNoteMetadataChange = {
@@ -30,5 +35,14 @@ export function applySavedNoteMetadataToWorkspaceState(
         path: note.path === previousPath ? updatedNote.path : note.path,
       };
     }),
+  });
+}
+
+export function isNoteSaveBlockedByPathChange(
+  operations: readonly FolderWorkspacePathChangeOperation[],
+  noteId: string,
+): boolean {
+  return operations.some((operation) => {
+    return !isPathChangeOperationComplete(operation) && operation.affectedNoteIds.includes(noteId);
   });
 }

--- a/apps/desktop/src/features/folder-navigation/model/noteSave.ts
+++ b/apps/desktop/src/features/folder-navigation/model/noteSave.ts
@@ -1,0 +1,34 @@
+import type { NoteFilePath } from "@grove/core";
+import type { ScannedMarkdownNote } from "../../../shared";
+
+import { reconcileFolderWorkspaceState, type FolderWorkspaceState } from "./folderWorkspaceState";
+import { mapScannedMarkdownNotes } from "./workspaceScan";
+
+export type SavedNoteMetadataChange = {
+  noteId: string;
+  previousPath: NoteFilePath;
+  savedNote: ScannedMarkdownNote;
+};
+
+export function applySavedNoteMetadataToWorkspaceState(
+  state: FolderWorkspaceState,
+  { noteId, previousPath, savedNote }: SavedNoteMetadataChange,
+): FolderWorkspaceState {
+  const [updatedNote] = mapScannedMarkdownNotes([savedNote]);
+
+  return reconcileFolderWorkspaceState({
+    ...state,
+    notes: state.notes.map((note) => {
+      if (note.id !== noteId) {
+        return note;
+      }
+
+      return {
+        ...note,
+        ...updatedNote,
+        id: noteId,
+        path: note.path === previousPath ? updatedNote.path : note.path,
+      };
+    }),
+  });
+}

--- a/apps/desktop/src/features/folder-navigation/model/usePathChangeQueue.ts
+++ b/apps/desktop/src/features/folder-navigation/model/usePathChangeQueue.ts
@@ -1,0 +1,115 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+
+import {
+  clearCompletedPathChangeOperations,
+  createPathChangeOperation,
+  getNextRunnablePathChangeOperationId,
+  retryOperationStep,
+  runNextOperationStep,
+} from "./folderWorkspaceState";
+import type {
+  FolderWorkspaceMutation,
+  FolderWorkspaceOperationStepId,
+  FolderWorkspacePathChangeExecutor,
+  FolderWorkspacePathChangeOperation,
+} from "./folderWorkspaceState";
+
+export type PathChangeQueueState = {
+  pathChangeOperations: readonly FolderWorkspacePathChangeOperation[];
+  runningOperationIds: readonly string[];
+  queuePathChangeOperation: (mutation: FolderWorkspaceMutation) => void;
+  retryPathChangeStep: (operationId: string, stepId: FolderWorkspaceOperationStepId) => void;
+  clearCompletedPathChanges: () => void;
+  runNextPathChangeStep: (operationId: string) => Promise<void>;
+};
+
+export function usePathChangeQueue(
+  executor: FolderWorkspacePathChangeExecutor,
+): PathChangeQueueState {
+  const [pathChangeOperations, setPathChangeOperations] = useState<
+    readonly FolderWorkspacePathChangeOperation[]
+  >([]);
+  const [runningOperationIds, setRunningOperationIds] = useState<readonly string[]>([]);
+  const runningOperationIdSet = useRef(new Set<string>());
+  const nextOperationNumber = useRef(1);
+
+  const queuePathChangeOperation = useCallback((mutation: FolderWorkspaceMutation): void => {
+    const operation = createPathChangeOperation(
+      `path-change-${nextOperationNumber.current}`,
+      mutation,
+    );
+
+    if (operation === null) {
+      return;
+    }
+
+    nextOperationNumber.current += 1;
+    setPathChangeOperations((currentOperations) => [operation, ...currentOperations]);
+  }, []);
+
+  const retryPathChangeStep = useCallback(
+    (operationId: string, stepId: FolderWorkspaceOperationStepId): void => {
+      setPathChangeOperations((currentOperations) =>
+        retryOperationStep(currentOperations, operationId, stepId),
+      );
+    },
+    [],
+  );
+
+  const clearCompletedPathChanges = useCallback((): void => {
+    setPathChangeOperations(clearCompletedPathChangeOperations);
+  }, []);
+
+  const runNextPathChangeStep = useCallback(
+    async (operationId: string): Promise<void> => {
+      const operation = pathChangeOperations.find((currentOperation) => {
+        return currentOperation.id === operationId;
+      });
+
+      if (operation === undefined || runningOperationIdSet.current.has(operationId)) {
+        return;
+      }
+
+      runningOperationIdSet.current.add(operationId);
+      setRunningOperationIds((currentOperationIds) => [...currentOperationIds, operationId]);
+
+      try {
+        const nextOperation = await runNextOperationStep(operation, executor);
+
+        setPathChangeOperations((currentOperations) =>
+          currentOperations.map((currentOperation) => {
+            return currentOperation.id === operationId ? nextOperation : currentOperation;
+          }),
+        );
+      } finally {
+        runningOperationIdSet.current.delete(operationId);
+        setRunningOperationIds((currentOperationIds) =>
+          currentOperationIds.filter((currentOperationId) => currentOperationId !== operationId),
+        );
+      }
+    },
+    [executor, pathChangeOperations],
+  );
+
+  useEffect(() => {
+    const nextRunnableOperationId = getNextRunnablePathChangeOperationId(
+      pathChangeOperations,
+      runningOperationIds,
+    );
+
+    if (nextRunnableOperationId === null) {
+      return;
+    }
+
+    void runNextPathChangeStep(nextRunnableOperationId);
+  }, [pathChangeOperations, runNextPathChangeStep, runningOperationIds]);
+
+  return {
+    pathChangeOperations,
+    runningOperationIds,
+    queuePathChangeOperation,
+    retryPathChangeStep,
+    clearCompletedPathChanges,
+    runNextPathChangeStep,
+  };
+}

--- a/apps/desktop/src/features/folder-navigation/ui/FolderNavigationWorkspace.tsx
+++ b/apps/desktop/src/features/folder-navigation/ui/FolderNavigationWorkspace.tsx
@@ -9,13 +9,14 @@ import {
   normalizeFolderScope,
 } from "@grove/core";
 import type { FolderScope, FolderTreeNode } from "@grove/core";
-import { useEffect, useMemo, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 
 import {
   moveMarkdownFile,
   readMarkdownNote,
   refreshNoteIndexes,
   scanMarkdownWorkspace,
+  writeMarkdownNote,
 } from "../../../shared";
 import {
   clearCompletedPathChangeOperations,
@@ -36,6 +37,9 @@ import {
   createCleanNoteEditBuffer,
   createErroredNoteEditBuffer,
   discardNoteEditDraft,
+  markNoteEditBufferSaved,
+  markNoteEditBufferSaveFailed,
+  markNoteEditBufferSaving,
   updateNoteEditDraft,
 } from "../model/noteEditBuffer";
 import { mapScannedMarkdownNotes } from "../model/workspaceScan";
@@ -94,6 +98,7 @@ type ActivePaneProps = {
   onMoveSelectedNote: (targetFolderPath: FolderScope) => FolderWorkspaceMutation;
   onRenameSelectedFolder: (targetFolderPath: FolderScope) => FolderWorkspaceMutation;
   onEditContent: (content: string) => void;
+  onSaveDraft: () => void;
   onDiscardDraft: () => void;
 };
 
@@ -133,6 +138,7 @@ type NoteEditorProps = {
   editorLoadState: NoteEditorLoadState;
   editorNotice: string | null;
   onEditContent: (content: string) => void;
+  onSaveDraft: () => void;
   onDiscardDraft: () => void;
 };
 
@@ -225,6 +231,10 @@ function getScanErrorMessage(error: unknown): string {
 
 function getNoteReadErrorMessage(error: unknown): string {
   return error instanceof Error ? error.message : "The Markdown note could not be read.";
+}
+
+function getNoteSaveErrorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : "The Markdown note could not be saved.";
 }
 
 function WorkspaceScanBanner({ scanState }: { scanState: WorkspaceScanState }) {
@@ -520,6 +530,7 @@ function NoteEditor({
   editorLoadState,
   editorNotice,
   onEditContent,
+  onSaveDraft,
   onDiscardDraft,
 }: NoteEditorProps) {
   if (selectedNote === undefined) {
@@ -544,6 +555,14 @@ function NoteEditor({
         </span>
         <button
           type="button"
+          className="folder-navigation__action"
+          onClick={onSaveDraft}
+          disabled={noteEditBuffer.status !== "dirty"}
+        >
+          Save
+        </button>
+        <button
+          type="button"
           className="folder-navigation__secondary-action"
           onClick={onDiscardDraft}
           disabled={noteEditBuffer.status !== "dirty"}
@@ -561,7 +580,7 @@ function NoteEditor({
         className="folder-navigation__textarea"
         value={noteEditBuffer.draftContent}
         onChange={(event) => onEditContent(event.target.value)}
-        disabled={noteEditBuffer.status === "error"}
+        disabled={noteEditBuffer.status === "error" || noteEditBuffer.status === "saving"}
         aria-label={`Markdown content for ${selectedNote.title}`}
       />
     </div>
@@ -579,6 +598,7 @@ function ActivePane({
   onMoveSelectedNote,
   onRenameSelectedFolder,
   onEditContent,
+  onSaveDraft,
   onDiscardDraft,
 }: ActivePaneProps) {
   const selectedNote = notes.find((note) => note.id === selectedNoteId) ?? notes[0];
@@ -602,6 +622,7 @@ function ActivePane({
               editorLoadState={editorLoadState}
               editorNotice={editorNotice}
               onEditContent={onEditContent}
+              onSaveDraft={onSaveDraft}
               onDiscardDraft={onDiscardDraft}
             />
             <MoveNoteControl
@@ -794,11 +815,11 @@ export function FolderNavigationWorkspace() {
 
   function selectNote(noteId: string): void {
     if (
-      noteEditBuffer?.status === "dirty" &&
+      (noteEditBuffer?.status === "dirty" || noteEditBuffer?.status === "saving") &&
       noteEditBuffer.noteId !== noteId &&
       selectedNoteId !== noteId
     ) {
-      setEditorNotice("Discard the current draft before opening another note.");
+      setEditorNotice("Save or discard the current draft before opening another note.");
       return;
     }
 
@@ -894,6 +915,48 @@ export function FolderNavigationWorkspace() {
     });
     setEditorNotice(null);
   }
+
+  const saveSelectedNoteDraft = useCallback(async (): Promise<void> => {
+    const buffer = noteEditBuffer;
+
+    if (buffer === null || buffer.status !== "dirty") {
+      return;
+    }
+
+    setNoteEditBuffer(markNoteEditBufferSaving(buffer));
+    setEditorNotice(null);
+
+    try {
+      const savedNote = await writeMarkdownNote({
+        path: buffer.path,
+        content: buffer.draftContent,
+      });
+      const [updatedNote] = mapScannedMarkdownNotes([savedNote]);
+
+      setWorkspaceState((currentState) =>
+        reconcileFolderWorkspaceState({
+          ...currentState,
+          notes: currentState.notes.map((note) => {
+            return note.id === buffer.noteId
+              ? { ...note, ...updatedNote, id: buffer.noteId }
+              : note;
+          }),
+        }),
+      );
+      setNoteEditBuffer(markNoteEditBufferSaved(buffer, buffer.draftContent));
+
+      try {
+        await refreshNoteIndexes({
+          noteIds: [buffer.noteId],
+          reason: "note-save",
+        });
+      } catch (error) {
+        setEditorNotice(`Saved, but index refresh failed: ${getNoteSaveErrorMessage(error)}`);
+      }
+    } catch (error) {
+      setNoteEditBuffer(markNoteEditBufferSaveFailed(buffer, getNoteSaveErrorMessage(error)));
+    }
+  }, [noteEditBuffer]);
 
   function discardSelectedDraft(): void {
     setNoteEditBuffer((currentBuffer) => {
@@ -1017,6 +1080,23 @@ export function FolderNavigationWorkspace() {
   }, [selectedNote?.id, selectedNote?.path]);
 
   useEffect(() => {
+    function saveOnKeyboardShortcut(event: KeyboardEvent): void {
+      if (!(event.metaKey || event.ctrlKey) || event.key.toLowerCase() !== "s") {
+        return;
+      }
+
+      event.preventDefault();
+      void saveSelectedNoteDraft();
+    }
+
+    window.addEventListener("keydown", saveOnKeyboardShortcut);
+
+    return () => {
+      window.removeEventListener("keydown", saveOnKeyboardShortcut);
+    };
+  }, [saveSelectedNoteDraft]);
+
+  useEffect(() => {
     const nextRunnableOperationId = getNextRunnablePathChangeOperationId(
       pathChangeOperations,
       runningOperationIds,
@@ -1057,6 +1137,9 @@ export function FolderNavigationWorkspace() {
         onMoveSelectedNote={moveSelectedNote}
         onRenameSelectedFolder={renameSelectedFolder}
         onEditContent={editSelectedNoteContent}
+        onSaveDraft={() => {
+          void saveSelectedNoteDraft();
+        }}
         onDiscardDraft={discardSelectedDraft}
       />
       <PathChangeQueue

--- a/apps/desktop/src/features/folder-navigation/ui/FolderNavigationWorkspace.tsx
+++ b/apps/desktop/src/features/folder-navigation/ui/FolderNavigationWorkspace.tsx
@@ -18,7 +18,6 @@ import {
   scanMarkdownWorkspace,
   writeMarkdownNote,
 } from "../../../shared";
-import type { ScannedMarkdownNote } from "../../../shared";
 import {
   getFailedOperationSteps,
   getNextPendingOperationStep,
@@ -40,6 +39,7 @@ import {
   markNoteEditBufferSaving,
   updateNoteEditDraft,
 } from "../model/noteEditBuffer";
+import { applySavedNoteMetadataToWorkspaceState } from "../model/noteSave";
 import { usePathChangeQueue } from "../model/usePathChangeQueue";
 import { mapScannedMarkdownNotes } from "../model/workspaceScan";
 import type {
@@ -875,28 +875,6 @@ export function FolderNavigationWorkspace() {
     setEditorNotice(null);
   }
 
-  function applySavedNoteMetadata(buffer: NoteEditBuffer, savedNote: ScannedMarkdownNote): void {
-    const [updatedNote] = mapScannedMarkdownNotes([savedNote]);
-
-    setWorkspaceState((currentState) =>
-      reconcileFolderWorkspaceState({
-        ...currentState,
-        notes: currentState.notes.map((note) => {
-          if (note.id !== buffer.noteId) {
-            return note;
-          }
-
-          return {
-            ...note,
-            ...updatedNote,
-            id: buffer.noteId,
-            path: note.path === buffer.path ? updatedNote.path : note.path,
-          };
-        }),
-      }),
-    );
-  }
-
   function markSelectedNoteDraftSaved(buffer: NoteEditBuffer): void {
     setNoteEditBuffer((currentBuffer) => {
       if (currentBuffer === null || currentBuffer.noteId !== buffer.noteId) {
@@ -925,7 +903,15 @@ export function FolderNavigationWorkspace() {
     }
 
     savingNoteIdSet.current.add(buffer.noteId);
-    setNoteEditBuffer(markNoteEditBufferSaving(buffer));
+    setNoteEditBuffer((currentBuffer) => {
+      if (currentBuffer === null || currentBuffer.noteId !== buffer.noteId) {
+        return currentBuffer;
+      }
+
+      return canSaveNoteEditBuffer(currentBuffer)
+        ? markNoteEditBufferSaving(currentBuffer)
+        : currentBuffer;
+    });
     setEditorNotice(null);
 
     try {
@@ -933,7 +919,13 @@ export function FolderNavigationWorkspace() {
         path: buffer.path,
         content: buffer.draftContent,
       });
-      applySavedNoteMetadata(buffer, savedNote);
+      setWorkspaceState((currentState) =>
+        applySavedNoteMetadataToWorkspaceState(currentState, {
+          noteId: buffer.noteId,
+          previousPath: buffer.path,
+          savedNote,
+        }),
+      );
       markSelectedNoteDraftSaved(buffer);
 
       try {

--- a/apps/desktop/src/features/folder-navigation/ui/FolderNavigationWorkspace.tsx
+++ b/apps/desktop/src/features/folder-navigation/ui/FolderNavigationWorkspace.tsx
@@ -20,18 +20,13 @@ import {
 } from "../../../shared";
 import type { ScannedMarkdownNote } from "../../../shared";
 import {
-  clearCompletedPathChangeOperations,
-  createPathChangeOperation,
   getFailedOperationSteps,
   getNextPendingOperationStep,
-  getNextRunnablePathChangeOperationId,
   isDescendantFolderPath,
   isPathChangeOperationComplete,
   moveNoteInFolderWorkspace,
   reconcileFolderWorkspaceState,
   renameFolderInWorkspace,
-  retryOperationStep,
-  runNextOperationStep,
 } from "../model/folderWorkspaceState";
 import { createDesktopPathChangeExecutor } from "../model/folderPathChangeExecutor";
 import {
@@ -43,6 +38,7 @@ import {
   markNoteEditBufferSaving,
   updateNoteEditDraft,
 } from "../model/noteEditBuffer";
+import { usePathChangeQueue } from "../model/usePathChangeQueue";
 import { mapScannedMarkdownNotes } from "../model/workspaceScan";
 import type {
   FolderNavigationNote,
@@ -765,13 +761,15 @@ export function FolderNavigationWorkspace() {
     status: "loading",
     errorMessage: null,
   });
-  const [pathChangeOperations, setPathChangeOperations] = useState<
-    readonly FolderWorkspacePathChangeOperation[]
-  >([]);
-  const [runningOperationIds, setRunningOperationIds] = useState<readonly string[]>([]);
-  const runningOperationIdSet = useRef(new Set<string>());
   const savingNoteIdSet = useRef(new Set<string>());
-  const nextOperationNumber = useRef(1);
+  const {
+    pathChangeOperations,
+    runningOperationIds,
+    queuePathChangeOperation,
+    retryPathChangeStep,
+    clearCompletedPathChanges,
+    runNextPathChangeStep,
+  } = usePathChangeQueue(desktopPathChangeExecutor);
   const { notes, explicitFolders, selectedFolderPath, expandedFolderPaths } = workspaceState;
 
   const folderTree = useMemo(() => {
@@ -832,58 +830,6 @@ export function FolderNavigationWorkspace() {
 
     setEditorNotice(null);
     setSelectedNoteId(noteId);
-  }
-
-  function queuePathChangeOperation(mutation: FolderWorkspaceMutation): void {
-    const operation = createPathChangeOperation(
-      `path-change-${nextOperationNumber.current}`,
-      mutation,
-    );
-
-    if (operation === null) {
-      return;
-    }
-
-    nextOperationNumber.current += 1;
-    setPathChangeOperations((currentOperations) => [operation, ...currentOperations]);
-  }
-
-  function retryPathChangeStep(operationId: string, stepId: FolderWorkspaceOperationStepId): void {
-    setPathChangeOperations((currentOperations) =>
-      retryOperationStep(currentOperations, operationId, stepId),
-    );
-  }
-
-  function clearCompletedPathChanges(): void {
-    setPathChangeOperations(clearCompletedPathChangeOperations);
-  }
-
-  async function runNextPathChangeStep(operationId: string): Promise<void> {
-    const operation = pathChangeOperations.find((currentOperation) => {
-      return currentOperation.id === operationId;
-    });
-
-    if (operation === undefined || runningOperationIdSet.current.has(operationId)) {
-      return;
-    }
-
-    runningOperationIdSet.current.add(operationId);
-    setRunningOperationIds((currentOperationIds) => [...currentOperationIds, operationId]);
-
-    try {
-      const nextOperation = await runNextOperationStep(operation, desktopPathChangeExecutor);
-
-      setPathChangeOperations((currentOperations) =>
-        currentOperations.map((currentOperation) => {
-          return currentOperation.id === operationId ? nextOperation : currentOperation;
-        }),
-      );
-    } finally {
-      runningOperationIdSet.current.delete(operationId);
-      setRunningOperationIds((currentOperationIds) =>
-        currentOperationIds.filter((currentOperationId) => currentOperationId !== operationId),
-      );
-    }
   }
 
   function moveSelectedNote(targetFolderPath: FolderScope): FolderWorkspaceMutation {
@@ -1148,19 +1094,6 @@ export function FolderNavigationWorkspace() {
       window.removeEventListener("keydown", saveOnKeyboardShortcut);
     };
   }, [saveSelectedNoteDraft]);
-
-  useEffect(() => {
-    const nextRunnableOperationId = getNextRunnablePathChangeOperationId(
-      pathChangeOperations,
-      runningOperationIds,
-    );
-
-    if (nextRunnableOperationId === null) {
-      return;
-    }
-
-    void runNextPathChangeStep(nextRunnableOperationId);
-  }, [pathChangeOperations, runNextPathChangeStep, runningOperationIds]);
 
   return (
     <section className="folder-navigation">

--- a/apps/desktop/src/features/folder-navigation/ui/FolderNavigationWorkspace.tsx
+++ b/apps/desktop/src/features/folder-navigation/ui/FolderNavigationWorkspace.tsx
@@ -43,6 +43,7 @@ import {
 import {
   applySavedNoteMetadataToWorkspaceState,
   isNoteSaveBlockedByPathChange,
+  isNoteSaveKeyboardShortcut,
 } from "../model/noteSave";
 import { usePathChangeQueue } from "../model/usePathChangeQueue";
 import { mapScannedMarkdownNotes } from "../model/workspaceScan";
@@ -241,6 +242,8 @@ function getNoteReadErrorMessage(error: unknown): string {
 function getNoteSaveErrorMessage(error: unknown): string {
   return error instanceof Error ? error.message : "The Markdown note could not be saved.";
 }
+
+const noteSaveBlockedMessage = "Wait for this note's path change to finish before saving.";
 
 function WorkspaceScanBanner({ scanState }: { scanState: WorkspaceScanState }) {
   if (scanState.status === "loading") {
@@ -801,7 +804,7 @@ export function FolderNavigationWorkspace() {
     !canSaveNoteEditBuffer(noteEditBuffer) ||
     !isNoteSaveBlockedByPathChange(pathChangeOperations, noteEditBuffer.noteId)
       ? null
-      : "Wait for this note's path change to finish before saving.";
+      : noteSaveBlockedMessage;
 
   function applyWorkspaceState(nextState: FolderWorkspaceState): void {
     setWorkspaceState(reconcileFolderWorkspaceState(nextState));
@@ -920,7 +923,7 @@ export function FolderNavigationWorkspace() {
     }
 
     if (isNoteSaveBlockedByPathChange(pathChangeOperations, buffer.noteId)) {
-      setEditorNotice("Wait for this note's path change to finish before saving.");
+      setEditorNotice(noteSaveBlockedMessage);
       return;
     }
 
@@ -1085,21 +1088,21 @@ export function FolderNavigationWorkspace() {
 
   useEffect(() => {
     function saveOnKeyboardShortcut(event: KeyboardEvent): void {
-      if (!(event.metaKey || event.ctrlKey) || event.key.toLowerCase() !== "s") {
+      if (!isNoteSaveKeyboardShortcut(event)) {
         return;
       }
+
+      event.preventDefault();
 
       if (!canSaveNoteEditBuffer(noteEditBuffer)) {
         return;
       }
 
       if (isNoteSaveBlockedByPathChange(pathChangeOperations, noteEditBuffer.noteId)) {
-        event.preventDefault();
-        setEditorNotice("Wait for this note's path change to finish before saving.");
+        setEditorNotice(noteSaveBlockedMessage);
         return;
       }
 
-      event.preventDefault();
       void saveSelectedNoteDraft();
     }
 

--- a/apps/desktop/src/features/folder-navigation/ui/FolderNavigationWorkspace.tsx
+++ b/apps/desktop/src/features/folder-navigation/ui/FolderNavigationWorkspace.tsx
@@ -237,6 +237,10 @@ function getNoteSaveErrorMessage(error: unknown): string {
   return error instanceof Error ? error.message : "The Markdown note could not be saved.";
 }
 
+function isDraftBlockingWorkspaceChange(buffer: NoteEditBuffer | null): boolean {
+  return buffer?.status === "dirty" || buffer?.status === "saving";
+}
+
 function WorkspaceScanBanner({ scanState }: { scanState: WorkspaceScanState }) {
   if (scanState.status === "loading") {
     return <p className="folder-navigation__muted">Scanning Markdown files...</p>;
@@ -765,6 +769,7 @@ export function FolderNavigationWorkspace() {
   >([]);
   const [runningOperationIds, setRunningOperationIds] = useState<readonly string[]>([]);
   const runningOperationIdSet = useRef(new Set<string>());
+  const savingNoteIdSet = useRef(new Set<string>());
   const nextOperationNumber = useRef(1);
   const { notes, explicitFolders, selectedFolderPath, expandedFolderPaths } = workspaceState;
 
@@ -815,7 +820,8 @@ export function FolderNavigationWorkspace() {
 
   function selectNote(noteId: string): void {
     if (
-      (noteEditBuffer?.status === "dirty" || noteEditBuffer?.status === "saving") &&
+      noteEditBuffer !== null &&
+      isDraftBlockingWorkspaceChange(noteEditBuffer) &&
       noteEditBuffer.noteId !== noteId &&
       selectedNoteId !== noteId
     ) {
@@ -880,6 +886,10 @@ export function FolderNavigationWorkspace() {
   }
 
   function moveSelectedNote(targetFolderPath: FolderScope): FolderWorkspaceMutation {
+    if (isDraftBlockingWorkspaceChange(noteEditBuffer)) {
+      throw new Error("Save or discard the current draft before moving notes.");
+    }
+
     const mutation = moveNoteInFolderWorkspace(workspaceState, selectedNoteId, targetFolderPath);
     applyWorkspaceState(mutation.state);
     queuePathChangeOperation(mutation);
@@ -887,6 +897,10 @@ export function FolderNavigationWorkspace() {
   }
 
   function renameSelectedFolder(targetFolderPath: FolderScope): FolderWorkspaceMutation {
+    if (isDraftBlockingWorkspaceChange(noteEditBuffer)) {
+      throw new Error("Save or discard the current draft before renaming folders.");
+    }
+
     if (selectedFolderPath === null) {
       return {
         affectedNoteIds: [],
@@ -919,10 +933,15 @@ export function FolderNavigationWorkspace() {
   const saveSelectedNoteDraft = useCallback(async (): Promise<void> => {
     const buffer = noteEditBuffer;
 
-    if (buffer === null || buffer.status !== "dirty") {
+    if (
+      buffer === null ||
+      buffer.status !== "dirty" ||
+      savingNoteIdSet.current.has(buffer.noteId)
+    ) {
       return;
     }
 
+    savingNoteIdSet.current.add(buffer.noteId);
     setNoteEditBuffer(markNoteEditBufferSaving(buffer));
     setEditorNotice(null);
 
@@ -937,13 +956,26 @@ export function FolderNavigationWorkspace() {
         reconcileFolderWorkspaceState({
           ...currentState,
           notes: currentState.notes.map((note) => {
-            return note.id === buffer.noteId
-              ? { ...note, ...updatedNote, id: buffer.noteId }
-              : note;
+            if (note.id !== buffer.noteId) {
+              return note;
+            }
+
+            return {
+              ...note,
+              ...updatedNote,
+              id: buffer.noteId,
+              path: note.path === buffer.path ? updatedNote.path : note.path,
+            };
           }),
         }),
       );
-      setNoteEditBuffer(markNoteEditBufferSaved(buffer, buffer.draftContent));
+      setNoteEditBuffer((currentBuffer) => {
+        if (currentBuffer === null || currentBuffer.noteId !== buffer.noteId) {
+          return currentBuffer;
+        }
+
+        return markNoteEditBufferSaved(currentBuffer, buffer.draftContent);
+      });
 
       try {
         await refreshNoteIndexes({
@@ -954,7 +986,15 @@ export function FolderNavigationWorkspace() {
         setEditorNotice(`Saved, but index refresh failed: ${getNoteSaveErrorMessage(error)}`);
       }
     } catch (error) {
-      setNoteEditBuffer(markNoteEditBufferSaveFailed(buffer, getNoteSaveErrorMessage(error)));
+      setNoteEditBuffer((currentBuffer) => {
+        if (currentBuffer === null || currentBuffer.noteId !== buffer.noteId) {
+          return currentBuffer;
+        }
+
+        return markNoteEditBufferSaveFailed(currentBuffer, getNoteSaveErrorMessage(error));
+      });
+    } finally {
+      savingNoteIdSet.current.delete(buffer.noteId);
     }
   }, [noteEditBuffer]);
 

--- a/apps/desktop/src/features/folder-navigation/ui/FolderNavigationWorkspace.tsx
+++ b/apps/desktop/src/features/folder-navigation/ui/FolderNavigationWorkspace.tsx
@@ -40,7 +40,10 @@ import {
   updateNoteEditBufferPath,
   updateNoteEditDraft,
 } from "../model/noteEditBuffer";
-import { applySavedNoteMetadataToWorkspaceState } from "../model/noteSave";
+import {
+  applySavedNoteMetadataToWorkspaceState,
+  isNoteSaveBlockedByPathChange,
+} from "../model/noteSave";
 import { usePathChangeQueue } from "../model/usePathChangeQueue";
 import { mapScannedMarkdownNotes } from "../model/workspaceScan";
 import type {
@@ -99,6 +102,7 @@ type ActivePaneProps = {
   onRenameSelectedFolder: (targetFolderPath: FolderScope) => FolderWorkspaceMutation;
   onEditContent: (content: string) => void;
   onSaveDraft: () => void;
+  saveBlockedReason: string | null;
   onDiscardDraft: () => void;
 };
 
@@ -139,6 +143,7 @@ type NoteEditorProps = {
   editorNotice: string | null;
   onEditContent: (content: string) => void;
   onSaveDraft: () => void;
+  saveBlockedReason: string | null;
   onDiscardDraft: () => void;
 };
 
@@ -531,6 +536,7 @@ function NoteEditor({
   editorNotice,
   onEditContent,
   onSaveDraft,
+  saveBlockedReason,
   onDiscardDraft,
 }: NoteEditorProps) {
   if (selectedNote === undefined) {
@@ -557,7 +563,7 @@ function NoteEditor({
           type="button"
           className="folder-navigation__action"
           onClick={onSaveDraft}
-          disabled={noteEditBuffer.status !== "dirty"}
+          disabled={noteEditBuffer.status !== "dirty" || saveBlockedReason !== null}
         >
           Save
         </button>
@@ -575,6 +581,9 @@ function NoteEditor({
       )}
       {editorNotice === null ? null : (
         <p className="folder-navigation__step-error">{editorNotice}</p>
+      )}
+      {saveBlockedReason === null ? null : (
+        <p className="folder-navigation__step-error">{saveBlockedReason}</p>
       )}
       <textarea
         className="folder-navigation__textarea"
@@ -599,6 +608,7 @@ function ActivePane({
   onRenameSelectedFolder,
   onEditContent,
   onSaveDraft,
+  saveBlockedReason,
   onDiscardDraft,
 }: ActivePaneProps) {
   const selectedNote = notes.find((note) => note.id === selectedNoteId) ?? notes[0];
@@ -623,6 +633,7 @@ function ActivePane({
               editorNotice={editorNotice}
               onEditContent={onEditContent}
               onSaveDraft={onSaveDraft}
+              saveBlockedReason={saveBlockedReason}
               onDiscardDraft={onDiscardDraft}
             />
             <MoveNoteControl
@@ -786,6 +797,11 @@ export function FolderNavigationWorkspace() {
   const selectedNote = useMemo(() => {
     return notes.find((note) => note.id === selectedNoteId) ?? notes[0];
   }, [notes, selectedNoteId]);
+  const saveBlockedReason =
+    !canSaveNoteEditBuffer(noteEditBuffer) ||
+    !isNoteSaveBlockedByPathChange(pathChangeOperations, noteEditBuffer.noteId)
+      ? null
+      : "Wait for this note's path change to finish before saving.";
 
   function applyWorkspaceState(nextState: FolderWorkspaceState): void {
     setWorkspaceState(reconcileFolderWorkspaceState(nextState));
@@ -903,6 +919,11 @@ export function FolderNavigationWorkspace() {
       return;
     }
 
+    if (isNoteSaveBlockedByPathChange(pathChangeOperations, buffer.noteId)) {
+      setEditorNotice("Wait for this note's path change to finish before saving.");
+      return;
+    }
+
     savingNoteIdSet.current.add(buffer.noteId);
     setNoteEditBuffer((currentBuffer) => {
       if (currentBuffer === null || currentBuffer.noteId !== buffer.noteId) {
@@ -942,7 +963,7 @@ export function FolderNavigationWorkspace() {
     } finally {
       savingNoteIdSet.current.delete(buffer.noteId);
     }
-  }, [noteEditBuffer]);
+  }, [noteEditBuffer, pathChangeOperations]);
 
   function discardSelectedDraft(): void {
     setNoteEditBuffer((currentBuffer) => {
@@ -1072,6 +1093,12 @@ export function FolderNavigationWorkspace() {
         return;
       }
 
+      if (isNoteSaveBlockedByPathChange(pathChangeOperations, noteEditBuffer.noteId)) {
+        event.preventDefault();
+        setEditorNotice("Wait for this note's path change to finish before saving.");
+        return;
+      }
+
       event.preventDefault();
       void saveSelectedNoteDraft();
     }
@@ -1081,7 +1108,7 @@ export function FolderNavigationWorkspace() {
     return () => {
       window.removeEventListener("keydown", saveOnKeyboardShortcut);
     };
-  }, [noteEditBuffer, saveSelectedNoteDraft]);
+  }, [noteEditBuffer, pathChangeOperations, saveSelectedNoteDraft]);
 
   return (
     <section className="folder-navigation">
@@ -1114,6 +1141,7 @@ export function FolderNavigationWorkspace() {
         onSaveDraft={() => {
           void saveSelectedNoteDraft();
         }}
+        saveBlockedReason={saveBlockedReason}
         onDiscardDraft={discardSelectedDraft}
       />
       <PathChangeQueue

--- a/apps/desktop/src/features/folder-navigation/ui/FolderNavigationWorkspace.tsx
+++ b/apps/desktop/src/features/folder-navigation/ui/FolderNavigationWorkspace.tsx
@@ -18,6 +18,7 @@ import {
   scanMarkdownWorkspace,
   writeMarkdownNote,
 } from "../../../shared";
+import type { ScannedMarkdownNote } from "../../../shared";
 import {
   clearCompletedPathChangeOperations,
   createPathChangeOperation,
@@ -930,6 +931,48 @@ export function FolderNavigationWorkspace() {
     setEditorNotice(null);
   }
 
+  function applySavedNoteMetadata(buffer: NoteEditBuffer, savedNote: ScannedMarkdownNote): void {
+    const [updatedNote] = mapScannedMarkdownNotes([savedNote]);
+
+    setWorkspaceState((currentState) =>
+      reconcileFolderWorkspaceState({
+        ...currentState,
+        notes: currentState.notes.map((note) => {
+          if (note.id !== buffer.noteId) {
+            return note;
+          }
+
+          return {
+            ...note,
+            ...updatedNote,
+            id: buffer.noteId,
+            path: note.path === buffer.path ? updatedNote.path : note.path,
+          };
+        }),
+      }),
+    );
+  }
+
+  function markSelectedNoteDraftSaved(buffer: NoteEditBuffer): void {
+    setNoteEditBuffer((currentBuffer) => {
+      if (currentBuffer === null || currentBuffer.noteId !== buffer.noteId) {
+        return currentBuffer;
+      }
+
+      return markNoteEditBufferSaved(currentBuffer, buffer.draftContent);
+    });
+  }
+
+  function markSelectedNoteDraftSaveFailed(buffer: NoteEditBuffer, error: unknown): void {
+    setNoteEditBuffer((currentBuffer) => {
+      if (currentBuffer === null || currentBuffer.noteId !== buffer.noteId) {
+        return currentBuffer;
+      }
+
+      return markNoteEditBufferSaveFailed(currentBuffer, getNoteSaveErrorMessage(error));
+    });
+  }
+
   const saveSelectedNoteDraft = useCallback(async (): Promise<void> => {
     const buffer = noteEditBuffer;
 
@@ -950,32 +993,8 @@ export function FolderNavigationWorkspace() {
         path: buffer.path,
         content: buffer.draftContent,
       });
-      const [updatedNote] = mapScannedMarkdownNotes([savedNote]);
-
-      setWorkspaceState((currentState) =>
-        reconcileFolderWorkspaceState({
-          ...currentState,
-          notes: currentState.notes.map((note) => {
-            if (note.id !== buffer.noteId) {
-              return note;
-            }
-
-            return {
-              ...note,
-              ...updatedNote,
-              id: buffer.noteId,
-              path: note.path === buffer.path ? updatedNote.path : note.path,
-            };
-          }),
-        }),
-      );
-      setNoteEditBuffer((currentBuffer) => {
-        if (currentBuffer === null || currentBuffer.noteId !== buffer.noteId) {
-          return currentBuffer;
-        }
-
-        return markNoteEditBufferSaved(currentBuffer, buffer.draftContent);
-      });
+      applySavedNoteMetadata(buffer, savedNote);
+      markSelectedNoteDraftSaved(buffer);
 
       try {
         await refreshNoteIndexes({
@@ -986,13 +1005,7 @@ export function FolderNavigationWorkspace() {
         setEditorNotice(`Saved, but index refresh failed: ${getNoteSaveErrorMessage(error)}`);
       }
     } catch (error) {
-      setNoteEditBuffer((currentBuffer) => {
-        if (currentBuffer === null || currentBuffer.noteId !== buffer.noteId) {
-          return currentBuffer;
-        }
-
-        return markNoteEditBufferSaveFailed(currentBuffer, getNoteSaveErrorMessage(error));
-      });
+      markSelectedNoteDraftSaveFailed(buffer, error);
     } finally {
       savingNoteIdSet.current.delete(buffer.noteId);
     }

--- a/apps/desktop/src/features/folder-navigation/ui/FolderNavigationWorkspace.tsx
+++ b/apps/desktop/src/features/folder-navigation/ui/FolderNavigationWorkspace.tsx
@@ -30,9 +30,11 @@ import {
 } from "../model/folderWorkspaceState";
 import { createDesktopPathChangeExecutor } from "../model/folderPathChangeExecutor";
 import {
+  canSaveNoteEditBuffer,
   createCleanNoteEditBuffer,
   createErroredNoteEditBuffer,
   discardNoteEditDraft,
+  isNoteEditBufferBlockingWorkspaceChange,
   markNoteEditBufferSaved,
   markNoteEditBufferSaveFailed,
   markNoteEditBufferSaving,
@@ -232,10 +234,6 @@ function getNoteReadErrorMessage(error: unknown): string {
 
 function getNoteSaveErrorMessage(error: unknown): string {
   return error instanceof Error ? error.message : "The Markdown note could not be saved.";
-}
-
-function isDraftBlockingWorkspaceChange(buffer: NoteEditBuffer | null): boolean {
-  return buffer?.status === "dirty" || buffer?.status === "saving";
 }
 
 function WorkspaceScanBanner({ scanState }: { scanState: WorkspaceScanState }) {
@@ -820,7 +818,7 @@ export function FolderNavigationWorkspace() {
   function selectNote(noteId: string): void {
     if (
       noteEditBuffer !== null &&
-      isDraftBlockingWorkspaceChange(noteEditBuffer) &&
+      isNoteEditBufferBlockingWorkspaceChange(noteEditBuffer) &&
       noteEditBuffer.noteId !== noteId &&
       selectedNoteId !== noteId
     ) {
@@ -833,7 +831,7 @@ export function FolderNavigationWorkspace() {
   }
 
   function moveSelectedNote(targetFolderPath: FolderScope): FolderWorkspaceMutation {
-    if (isDraftBlockingWorkspaceChange(noteEditBuffer)) {
+    if (isNoteEditBufferBlockingWorkspaceChange(noteEditBuffer)) {
       throw new Error("Save or discard the current draft before moving notes.");
     }
 
@@ -844,7 +842,7 @@ export function FolderNavigationWorkspace() {
   }
 
   function renameSelectedFolder(targetFolderPath: FolderScope): FolderWorkspaceMutation {
-    if (isDraftBlockingWorkspaceChange(noteEditBuffer)) {
+    if (isNoteEditBufferBlockingWorkspaceChange(noteEditBuffer)) {
       throw new Error("Save or discard the current draft before renaming folders.");
     }
 
@@ -922,11 +920,7 @@ export function FolderNavigationWorkspace() {
   const saveSelectedNoteDraft = useCallback(async (): Promise<void> => {
     const buffer = noteEditBuffer;
 
-    if (
-      buffer === null ||
-      buffer.status !== "dirty" ||
-      savingNoteIdSet.current.has(buffer.noteId)
-    ) {
+    if (!canSaveNoteEditBuffer(buffer) || savingNoteIdSet.current.has(buffer.noteId)) {
       return;
     }
 
@@ -1084,6 +1078,10 @@ export function FolderNavigationWorkspace() {
         return;
       }
 
+      if (!canSaveNoteEditBuffer(noteEditBuffer)) {
+        return;
+      }
+
       event.preventDefault();
       void saveSelectedNoteDraft();
     }
@@ -1093,7 +1091,7 @@ export function FolderNavigationWorkspace() {
     return () => {
       window.removeEventListener("keydown", saveOnKeyboardShortcut);
     };
-  }, [saveSelectedNoteDraft]);
+  }, [noteEditBuffer, saveSelectedNoteDraft]);
 
   return (
     <section className="folder-navigation">

--- a/apps/desktop/src/features/folder-navigation/ui/FolderNavigationWorkspace.tsx
+++ b/apps/desktop/src/features/folder-navigation/ui/FolderNavigationWorkspace.tsx
@@ -37,6 +37,7 @@ import {
   markNoteEditBufferSaved,
   markNoteEditBufferSaveFailed,
   markNoteEditBufferSaving,
+  updateNoteEditBufferPath,
   updateNoteEditDraft,
 } from "../model/noteEditBuffer";
 import { applySavedNoteMetadataToWorkspaceState } from "../model/noteSave";
@@ -1004,12 +1005,9 @@ export function FolderNavigationWorkspace() {
       return;
     }
 
-    if (noteEditBuffer?.noteId === selectedNote.id && noteEditBuffer.status === "dirty") {
+    if (noteEditBuffer?.noteId === selectedNote.id && noteEditBuffer.status !== "error") {
       if (noteEditBuffer.path !== selectedNote.path) {
-        setNoteEditBuffer({
-          ...noteEditBuffer,
-          path: selectedNote.path,
-        });
+        setNoteEditBuffer(updateNoteEditBufferPath(noteEditBuffer, selectedNote.path));
       }
       setEditorLoadState({ status: "idle" });
       return;

--- a/apps/desktop/src/shared/api/commands.test.ts
+++ b/apps/desktop/src/shared/api/commands.test.ts
@@ -6,6 +6,7 @@ import {
   readMarkdownNote,
   refreshNoteIndexes,
   scanMarkdownWorkspace,
+  writeMarkdownNote,
 } from "./commands";
 
 vi.mock("@tauri-apps/api/core", () => ({
@@ -42,13 +43,13 @@ describe("desktop command wrappers", () => {
 
     await refreshNoteIndexes({
       noteIds: ["note-plan"],
-      reason: "note-move",
+      reason: "note-save",
     });
 
     expect(invokeMock).toHaveBeenCalledWith("refresh_note_indexes", {
       refresh: {
         noteIds: ["note-plan"],
-        reason: "note-move",
+        reason: "note-save",
       },
     });
   });
@@ -85,12 +86,48 @@ describe("desktop command wrappers", () => {
     });
   });
 
+  it("invokes the Markdown note write command", async () => {
+    invokeMock.mockResolvedValue({
+      path: "Projects/Grove/Plan.md",
+      title: "Workspace plan",
+      updatedAtUnixMs: 1776265200000,
+    });
+
+    await expect(
+      writeMarkdownNote({
+        path: "Projects/Grove/Plan.md",
+        content: "# Workspace plan\n\nSaved",
+      }),
+    ).resolves.toStrictEqual({
+      path: "Projects/Grove/Plan.md",
+      title: "Workspace plan",
+      updatedAtUnixMs: 1776265200000,
+    });
+    expect(invokeMock).toHaveBeenCalledWith("write_markdown_note", {
+      note: {
+        path: "Projects/Grove/Plan.md",
+        content: "# Workspace plan\n\nSaved",
+      },
+    });
+  });
+
   it("rejects invalid Markdown note read results", async () => {
     invokeMock.mockResolvedValue({ content: "# Plan" });
 
     await expect(readMarkdownNote({ path: "Projects/Grove/Plan.md" })).rejects.toThrow(
       "invalid note content",
     );
+  });
+
+  it("rejects invalid Markdown note write metadata", async () => {
+    invokeMock.mockResolvedValue({ path: "Projects/Grove/Plan.md", title: "Plan" });
+
+    await expect(
+      writeMarkdownNote({
+        path: "Projects/Grove/Plan.md",
+        content: "# Plan",
+      }),
+    ).rejects.toThrow("invalid note metadata");
   });
 
   it("rejects invalid Markdown workspace scan results", async () => {

--- a/apps/desktop/src/shared/api/commands.ts
+++ b/apps/desktop/src/shared/api/commands.ts
@@ -8,7 +8,7 @@ export type MoveMarkdownFileCommand = {
 
 export type RefreshNoteIndexesCommand = {
   noteIds: readonly string[];
-  reason: "note-move" | "folder-rename";
+  reason: "note-move" | "folder-rename" | "note-save";
 };
 
 export type ScannedMarkdownNote = {
@@ -19,6 +19,11 @@ export type ScannedMarkdownNote = {
 
 export type ReadMarkdownNoteCommand = {
   path: string;
+};
+
+export type WriteMarkdownNoteCommand = {
+  path: string;
+  content: string;
 };
 
 export async function moveMarkdownFile(command: MoveMarkdownFileCommand): Promise<void> {
@@ -44,6 +49,18 @@ export async function readMarkdownNote(command: ReadMarkdownNoteCommand): Promis
 
   if (typeof result !== "string") {
     throw new Error("The desktop read command returned invalid note content.");
+  }
+
+  return result;
+}
+
+export async function writeMarkdownNote(
+  command: WriteMarkdownNoteCommand,
+): Promise<ScannedMarkdownNote> {
+  const result = await invokeCommandResult("write_markdown_note", { note: command });
+
+  if (!isScannedMarkdownNote(result)) {
+    throw new Error("The desktop write command returned invalid note metadata.");
   }
 
   return result;

--- a/apps/desktop/src/shared/index.ts
+++ b/apps/desktop/src/shared/index.ts
@@ -3,11 +3,13 @@ export {
   readMarkdownNote,
   refreshNoteIndexes,
   scanMarkdownWorkspace,
+  writeMarkdownNote,
 } from "./api/commands";
 export type {
   MoveMarkdownFileCommand,
   ReadMarkdownNoteCommand,
   RefreshNoteIndexesCommand,
+  WriteMarkdownNoteCommand,
 } from "./api/commands";
 export type { ScannedMarkdownNote } from "./api/commands";
 export { ShellCard } from "./ui/ShellCard";


### PR DESCRIPTION
## Summary
- add a desktop Tauri command and typed wrapper for writing Markdown notes by workspace-relative path
- connect the desktop editor Save button and Cmd/Ctrl+S shortcut to write drafts, update note metadata, and queue note-save index refreshes
- keep failed saves dirty with the draft intact, while successful saves return the edit buffer to clean

## Testing
- pnpm --filter @grove/desktop test
- cargo test --manifest-path apps/desktop/src-tauri/Cargo.toml
- pnpm typecheck
- pnpm lint
- pnpm test
- pnpm --filter @grove/desktop build
- pnpm format
- git diff --check
- pnpm build:desktop

Refs #50
