### PR TITLE
Add desktop note creation flow

### DIFF
--- a/apps/desktop/src-tauri/src/main.rs
+++ b/apps/desktop/src-tauri/src/main.rs
@@ -50,6 +50,7 @@ enum IndexRefreshReason {
     NoteMove,
     FolderRename,
     NoteSave,
+    NoteCreate,
 }
 
 #[derive(Debug, Serialize)]

--- a/apps/desktop/src-tauri/src/main.rs
+++ b/apps/desktop/src-tauri/src/main.rs
@@ -385,11 +385,30 @@ async fn write_markdown_file(path: &Path, content: &[u8]) -> anyhow::Result<()> 
 }
 
 async fn create_markdown_file(path: &Path, content: &[u8]) -> anyhow::Result<()> {
-    if tokio::fs::try_exists(path).await? {
-        anyhow::bail!("The target Markdown file already exists: {}", path.display());
+    if let Some(parent_path) = path.parent() {
+        tokio::fs::create_dir_all(parent_path).await?;
     }
 
-    write_markdown_file(path, content).await
+    let mut file = tokio::fs::OpenOptions::new()
+        .write(true)
+        .create_new(true)
+        .open(path)
+        .await
+        .map_err(|error| {
+            if error.kind() == std::io::ErrorKind::AlreadyExists {
+                anyhow::anyhow!(
+                    "The target Markdown file already exists: {}",
+                    path.display()
+                )
+            } else {
+                error.into()
+            }
+        })?;
+    file.write_all(content).await?;
+    file.flush().await?;
+    file.sync_all().await?;
+
+    Ok(())
 }
 
 fn get_temporary_write_path(path: &Path) -> anyhow::Result<PathBuf> {
@@ -577,10 +596,9 @@ mod tests {
     };
 
     use super::{
-        find_first_markdown_heading, get_temporary_write_path,
+        create_markdown_file, find_first_markdown_heading, get_temporary_write_path,
         get_workspace_relative_markdown_path, move_file_without_overwrite, read_markdown_file,
         scan_markdown_files, system_time_to_unix_ms, validate_markdown_path, write_markdown_file,
-        create_markdown_file,
     };
 
     fn run_async<F>(future: F) -> F::Output

--- a/apps/desktop/src-tauri/src/main.rs
+++ b/apps/desktop/src-tauri/src/main.rs
@@ -32,6 +32,13 @@ struct ReadMarkdownNoteRequest {
 
 #[derive(Debug, Deserialize)]
 #[serde(rename_all = "camelCase")]
+struct CreateMarkdownNoteRequest {
+    path: String,
+    content: String,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
 struct WriteMarkdownNoteRequest {
     path: String,
     content: String,
@@ -148,6 +155,23 @@ async fn read_markdown_note(
 }
 
 #[tauri::command]
+async fn create_markdown_note(
+    app_handle: tauri::AppHandle,
+    note: CreateMarkdownNoteRequest,
+) -> Result<ScannedMarkdownNote, CommandError> {
+    let workspace_root = default_workspace_root(&app_handle)?;
+    let note_path = resolve_markdown_path(&workspace_root, &note.path)?;
+
+    create_markdown_file(&note_path, note.content.as_bytes())
+        .await
+        .map_err(|error| CommandError::new("note_create_failed", error.to_string()))?;
+
+    summarize_markdown_file(&workspace_root, &note_path)
+        .await
+        .map_err(|error| CommandError::new("note_create_failed", error.to_string()))
+}
+
+#[tauri::command]
 async fn write_markdown_note(
     app_handle: tauri::AppHandle,
     note: WriteMarkdownNoteRequest,
@@ -167,6 +191,7 @@ async fn write_markdown_note(
 fn main() {
     if let Err(error) = tauri::Builder::default()
         .invoke_handler(tauri::generate_handler![
+            create_markdown_note,
             move_markdown_file,
             read_markdown_note,
             refresh_note_indexes,
@@ -358,6 +383,14 @@ async fn write_markdown_file(path: &Path, content: &[u8]) -> anyhow::Result<()> 
     write_result
 }
 
+async fn create_markdown_file(path: &Path, content: &[u8]) -> anyhow::Result<()> {
+    if tokio::fs::try_exists(path).await? {
+        anyhow::bail!("The target Markdown file already exists: {}", path.display());
+    }
+
+    write_markdown_file(path, content).await
+}
+
 fn get_temporary_write_path(path: &Path) -> anyhow::Result<PathBuf> {
     let file_name = path
         .file_name()
@@ -546,6 +579,7 @@ mod tests {
         find_first_markdown_heading, get_temporary_write_path,
         get_workspace_relative_markdown_path, move_file_without_overwrite, read_markdown_file,
         scan_markdown_files, system_time_to_unix_ms, validate_markdown_path, write_markdown_file,
+        create_markdown_file,
     };
 
     fn run_async<F>(future: F) -> F::Output
@@ -711,6 +745,40 @@ mod tests {
             anyhow::Ok(())
         })
         .expect("Markdown write should succeed");
+    }
+
+    #[test]
+    fn creates_new_markdown_files_without_overwriting_existing_paths() {
+        run_async(async {
+            let workspace_dir = unique_test_dir("creates-new-markdown-files");
+            let note_path = workspace_dir.join("Projects").join("Plan.md");
+
+            create_markdown_file(&note_path, b"").await?;
+
+            assert_eq!(tokio::fs::read_to_string(&note_path).await?, "");
+            tokio::fs::remove_dir_all(&workspace_dir).await?;
+            anyhow::Ok(())
+        })
+        .expect("Markdown create should succeed");
+    }
+
+    #[test]
+    fn rejects_new_markdown_files_when_the_target_exists() {
+        run_async(async {
+            let workspace_dir = unique_test_dir("rejects-existing-create-target");
+            let note_path = workspace_dir.join("Projects").join("Plan.md");
+            tokio::fs::create_dir_all(note_path.parent().expect("note parent")).await?;
+            tokio::fs::write(&note_path, "# Plan").await?;
+
+            let error = create_markdown_file(&note_path, b"")
+                .await
+                .expect_err("existing create target should be rejected");
+
+            assert!(error.to_string().contains("already exists"));
+            tokio::fs::remove_dir_all(&workspace_dir).await?;
+            anyhow::Ok(())
+        })
+        .expect("Markdown create collision test should run");
     }
 
     #[test]

--- a/apps/desktop/src-tauri/src/main.rs
+++ b/apps/desktop/src-tauri/src/main.rs
@@ -404,11 +404,21 @@ async fn create_markdown_file(path: &Path, content: &[u8]) -> anyhow::Result<()>
                 error.into()
             }
         })?;
-    file.write_all(content).await?;
-    file.flush().await?;
-    file.sync_all().await?;
 
-    Ok(())
+    let write_result = async {
+        file.write_all(content).await?;
+        file.flush().await?;
+        file.sync_all().await?;
+        anyhow::Ok(())
+    }
+    .await;
+
+    if write_result.is_err() {
+        drop(file);
+        let _ = tokio::fs::remove_file(path).await;
+    }
+
+    write_result
 }
 
 fn get_temporary_write_path(path: &Path) -> anyhow::Result<PathBuf> {

--- a/apps/desktop/src/features/folder-navigation/model/noteCreation.test.ts
+++ b/apps/desktop/src/features/folder-navigation/model/noteCreation.test.ts
@@ -1,0 +1,48 @@
+import { normalizeFolderPath, normalizeNoteFilePath } from "@grove/core";
+import { describe, expect, it } from "vitest";
+
+import { createNewNotePath, insertCreatedNotePath } from "./noteCreation";
+
+describe("createNewNotePath", () => {
+  it("creates a Markdown path in the workspace root", () => {
+    expect(createNewNotePath("Daily plan", null, [])).toBe("Daily plan.md");
+  });
+
+  it("creates a Markdown path in the selected folder", () => {
+    expect(createNewNotePath("Project brief", normalizeFolderPath("Projects/Grove"), [])).toBe(
+      "Projects/Grove/Project brief.md",
+    );
+  });
+
+  it("falls back to Untitled and disambiguates collisions predictably", () => {
+    expect(
+      createNewNotePath(" / ", normalizeFolderPath("Projects/Grove"), [
+        normalizeNoteFilePath("Projects/Grove/Untitled.md"),
+        normalizeNoteFilePath("Projects/Grove/Untitled 2.md"),
+      ]),
+    ).toBe("Projects/Grove/Untitled 3.md");
+  });
+
+  it("removes invalid file name characters before creating the path", () => {
+    expect(createNewNotePath("Roadmap: Q2/2026?", null, [])).toBe("Roadmap Q2 2026.md");
+  });
+
+  it("treats existing note paths as case-insensitive collisions", () => {
+    expect(
+      createNewNotePath("plan", normalizeFolderPath("Projects"), [
+        normalizeNoteFilePath("Projects/Plan.md"),
+      ]),
+    ).toBe("Projects/plan 2.md");
+  });
+});
+
+describe("insertCreatedNotePath", () => {
+  it("keeps created note paths sorted with existing notes", () => {
+    expect(
+      insertCreatedNotePath(
+        [normalizeNoteFilePath("Projects/Grove/Plan.md"), normalizeNoteFilePath("Inbox.md")],
+        normalizeNoteFilePath("Projects/Grove/Brief.md"),
+      ),
+    ).toStrictEqual(["Inbox.md", "Projects/Grove/Brief.md", "Projects/Grove/Plan.md"]);
+  });
+});

--- a/apps/desktop/src/features/folder-navigation/model/noteCreation.ts
+++ b/apps/desktop/src/features/folder-navigation/model/noteCreation.ts
@@ -1,0 +1,49 @@
+import { compareWorkspacePaths, normalizeFolderPath, normalizeNoteFilePath } from "@grove/core";
+import type { FolderScope, NoteFilePath } from "@grove/core";
+
+const INVALID_FILE_NAME_CHARACTERS = /[\p{Cc}<>:"/\\|?*]/gu;
+const WHITESPACE = /\s+/g;
+
+export function createNewNotePath(
+  title: string,
+  selectedFolderPath: FolderScope,
+  existingNotePaths: readonly NoteFilePath[],
+): NoteFilePath {
+  const fileStem = sanitizeNoteFileStem(title);
+  const existingPathSet = new Set(existingNotePaths.map((path) => path.toLowerCase()));
+
+  for (let duplicateIndex = 0; duplicateIndex < Number.MAX_SAFE_INTEGER; duplicateIndex += 1) {
+    const suffix = duplicateIndex === 0 ? "" : ` ${duplicateIndex + 1}`;
+    const candidateFileName = `${fileStem}${suffix}.md`;
+    const candidatePath =
+      selectedFolderPath === null
+        ? candidateFileName
+        : `${normalizeFolderPath(selectedFolderPath)}/${candidateFileName}`;
+    const normalizedPath = normalizeNoteFilePath(candidatePath);
+
+    if (!existingPathSet.has(normalizedPath.toLowerCase())) {
+      return normalizedPath;
+    }
+  }
+
+  throw new Error("A unique Markdown path could not be generated for the new note.");
+}
+
+export function insertCreatedNotePath(
+  notePaths: readonly NoteFilePath[],
+  createdNotePath: NoteFilePath,
+): NoteFilePath[] {
+  return [...notePaths, createdNotePath].sort(compareWorkspacePaths);
+}
+
+function sanitizeNoteFileStem(title: string): string {
+  const sanitizedTitle = title
+    .replace(INVALID_FILE_NAME_CHARACTERS, " ")
+    .replace(WHITESPACE, " ")
+    .trim()
+    .replaceAll(".", " ")
+    .replace(WHITESPACE, " ")
+    .trim();
+
+  return sanitizedTitle === "" ? "Untitled" : sanitizedTitle;
+}

--- a/apps/desktop/src/features/folder-navigation/ui/FolderNavigationWorkspace.tsx
+++ b/apps/desktop/src/features/folder-navigation/ui/FolderNavigationWorkspace.tsx
@@ -952,7 +952,7 @@ export function FolderNavigationWorkspace() {
   }
 
   const createNoteInSelectedFolder = useCallback(async (): Promise<void> => {
-    if (scanState.status !== "ready") {
+    if (scanState.status !== "ready" || createState.status === "creating") {
       return;
     }
 
@@ -1023,7 +1023,14 @@ export function FolderNavigationWorkspace() {
         errorMessage: getNoteCreateErrorMessage(error),
       });
     }
-  }, [createTitle, noteEditBuffer, scanState.status, selectedFolderPath, workspaceState.notes]);
+  }, [
+    createState.status,
+    createTitle,
+    noteEditBuffer,
+    scanState.status,
+    selectedFolderPath,
+    workspaceState.notes,
+  ]);
 
   function markSelectedNoteDraftSaved(buffer: NoteEditBuffer): void {
     setNoteEditBuffer((currentBuffer) => {

--- a/apps/desktop/src/features/folder-navigation/ui/FolderNavigationWorkspace.tsx
+++ b/apps/desktop/src/features/folder-navigation/ui/FolderNavigationWorkspace.tsx
@@ -12,6 +12,7 @@ import type { FolderScope, FolderTreeNode } from "@grove/core";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 
 import {
+  createMarkdownNote,
   moveMarkdownFile,
   readMarkdownNote,
   refreshNoteIndexes,
@@ -28,6 +29,7 @@ import {
   renameFolderInWorkspace,
 } from "../model/folderWorkspaceState";
 import { createDesktopPathChangeExecutor } from "../model/folderPathChangeExecutor";
+import { createNewNotePath } from "../model/noteCreation";
 import {
   canSaveNoteEditBuffer,
   createCleanNoteEditBuffer,
@@ -83,6 +85,10 @@ type NoteListProps = {
   scopedNotes: readonly NoteListItem[];
   selectedNoteId: string;
   scanState: WorkspaceScanState;
+  createState: NoteCreateState;
+  createTitle: string;
+  onCreateTitleChange: (title: string) => void;
+  onCreateNote: () => void;
   onSelectNote: (noteId: string) => void;
 };
 
@@ -130,6 +136,11 @@ type PathChangeQueueProps = {
 
 type WorkspaceScanState = {
   status: "loading" | "ready" | "failed";
+  errorMessage: string | null;
+};
+
+type NoteCreateState = {
+  status: "idle" | "creating" | "failed";
   errorMessage: string | null;
 };
 
@@ -241,6 +252,10 @@ function getNoteReadErrorMessage(error: unknown): string {
 
 function getNoteSaveErrorMessage(error: unknown): string {
   return error instanceof Error ? error.message : "The Markdown note could not be saved.";
+}
+
+function getNoteCreateErrorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : "The Markdown note could not be created.";
 }
 
 const noteSaveBlockedMessage = "Wait for this note's path change to finish before saving.";
@@ -392,6 +407,10 @@ function NoteList({
   scopedNotes,
   selectedNoteId,
   scanState,
+  createState,
+  createTitle,
+  onCreateTitleChange,
+  onCreateNote,
   onSelectNote,
 }: NoteListProps) {
   return (
@@ -399,6 +418,34 @@ function NoteList({
       <p className="folder-navigation__eyebrow">{getFolderLabel(selectedFolderPath)}</p>
       <h2 className="folder-navigation__heading">Notes</h2>
       <WorkspaceScanBanner scanState={scanState} />
+      <div className="folder-navigation__operation">
+        <label className="folder-navigation__label" htmlFor="create-note-title">
+          New note
+        </label>
+        <input
+          id="create-note-title"
+          className="folder-navigation__input"
+          value={createTitle}
+          onChange={(event) => onCreateTitleChange(event.target.value)}
+          placeholder={
+            selectedFolderPath === null
+              ? "Untitled"
+              : `Untitled in ${getFolderDisplayName(selectedFolderPath)}`
+          }
+          disabled={createState.status === "creating" || scanState.status === "loading"}
+        />
+        <button
+          type="button"
+          className="folder-navigation__action"
+          onClick={onCreateNote}
+          disabled={createState.status === "creating" || scanState.status === "loading"}
+        >
+          {createState.status === "creating" ? "Creating" : "Create note"}
+        </button>
+        {createState.errorMessage === null ? null : (
+          <p className="folder-navigation__step-error">{createState.errorMessage}</p>
+        )}
+      </div>
       {scopedNotes.length > 0 ? (
         <ol className="folder-navigation__notes">
           {scopedNotes.map((note) => (
@@ -770,6 +817,11 @@ export function FolderNavigationWorkspace() {
   const [noteEditBuffer, setNoteEditBuffer] = useState<NoteEditBuffer | null>(null);
   const [editorLoadState, setEditorLoadState] = useState<NoteEditorLoadState>({ status: "idle" });
   const [editorNotice, setEditorNotice] = useState<string | null>(null);
+  const [createTitle, setCreateTitle] = useState("");
+  const [createState, setCreateState] = useState<NoteCreateState>({
+    status: "idle",
+    errorMessage: null,
+  });
   const [scanState, setScanState] = useState<WorkspaceScanState>({
     status: "loading",
     errorMessage: null,
@@ -895,6 +947,69 @@ export function FolderNavigationWorkspace() {
     setEditorNotice(null);
   }
 
+  const createNoteInSelectedFolder = useCallback(async (): Promise<void> => {
+    if (scanState.status !== "ready") {
+      return;
+    }
+
+    if (isNoteEditBufferBlockingWorkspaceChange(noteEditBuffer)) {
+      setCreateState({
+        status: "failed",
+        errorMessage: "Save or discard the current draft before creating another note.",
+      });
+      return;
+    }
+
+    const nextPath = createNewNotePath(
+      createTitle,
+      selectedFolderPath,
+      workspaceState.notes.map((note) => note.path),
+    );
+
+    setCreateState({
+      status: "creating",
+      errorMessage: null,
+    });
+
+    try {
+      const createdNote = await createMarkdownNote({
+        path: nextPath,
+        content: "",
+      });
+      const [mappedNote] = mapScannedMarkdownNotes([createdNote]);
+
+      if (mappedNote === undefined) {
+        throw new Error("The created Markdown note metadata was missing.");
+      }
+
+      setWorkspaceState((currentState) =>
+        reconcileFolderWorkspaceState({
+          ...currentState,
+          notes: [...currentState.notes, mappedNote].sort((left, right) =>
+            compareWorkspacePaths(left.path, right.path),
+          ),
+          selectedFolderPath,
+          expandedFolderPaths: [
+            ...currentState.expandedFolderPaths,
+            ...getExpandedFolderPathsForNotes([mappedNote]),
+          ],
+        }),
+      );
+      setSelectedNoteId(mappedNote.id);
+      setCreateTitle("");
+      setCreateState({
+        status: "idle",
+        errorMessage: null,
+      });
+      setEditorNotice(null);
+    } catch (error) {
+      setCreateState({
+        status: "failed",
+        errorMessage: getNoteCreateErrorMessage(error),
+      });
+    }
+  }, [createTitle, noteEditBuffer, scanState.status, selectedFolderPath, workspaceState.notes]);
+
   function markSelectedNoteDraftSaved(buffer: NoteEditBuffer): void {
     setNoteEditBuffer((currentBuffer) => {
       if (currentBuffer === null || currentBuffer.noteId !== buffer.noteId) {
@@ -1000,6 +1115,10 @@ export function FolderNavigationWorkspace() {
         setSelectedNoteId(notes[0]?.id ?? "");
         setScanState({
           status: "ready",
+          errorMessage: null,
+        });
+        setCreateState({
+          status: "idle",
           errorMessage: null,
         });
       } catch (error) {
@@ -1128,6 +1247,17 @@ export function FolderNavigationWorkspace() {
         scopedNotes={scopedNotes}
         selectedNoteId={selectedNoteId}
         scanState={scanState}
+        createState={createState}
+        createTitle={createTitle}
+        onCreateTitleChange={(title) => {
+          setCreateTitle(title);
+          if (createState.errorMessage !== null) {
+            setCreateState({ status: "idle", errorMessage: null });
+          }
+        }}
+        onCreateNote={() => {
+          void createNoteInSelectedFolder();
+        }}
         onSelectNote={selectNote}
       />
       <ActivePane

--- a/apps/desktop/src/features/folder-navigation/ui/FolderNavigationWorkspace.tsx
+++ b/apps/desktop/src/features/folder-navigation/ui/FolderNavigationWorkspace.tsx
@@ -258,6 +258,10 @@ function getNoteCreateErrorMessage(error: unknown): string {
   return error instanceof Error ? error.message : "The Markdown note could not be created.";
 }
 
+function getNoteIndexRefreshErrorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : "The note indexes could not be refreshed.";
+}
+
 const noteSaveBlockedMessage = "Wait for this note's path change to finish before saving.";
 
 function WorkspaceScanBanner({ scanState }: { scanState: WorkspaceScanState }) {
@@ -1002,6 +1006,17 @@ export function FolderNavigationWorkspace() {
         errorMessage: null,
       });
       setEditorNotice(null);
+
+      try {
+        await refreshNoteIndexes({
+          noteIds: [mappedNote.id],
+          reason: "note-create",
+        });
+      } catch (error) {
+        setEditorNotice(
+          `Created, but index refresh failed: ${getNoteIndexRefreshErrorMessage(error)}`,
+        );
+      }
     } catch (error) {
       setCreateState({
         status: "failed",

--- a/apps/desktop/src/shared/api/commands.test.ts
+++ b/apps/desktop/src/shared/api/commands.test.ts
@@ -2,6 +2,7 @@ import { invoke } from "@tauri-apps/api/core";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import {
+  createMarkdownNote,
   moveMarkdownFile,
   readMarkdownNote,
   refreshNoteIndexes,
@@ -71,6 +72,31 @@ describe("desktop command wrappers", () => {
       },
     ]);
     expect(invokeMock).toHaveBeenCalledWith("scan_markdown_workspace", {});
+  });
+
+  it("invokes the Markdown note create command", async () => {
+    invokeMock.mockResolvedValue({
+      path: "Projects/Grove/Plan.md",
+      title: "Plan",
+      updatedAtUnixMs: 1776265200000,
+    });
+
+    await expect(
+      createMarkdownNote({
+        path: "Projects/Grove/Plan.md",
+        content: "",
+      }),
+    ).resolves.toStrictEqual({
+      path: "Projects/Grove/Plan.md",
+      title: "Plan",
+      updatedAtUnixMs: 1776265200000,
+    });
+    expect(invokeMock).toHaveBeenCalledWith("create_markdown_note", {
+      note: {
+        path: "Projects/Grove/Plan.md",
+        content: "",
+      },
+    });
   });
 
   it("invokes the Markdown note read command", async () => {
@@ -161,5 +187,16 @@ describe("desktop command wrappers", () => {
         nextPath: "Reading/Plan.md",
       }),
     ).rejects.toThrow("The target Markdown file already exists.");
+  });
+
+  it("rejects invalid Markdown note create metadata", async () => {
+    invokeMock.mockResolvedValue({ path: "Projects/Grove/Plan.md", title: "Plan" });
+
+    await expect(
+      createMarkdownNote({
+        path: "Projects/Grove/Plan.md",
+        content: "",
+      }),
+    ).rejects.toThrow("invalid note metadata");
   });
 });

--- a/apps/desktop/src/shared/api/commands.ts
+++ b/apps/desktop/src/shared/api/commands.ts
@@ -8,7 +8,7 @@ export type MoveMarkdownFileCommand = {
 
 export type RefreshNoteIndexesCommand = {
   noteIds: readonly string[];
-  reason: "note-move" | "folder-rename" | "note-save";
+  reason: "note-move" | "folder-rename" | "note-save" | "note-create";
 };
 
 export type ScannedMarkdownNote = {

--- a/apps/desktop/src/shared/api/commands.ts
+++ b/apps/desktop/src/shared/api/commands.ts
@@ -17,6 +17,11 @@ export type ScannedMarkdownNote = {
   updatedAtUnixMs: number;
 };
 
+export type CreateMarkdownNoteCommand = {
+  path: string;
+  content: string;
+};
+
 export type ReadMarkdownNoteCommand = {
   path: string;
 };
@@ -39,6 +44,18 @@ export async function scanMarkdownWorkspace(): Promise<ScannedMarkdownNote[]> {
 
   if (!isScannedMarkdownNotes(result)) {
     throw new Error("The desktop scan command returned an invalid note list.");
+  }
+
+  return result;
+}
+
+export async function createMarkdownNote(
+  command: CreateMarkdownNoteCommand,
+): Promise<ScannedMarkdownNote> {
+  const result = await invokeCommandResult("create_markdown_note", { note: command });
+
+  if (!isScannedMarkdownNote(result)) {
+    throw new Error("The desktop create command returned invalid note metadata.");
   }
 
   return result;

--- a/apps/desktop/src/shared/index.ts
+++ b/apps/desktop/src/shared/index.ts
@@ -1,4 +1,5 @@
 export {
+  createMarkdownNote,
   moveMarkdownFile,
   readMarkdownNote,
   refreshNoteIndexes,
@@ -6,6 +7,7 @@ export {
   writeMarkdownNote,
 } from "./api/commands";
 export type {
+  CreateMarkdownNoteCommand,
   MoveMarkdownFileCommand,
   ReadMarkdownNoteCommand,
   RefreshNoteIndexesCommand,


### PR DESCRIPTION
## Summary
- add a desktop note creation command that creates workspace-relative Markdown files without overwriting existing paths
- add note path generation helpers that sanitize titles, scope new files to the selected folder, and disambiguate collisions predictably
- add a New note control to the desktop folder navigation UI that creates and opens notes in place

## Testing
- pnpm --filter @grove/desktop test
- cargo test
- pnpm --filter @grove/desktop typecheck
- pnpm --filter @grove/desktop build
- pnpm lint
- pnpm format
- git diff --check

Refs #51
