### PR TITLE
Define note title derivation semantics

### DIFF
--- a/apps/desktop/src-tauri/src/main.rs
+++ b/apps/desktop/src-tauri/src/main.rs
@@ -350,7 +350,7 @@ async fn read_note_title(path: &Path) -> anyhow::Result<String> {
 
     let content = read_markdown_file(path).await?;
 
-    Ok(find_first_markdown_heading(&content).unwrap_or(fallback_title))
+    Ok(derive_markdown_title(&content, &fallback_title))
 }
 
 async fn read_markdown_file(path: &Path) -> anyhow::Result<String> {
@@ -494,25 +494,54 @@ async fn summarize_markdown_file(
     })
 }
 
+fn derive_markdown_title(content: &str, fallback_title: &str) -> String {
+    find_frontmatter_title(content)
+        .or_else(|| find_first_markdown_heading(content))
+        .unwrap_or_else(|| fallback_title.to_string())
+}
+
+fn find_frontmatter_title(content: &str) -> Option<String> {
+    let normalized_content = content.strip_prefix('\u{feff}').unwrap_or(content);
+    let mut lines = normalized_content.lines();
+
+    if lines.next()?.trim() != "---" {
+        return None;
+    }
+
+    for line in lines {
+        let trimmed_line = line.trim();
+
+        if matches!(trimmed_line, "---" | "...") {
+            return None;
+        }
+
+        let Some((key, raw_value)) = trimmed_line.split_once(':') else {
+            continue;
+        };
+
+        if !key.trim().eq_ignore_ascii_case("title") {
+            continue;
+        }
+
+        let title = strip_wrapping_quotes(raw_value.trim()).trim();
+
+        if !title.is_empty() {
+            return Some(title.to_string());
+        }
+    }
+
+    None
+}
+
 fn find_first_markdown_heading(content: &str) -> Option<String> {
     for line in content.lines() {
         let trimmed_line = line.trim_start();
-        let heading_marker_len = trimmed_line
-            .chars()
-            .take_while(|character| *character == '#')
-            .count();
 
-        if heading_marker_len == 0 || heading_marker_len > 6 {
+        if !trimmed_line.starts_with("# ") {
             continue;
         }
 
-        let heading_body = &trimmed_line[heading_marker_len..];
-
-        if !heading_body.starts_with(char::is_whitespace) {
-            continue;
-        }
-
-        let title = strip_closing_heading_marker(heading_body.trim());
+        let title = strip_closing_heading_marker(trimmed_line[2..].trim());
 
         if title.is_empty() {
             continue;
@@ -541,6 +570,19 @@ fn strip_closing_heading_marker(title: &str) -> &str {
     }
 
     trimmed_title
+}
+
+fn strip_wrapping_quotes(value: &str) -> &str {
+    let bytes = value.as_bytes();
+
+    if bytes.len() >= 2
+        && ((bytes[0] == b'"' && bytes[bytes.len() - 1] == b'"')
+            || (bytes[0] == b'\'' && bytes[bytes.len() - 1] == b'\''))
+    {
+        return value[1..value.len() - 1].trim();
+    }
+
+    value
 }
 
 async fn move_file_without_overwrite(previous_path: &Path, next_path: &Path) -> anyhow::Result<()> {
@@ -606,7 +648,8 @@ mod tests {
     };
 
     use super::{
-        create_markdown_file, find_first_markdown_heading, get_temporary_write_path,
+        create_markdown_file, derive_markdown_title, find_first_markdown_heading,
+        get_temporary_write_path,
         get_workspace_relative_markdown_path, move_file_without_overwrite, read_markdown_file,
         scan_markdown_files, system_time_to_unix_ms, validate_markdown_path, write_markdown_file,
     };
@@ -696,7 +739,7 @@ mod tests {
 
     #[test]
     fn reads_first_markdown_heading_as_title() {
-        let title = find_first_markdown_heading("#tag\n\n## Project plan ##\nbody")
+        let title = find_first_markdown_heading("#tag\n\n# Project plan ##\nbody")
             .expect("heading should be found");
 
         assert_eq!(title, "Project plan");
@@ -707,6 +750,24 @@ mod tests {
         let title = find_first_markdown_heading("# C#").expect("heading should be found");
 
         assert_eq!(title, "C#");
+    }
+
+    #[test]
+    fn derives_title_from_frontmatter_before_heading() {
+        assert_eq!(
+            derive_markdown_title("---\ntitle: \"Roadmap\"\n---\n# Plan", "Plan"),
+            "Roadmap"
+        );
+    }
+
+    #[test]
+    fn derives_title_from_first_h1_before_the_file_stem() {
+        assert_eq!(derive_markdown_title("## Context\n# Plan ###", "Fallback"), "Plan");
+    }
+
+    #[test]
+    fn falls_back_to_the_file_stem_when_content_has_no_explicit_title() {
+        assert_eq!(derive_markdown_title("Body", "Daily Plan"), "Daily Plan");
     }
 
     #[test]

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -133,6 +133,25 @@ path 変更後の一貫性:
 - watcher や index 更新が途中失敗しても Markdown ファイルを正本とし、次回 scan で index を再同期できる状態を維持する
 - folder tree、scoped note list、note count は保存せず、更新後の path 集合から再導出する
 
+## ノートタイトルと rename semantics
+
+ノートタイトルは次の優先順位で導出します。
+
+1. frontmatter の `title`
+2. 最初の Markdown H1 (`# Title`)
+3. file stem (`Project Plan.md` -> `Project Plan`)
+
+この優先順位は `packages/core` の pure helper が定義し、desktop の scan/save metadata も同じルールに合わせます。
+
+title の変更ルール:
+
+- frontmatter `title` を編集した場合は metadata change として扱い、file path は変えない
+- H1 を編集した場合も metadata change として扱い、file path は変えない
+- frontmatter と H1 がないノートでは file stem がタイトルの正本なので、表示タイトルを変えるには Markdown file path を rename する
+- file rename は既存の path semantics に従って collision を検証し、他ノートを silent overwrite しない
+
+この境界により、ローカル Markdown ファイルと UI の title 表示が一貫し、明示タイトルを持つノートと file-name-driven なノートの振る舞いを分けて扱えます。
+
 リンク、タグ、その他 metadata は folder 階層の正本ではありません。
 folder path 変更後は `packages/db` が `core` の path semantics と WikiLink 解決ルールを呼び、SQLite index を再構築または更新します。
 

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -14,6 +14,8 @@ export {
   renameFolderInNotePath,
 } from "./folders";
 export type { FolderPath, FolderScope, FolderTreeNode, NoteFilePath } from "./folders";
+export { deriveNoteTitle, renameNoteFilePath } from "./titles";
+export type { DerivedNoteTitle, DerivedNoteTitleSource } from "./titles";
 
 export type NoteLink = {
   fromId: string;

--- a/packages/core/src/titles.test.ts
+++ b/packages/core/src/titles.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from "vitest";
+
+import { deriveNoteTitle, normalizeNoteFilePath, renameNoteFilePath } from "./index";
+
+describe("deriveNoteTitle", () => {
+  it("prefers a frontmatter title over other title sources", () => {
+    expect(
+      deriveNoteTitle(
+        normalizeNoteFilePath("Projects/Grove/Plan.md"),
+        ["---", 'title: "Roadmap"', "---", "# Plan"].join("\n"),
+      ),
+    ).toStrictEqual({
+      title: "Roadmap",
+      source: "frontmatter",
+    });
+  });
+
+  it("uses the first H1 when frontmatter does not define a title", () => {
+    expect(
+      deriveNoteTitle(
+        normalizeNoteFilePath("Projects/Grove/Plan.md"),
+        ["## Context", "# Plan ###", "## Follow-up"].join("\n"),
+      ),
+    ).toStrictEqual({
+      title: "Plan",
+      source: "heading",
+    });
+  });
+
+  it("falls back to the file stem when the content has no explicit title", () => {
+    expect(deriveNoteTitle(normalizeNoteFilePath("Projects/Grove/Daily Plan.md"), "Body")).toStrictEqual({
+      title: "Daily Plan",
+      source: "file-stem",
+    });
+  });
+});
+
+describe("renameNoteFilePath", () => {
+  it("renames a note inside its existing folder", () => {
+    expect(
+      renameNoteFilePath(normalizeNoteFilePath("Projects/Grove/Plan.md"), "Roadmap", []),
+    ).toBe("Projects/Grove/Roadmap.md");
+  });
+
+  it("sanitizes the title before producing the next Markdown path", () => {
+    expect(renameNoteFilePath(normalizeNoteFilePath("Inbox.md"), "Roadmap: Q2/2026?", [])).toBe(
+      "Roadmap Q2 2026.md",
+    );
+  });
+
+  it("rejects case-insensitive collisions with existing note paths", () => {
+    expect(() =>
+      renameNoteFilePath(normalizeNoteFilePath("Projects/Grove/Plan.md"), "Research", [
+        normalizeNoteFilePath("Projects/Grove/research.md"),
+      ]),
+    ).toThrow("target Markdown path");
+  });
+});

--- a/packages/core/src/titles.ts
+++ b/packages/core/src/titles.ts
@@ -1,0 +1,153 @@
+import { getFolderPathForNote, normalizeNoteFilePath } from "./folders";
+import type { NoteFilePath } from "./folders";
+
+export type DerivedNoteTitleSource = "frontmatter" | "heading" | "file-stem";
+
+export type DerivedNoteTitle = {
+  title: string;
+  source: DerivedNoteTitleSource;
+};
+
+const FRONTMATTER_DELIMITER = "---";
+const FRONTMATTER_END_DELIMITERS = new Set(["---", "..."]);
+const FRONTMATTER_TITLE_PATTERN = /^title\s*:\s*(.+)$/i;
+const INVALID_FILE_NAME_CHARACTERS = /[\p{Cc}<>:"/\\|?*]/gu;
+const WHITESPACE = /\s+/g;
+
+export function deriveNoteTitle(notePath: NoteFilePath, content: string): DerivedNoteTitle {
+  const frontmatterTitle = findFrontmatterTitle(content);
+
+  if (frontmatterTitle !== null) {
+    return {
+      title: frontmatterTitle,
+      source: "frontmatter",
+    };
+  }
+
+  const headingTitle = findFirstMarkdownHeading(content);
+
+  if (headingTitle !== null) {
+    return {
+      title: headingTitle,
+      source: "heading",
+    };
+  }
+
+  return {
+    title: getNoteFileStem(notePath),
+    source: "file-stem",
+  };
+}
+
+export function renameNoteFilePath(
+  notePath: NoteFilePath,
+  nextTitle: string,
+  existingNotePaths: readonly NoteFilePath[],
+): NoteFilePath {
+  const fileName = `${sanitizeNoteFileStem(nextTitle)}.md`;
+  const folderPath = getFolderPathForNote(notePath);
+  const nextPath = normalizeNoteFilePath(
+    folderPath === null ? fileName : `${folderPath}/${fileName}`,
+  );
+
+  const hasCollision = existingNotePaths.some((existingPath) => {
+    return existingPath !== notePath && existingPath.toLowerCase() === nextPath.toLowerCase();
+  });
+
+  if (hasCollision) {
+    throw new Error("A note already uses the target Markdown path.");
+  }
+
+  return nextPath;
+}
+
+function findFrontmatterTitle(content: string): string | null {
+  const normalizedContent = content.startsWith("\uFEFF") ? content.slice(1) : content;
+  const lines = normalizedContent.split(/\r?\n/u);
+
+  if (lines[0]?.trim() !== FRONTMATTER_DELIMITER) {
+    return null;
+  }
+
+  for (let index = 1; index < lines.length; index += 1) {
+    const line = lines[index]?.trim() ?? "";
+
+    if (FRONTMATTER_END_DELIMITERS.has(line)) {
+      return null;
+    }
+
+    const match = FRONTMATTER_TITLE_PATTERN.exec(line);
+
+    if (match === null) {
+      continue;
+    }
+
+    const title = stripWrappingQuotes(match[1]?.trim() ?? "");
+
+    if (title.length > 0) {
+      return title;
+    }
+  }
+
+  return null;
+}
+
+function findFirstMarkdownHeading(content: string): string | null {
+  for (const line of content.split(/\r?\n/u)) {
+    const trimmedLine = line.trimStart();
+
+    if (!trimmedLine.startsWith("# ") || trimmedLine.startsWith("##")) {
+      continue;
+    }
+
+    const title = stripClosingHeadingMarker(trimmedLine.slice(2).trim());
+
+    if (title.length > 0) {
+      return title;
+    }
+  }
+
+  return null;
+}
+
+function stripClosingHeadingMarker(title: string): string {
+  const trimmedTitle = title.trimEnd();
+  const withoutHashes = trimmedTitle.replace(/\s+#+$/u, "");
+
+  return withoutHashes.length > 0 ? withoutHashes : trimmedTitle;
+}
+
+function stripWrappingQuotes(value: string): string {
+  if (value.length < 2) {
+    return value;
+  }
+
+  const firstCharacter = value[0];
+  const lastCharacter = value[value.length - 1];
+
+  if (
+    (firstCharacter === "\"" && lastCharacter === "\"") ||
+    (firstCharacter === "'" && lastCharacter === "'")
+  ) {
+    return value.slice(1, -1).trim();
+  }
+
+  return value;
+}
+
+function getNoteFileStem(notePath: NoteFilePath): string {
+  const fileName = notePath.split("/").at(-1) ?? "Untitled.md";
+  return fileName.replace(/\.md$/iu, "").trim() || "Untitled";
+}
+
+function sanitizeNoteFileStem(title: string): string {
+  const sanitizedTitle = title
+    .replace(INVALID_FILE_NAME_CHARACTERS, " ")
+    .replace(WHITESPACE, " ")
+    .trim()
+    .replaceAll(".", " ")
+    .replace(WHITESPACE, " ")
+    .trim();
+
+  return sanitizedTitle === "" ? "Untitled" : sanitizedTitle;
+}


### PR DESCRIPTION
## Summary
- add core note title derivation helpers with frontmatter, H1, and file-stem precedence
- add core rename-path collision validation for title-driven file renames and document the behavior
- align desktop Rust Markdown scan/save title metadata with the same precedence and add regression tests

## Testing
- pnpm test
- pnpm typecheck
- pnpm lint
- cargo test
- git diff --check
- git diff --cached --check

Refs #52
