### PR TITLE
Integrate desktop Markdown editor commands

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -13,6 +13,7 @@
   },
   "dependencies": {
     "@grove/core": "workspace:*",
+    "@grove/editor": "workspace:*",
     "@grove/plugin-api": "workspace:*",
     "@tanstack/react-router": "^1.168.21",
     "@tauri-apps/api": "^2.0.0",

--- a/apps/desktop/src/features/folder-navigation/model/markdownEditor.test.ts
+++ b/apps/desktop/src/features/folder-navigation/model/markdownEditor.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from "vitest";
+
+import { dispatchMarkdownEditorCommand } from "./markdownEditor";
+
+describe("dispatchMarkdownEditorCommand", () => {
+  it("returns the next controlled value and restored selection", () => {
+    expect(
+      dispatchMarkdownEditorCommand({
+        content: "Save often",
+        selection: { start: 5, end: 10 },
+        command: "bold",
+      }),
+    ).toEqual({
+      content: "Save **often**",
+      selection: { start: 7, end: 12 },
+    });
+  });
+});

--- a/apps/desktop/src/features/folder-navigation/model/markdownEditor.ts
+++ b/apps/desktop/src/features/folder-navigation/model/markdownEditor.ts
@@ -1,0 +1,32 @@
+import { applyMarkdownCommand } from "@grove/editor";
+import type { MarkdownCommand, MarkdownSelection } from "@grove/editor";
+
+export type MarkdownEditorCommandDispatch = {
+  content: string;
+  selection: MarkdownSelection;
+  command: MarkdownCommand;
+};
+
+export type MarkdownEditorCommandDispatchResult = {
+  content: string;
+  selection: MarkdownSelection;
+};
+
+export function dispatchMarkdownEditorCommand({
+  content,
+  selection,
+  command,
+}: MarkdownEditorCommandDispatch): MarkdownEditorCommandDispatchResult {
+  const result = applyMarkdownCommand(
+    {
+      value: content,
+      selection,
+    },
+    command,
+  );
+
+  return {
+    content: result.value,
+    selection: result.selection,
+  };
+}

--- a/apps/desktop/src/features/folder-navigation/ui/FolderNavigationWorkspace.css
+++ b/apps/desktop/src/features/folder-navigation/ui/FolderNavigationWorkspace.css
@@ -205,6 +205,13 @@
   gap: 0.75rem;
 }
 
+.folder-navigation__markdown-toolbar {
+  align-items: center;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}
+
 .folder-navigation__editor p {
   line-height: 1.6;
   margin: 0;
@@ -345,8 +352,20 @@
   width: fit-content;
 }
 
+.folder-navigation__format-action {
+  background: #eef1ec;
+  border: 1px solid #c8d3ca;
+  border-radius: 8px;
+  color: #17211b;
+  cursor: pointer;
+  min-height: 2rem;
+  padding: 0 0.625rem;
+  width: fit-content;
+}
+
 .folder-navigation__action:disabled,
 .folder-navigation__secondary-action:disabled,
+.folder-navigation__format-action:disabled,
 .folder-navigation__input:disabled {
   cursor: not-allowed;
   opacity: 0.55;

--- a/apps/desktop/src/features/folder-navigation/ui/FolderNavigationWorkspace.tsx
+++ b/apps/desktop/src/features/folder-navigation/ui/FolderNavigationWorkspace.tsx
@@ -684,6 +684,7 @@ function NoteEditor({
             key={item.command}
             type="button"
             className="folder-navigation__format-action"
+            onMouseDown={(event) => event.preventDefault()}
             onClick={() => dispatchMarkdownCommand(item.command)}
             disabled={editorDisabled}
           >

--- a/apps/desktop/src/features/folder-navigation/ui/FolderNavigationWorkspace.tsx
+++ b/apps/desktop/src/features/folder-navigation/ui/FolderNavigationWorkspace.tsx
@@ -9,7 +9,8 @@ import {
   normalizeFolderScope,
 } from "@grove/core";
 import type { FolderScope, FolderTreeNode } from "@grove/core";
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import type { MarkdownCommand, MarkdownSelection } from "@grove/editor";
+import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from "react";
 
 import {
   createMarkdownNote,
@@ -29,6 +30,7 @@ import {
   renameFolderInWorkspace,
 } from "../model/folderWorkspaceState";
 import { createDesktopPathChangeExecutor } from "../model/folderPathChangeExecutor";
+import { dispatchMarkdownEditorCommand } from "../model/markdownEditor";
 import { createNewNotePath } from "../model/noteCreation";
 import {
   canSaveNoteEditBuffer,
@@ -263,6 +265,14 @@ function getNoteIndexRefreshErrorMessage(error: unknown): string {
 }
 
 const noteSaveBlockedMessage = "Wait for this note's path change to finish before saving.";
+
+const markdownToolbarCommands: readonly { command: MarkdownCommand; label: string }[] = [
+  { command: "bold", label: "Bold" },
+  { command: "italic", label: "Italic" },
+  { command: "heading", label: "Heading" },
+  { command: "link", label: "Link" },
+  { command: "code", label: "Code" },
+];
 
 function WorkspaceScanBanner({ scanState }: { scanState: WorkspaceScanState }) {
   if (scanState.status === "loading") {
@@ -593,6 +603,22 @@ function NoteEditor({
   saveBlockedReason,
   onDiscardDraft,
 }: NoteEditorProps) {
+  const textareaRef = useRef<HTMLTextAreaElement | null>(null);
+  const pendingSelectionRef = useRef<MarkdownSelection | null>(null);
+
+  useLayoutEffect(() => {
+    const pendingSelection = pendingSelectionRef.current;
+    const textarea = textareaRef.current;
+
+    if (pendingSelection === null || textarea === null) {
+      return;
+    }
+
+    textarea.setSelectionRange(pendingSelection.start, pendingSelection.end);
+    textarea.focus();
+    pendingSelectionRef.current = null;
+  }, [noteEditBuffer?.draftContent]);
+
   if (selectedNote === undefined) {
     return <p>Select a note to edit its Markdown content.</p>;
   }
@@ -603,6 +629,28 @@ function NoteEditor({
 
   if (noteEditBuffer === null || noteEditBuffer.noteId !== selectedNote.id) {
     return <p className="folder-navigation__muted">Markdown content is not loaded.</p>;
+  }
+
+  const editorDisabled = noteEditBuffer.status === "error" || noteEditBuffer.status === "saving";
+
+  function dispatchMarkdownCommand(command: MarkdownCommand): void {
+    const textarea = textareaRef.current;
+
+    if (textarea === null || noteEditBuffer === null) {
+      return;
+    }
+
+    const result = dispatchMarkdownEditorCommand({
+      content: noteEditBuffer.draftContent,
+      selection: {
+        start: textarea.selectionStart,
+        end: textarea.selectionEnd,
+      },
+      command,
+    });
+
+    pendingSelectionRef.current = result.selection;
+    onEditContent(result.content);
   }
 
   return (
@@ -630,6 +678,19 @@ function NoteEditor({
           Discard draft
         </button>
       </div>
+      <div className="folder-navigation__markdown-toolbar" aria-label="Markdown formatting">
+        {markdownToolbarCommands.map((item) => (
+          <button
+            key={item.command}
+            type="button"
+            className="folder-navigation__format-action"
+            onClick={() => dispatchMarkdownCommand(item.command)}
+            disabled={editorDisabled}
+          >
+            {item.label}
+          </button>
+        ))}
+      </div>
       {noteEditBuffer.errorMessage === null ? null : (
         <p className="folder-navigation__step-error">{noteEditBuffer.errorMessage}</p>
       )}
@@ -640,10 +701,11 @@ function NoteEditor({
         <p className="folder-navigation__step-error">{saveBlockedReason}</p>
       )}
       <textarea
+        ref={textareaRef}
         className="folder-navigation__textarea"
         value={noteEditBuffer.draftContent}
         onChange={(event) => onEditContent(event.target.value)}
-        disabled={noteEditBuffer.status === "error" || noteEditBuffer.status === "saving"}
+        disabled={editorDisabled}
         aria-label={`Markdown content for ${selectedNote.title}`}
       />
     </div>

--- a/packages/editor/src/index.test.ts
+++ b/packages/editor/src/index.test.ts
@@ -1,9 +1,122 @@
 import { describe, expect, it } from "vitest";
 
-import { createEditorMode } from "./index";
+import { applyMarkdownCommand, createEditorMode, createMarkdownEditorAdapter } from "./index";
 
 describe("createEditorMode", () => {
   it("returns markdown as the initial editor mode", () => {
     expect(createEditorMode()).toBe("markdown");
+  });
+});
+
+describe("applyMarkdownCommand", () => {
+  it("wraps selected text with bold markers", () => {
+    expect(
+      applyMarkdownCommand(
+        {
+          value: "Write notes",
+          selection: { start: 6, end: 11 },
+        },
+        "bold",
+      ),
+    ).toEqual({
+      value: "Write **notes**",
+      selection: { start: 8, end: 13 },
+    });
+  });
+
+  it("wraps selected text with italic markers", () => {
+    expect(
+      applyMarkdownCommand(
+        {
+          value: "plain text",
+          selection: { start: 0, end: 5 },
+        },
+        "italic",
+      ),
+    ).toEqual({
+      value: "*plain* text",
+      selection: { start: 1, end: 6 },
+    });
+  });
+
+  it("wraps selected text with inline code markers", () => {
+    expect(
+      applyMarkdownCommand(
+        {
+          value: "Use command",
+          selection: { start: 4, end: 11 },
+        },
+        "code",
+      ),
+    ).toEqual({
+      value: "Use `command`",
+      selection: { start: 5, end: 12 },
+    });
+  });
+
+  it("creates a Markdown link around selected text", () => {
+    expect(
+      applyMarkdownCommand(
+        {
+          value: "Grove docs",
+          selection: { start: 0, end: 5 },
+        },
+        "link",
+      ),
+    ).toEqual({
+      value: "[Grove]() docs",
+      selection: { start: 1, end: 6 },
+    });
+  });
+
+  it("adds an H1 marker to the active line", () => {
+    expect(
+      applyMarkdownCommand(
+        {
+          value: "Intro\nDaily note",
+          selection: { start: 8, end: 13 },
+        },
+        "heading",
+      ),
+    ).toEqual({
+      value: "Intro\n# Daily note",
+      selection: { start: 10, end: 15 },
+    });
+  });
+
+  it("normalizes an existing heading marker to H1", () => {
+    expect(
+      applyMarkdownCommand(
+        {
+          value: "### Daily note",
+          selection: { start: 5, end: 10 },
+        },
+        "heading",
+      ),
+    ).toEqual({
+      value: "# Daily note",
+      selection: { start: 3, end: 8 },
+    });
+  });
+});
+
+describe("createMarkdownEditorAdapter", () => {
+  it("keeps value and selection state while dispatching commands", () => {
+    const adapter = createMarkdownEditorAdapter({
+      value: "Draft",
+      selection: { start: 0, end: 5 },
+    });
+
+    adapter.setValue("Draft note");
+    adapter.setSelection({ start: 6, end: 10 });
+
+    expect(adapter.dispatchCommand("bold")).toEqual({
+      value: "Draft **note**",
+      selection: { start: 8, end: 12 },
+    });
+    expect(adapter.getState()).toEqual({
+      value: "Draft **note**",
+      selection: { start: 8, end: 12 },
+    });
   });
 });

--- a/packages/editor/src/index.ts
+++ b/packages/editor/src/index.ts
@@ -1,5 +1,133 @@
 export type EditorMode = "markdown";
 
+export type MarkdownCommand = "bold" | "italic" | "heading" | "link" | "code";
+
+export type MarkdownSelection = {
+  start: number;
+  end: number;
+};
+
+export type MarkdownEditorState = {
+  value: string;
+  selection: MarkdownSelection;
+};
+
+export type MarkdownCommandResult = MarkdownEditorState;
+
+export type MarkdownEditorAdapter = {
+  getState: () => MarkdownEditorState;
+  setValue: (value: string) => void;
+  setSelection: (selection: MarkdownSelection) => void;
+  dispatchCommand: (command: MarkdownCommand) => MarkdownCommandResult;
+};
+
 export function createEditorMode(): EditorMode {
   return "markdown";
+}
+
+export function createMarkdownEditorAdapter(
+  initialState: MarkdownEditorState,
+): MarkdownEditorAdapter {
+  let state = normalizeMarkdownEditorState(initialState);
+
+  return {
+    getState: () => state,
+    setValue: (value) => {
+      state = normalizeMarkdownEditorState({
+        value,
+        selection: clampSelection(state.selection, value.length),
+      });
+    },
+    setSelection: (selection) => {
+      state = normalizeMarkdownEditorState({
+        value: state.value,
+        selection,
+      });
+    },
+    dispatchCommand: (command) => {
+      state = applyMarkdownCommand(state, command);
+      return state;
+    },
+  };
+}
+
+export function applyMarkdownCommand(
+  state: MarkdownEditorState,
+  command: MarkdownCommand,
+): MarkdownCommandResult {
+  const normalizedState = normalizeMarkdownEditorState(state);
+
+  if (command === "heading") {
+    return applyHeadingCommand(normalizedState);
+  }
+
+  if (command === "link") {
+    return wrapSelection(normalizedState, "[", "]()", 1, 1);
+  }
+
+  if (command === "bold") {
+    return wrapSelection(normalizedState, "**", "**", 2, 2);
+  }
+
+  if (command === "italic") {
+    return wrapSelection(normalizedState, "*", "*", 1, 1);
+  }
+
+  return wrapSelection(normalizedState, "`", "`", 1, 1);
+}
+
+function normalizeMarkdownEditorState(state: MarkdownEditorState): MarkdownEditorState {
+  return {
+    value: state.value,
+    selection: clampSelection(state.selection, state.value.length),
+  };
+}
+
+function clampSelection(selection: MarkdownSelection, valueLength: number): MarkdownSelection {
+  const start = Math.min(Math.max(selection.start, 0), valueLength);
+  const end = Math.min(Math.max(selection.end, 0), valueLength);
+
+  return start <= end ? { start, end } : { start: end, end: start };
+}
+
+function wrapSelection(
+  state: MarkdownEditorState,
+  prefix: string,
+  suffix: string,
+  selectionStartOffset: number,
+  selectionEndOffset: number,
+): MarkdownCommandResult {
+  const { value, selection } = state;
+  const selectedText = value.slice(selection.start, selection.end);
+  const nextValue = `${value.slice(0, selection.start)}${prefix}${selectedText}${suffix}${value.slice(selection.end)}`;
+  const nextSelectionStart = selection.start + selectionStartOffset;
+  const nextSelectionEnd = selection.end + selectionEndOffset;
+
+  return {
+    value: nextValue,
+    selection: {
+      start: nextSelectionStart,
+      end: nextSelectionEnd,
+    },
+  };
+}
+
+function applyHeadingCommand(state: MarkdownEditorState): MarkdownCommandResult {
+  const lineStart = state.value.lastIndexOf("\n", state.selection.start - 1) + 1;
+  const lineEndIndex = state.value.indexOf("\n", state.selection.start);
+  const lineEnd = lineEndIndex === -1 ? state.value.length : lineEndIndex;
+  const line = state.value.slice(lineStart, lineEnd);
+  const existingHeading = /^(#{1,6}\s+)/.exec(line);
+  const removedLength = existingHeading?.[0].length ?? 0;
+  const nextLine = existingHeading === null ? `# ${line}` : `# ${line.slice(removedLength)}`;
+  const nextValue = `${state.value.slice(0, lineStart)}${nextLine}${state.value.slice(lineEnd)}`;
+  const selectionDelta = existingHeading === null ? 2 : 2 - removedLength;
+
+  return {
+    value: nextValue,
+    selection: {
+      start: Math.max(lineStart + 2, state.selection.start + selectionDelta),
+      end: Math.max(lineStart + 2, state.selection.end + selectionDelta),
+    },
+  };
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -32,6 +32,9 @@ importers:
       '@grove/core':
         specifier: workspace:*
         version: link:../../packages/core
+      '@grove/editor':
+        specifier: workspace:*
+        version: link:../../packages/editor
       '@grove/plugin-api':
         specifier: workspace:*
         version: link:../../packages/plugin-api


### PR DESCRIPTION
## Summary
- add a framework-independent Markdown editor adapter in `@grove/editor`
- connect desktop note draft textarea to Markdown commands for bold, italic, heading, link, and code
- preserve textarea selection after command dispatch and cover command mapping with tests

## Testing
- pnpm test
- pnpm typecheck
- pnpm lint
- pnpm format
- pnpm --filter @grove/desktop build
- git diff --check
- git diff --cached --check

Refs #48
