### PR TITLE
Hide desktop path change queue outside development

### DIFF
--- a/apps/desktop/src/features/folder-navigation/ui/FolderNavigationWorkspace.css
+++ b/apps/desktop/src/features/folder-navigation/ui/FolderNavigationWorkspace.css
@@ -2,9 +2,16 @@
   background: #f7f8f5;
   color: #17211b;
   display: grid;
-  grid-template-columns: 18rem minmax(20rem, 26rem) minmax(20rem, 1fr) minmax(18rem, 24rem);
   min-height: 100vh;
   overflow-x: auto;
+}
+
+.folder-navigation--with-queue {
+  grid-template-columns: 18rem minmax(20rem, 26rem) minmax(20rem, 1fr) minmax(18rem, 24rem);
+}
+
+.folder-navigation--without-queue {
+  grid-template-columns: 18rem minmax(20rem, 26rem) minmax(20rem, 1fr);
 }
 
 .folder-navigation__sidebar,

--- a/apps/desktop/src/features/folder-navigation/ui/FolderNavigationWorkspace.css
+++ b/apps/desktop/src/features/folder-navigation/ui/FolderNavigationWorkspace.css
@@ -44,6 +44,7 @@
   margin: 0 0 1rem;
 }
 
+.folder-navigation__pane-heading,
 .folder-navigation__queue-heading {
   align-items: center;
   display: flex;
@@ -53,6 +54,11 @@
   margin-bottom: 1rem;
 }
 
+.folder-navigation__pane-heading {
+  margin-bottom: 1rem;
+}
+
+.folder-navigation__pane-heading .folder-navigation__heading,
 .folder-navigation__queue-heading .folder-navigation__heading {
   margin: 0;
 }
@@ -64,7 +70,6 @@
   border-radius: 999px;
   color: #39483f;
   cursor: pointer;
-  margin: 1.25rem 1.25rem 0 0;
   min-height: 2.25rem;
   padding: 0 0.875rem;
   width: fit-content;
@@ -402,9 +407,5 @@
   .folder-navigation__pane {
     border-bottom: 1px solid #dce4dd;
     border-right: 0;
-  }
-
-  .folder-navigation__queue-toggle {
-    margin: 0 1.25rem 1.25rem;
   }
 }

--- a/apps/desktop/src/features/folder-navigation/ui/FolderNavigationWorkspace.css
+++ b/apps/desktop/src/features/folder-navigation/ui/FolderNavigationWorkspace.css
@@ -57,6 +57,19 @@
   margin: 0;
 }
 
+.folder-navigation__queue-toggle {
+  align-self: start;
+  background: #eef1ec;
+  border: 1px solid #c8d3ca;
+  border-radius: 999px;
+  color: #39483f;
+  cursor: pointer;
+  margin: 1.25rem 1.25rem 0 0;
+  min-height: 2.25rem;
+  padding: 0 0.875rem;
+  width: fit-content;
+}
+
 .folder-navigation__root-button,
 .folder-navigation__folder-button {
   align-items: center;
@@ -373,7 +386,8 @@
 .folder-navigation__action:disabled,
 .folder-navigation__secondary-action:disabled,
 .folder-navigation__format-action:disabled,
-.folder-navigation__input:disabled {
+.folder-navigation__input:disabled,
+.folder-navigation__queue-toggle:disabled {
   cursor: not-allowed;
   opacity: 0.55;
 }
@@ -388,5 +402,9 @@
   .folder-navigation__pane {
     border-bottom: 1px solid #dce4dd;
     border-right: 0;
+  }
+
+  .folder-navigation__queue-toggle {
+    margin: 0 1.25rem 1.25rem;
   }
 }

--- a/apps/desktop/src/features/folder-navigation/ui/FolderNavigationWorkspace.test.tsx
+++ b/apps/desktop/src/features/folder-navigation/ui/FolderNavigationWorkspace.test.tsx
@@ -1,0 +1,43 @@
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it } from "vitest";
+
+import {
+  FolderNavigationWorkspaceContent,
+  getFolderNavigationWorkspaceClassName,
+} from "./FolderNavigationWorkspace";
+
+describe("getFolderNavigationWorkspaceClassName", () => {
+  it("uses the four-column layout when the queue is visible", () => {
+    expect(getFolderNavigationWorkspaceClassName(true)).toBe(
+      "folder-navigation folder-navigation--with-queue",
+    );
+  });
+
+  it("uses the three-column layout when the queue is hidden", () => {
+    expect(getFolderNavigationWorkspaceClassName(false)).toBe(
+      "folder-navigation folder-navigation--without-queue",
+    );
+  });
+});
+
+describe("FolderNavigationWorkspaceContent", () => {
+  it("renders the path change queue in development mode", () => {
+    const markup = renderToStaticMarkup(
+      <FolderNavigationWorkspaceContent showPathChangeQueue={true} />,
+    );
+
+    expect(markup).toContain("Pending path changes");
+    expect(markup).toContain("Path change queue");
+    expect(markup).toContain("folder-navigation--with-queue");
+  });
+
+  it("hides the path change queue in production mode", () => {
+    const markup = renderToStaticMarkup(
+      <FolderNavigationWorkspaceContent showPathChangeQueue={false} />,
+    );
+
+    expect(markup).not.toContain("Pending path changes");
+    expect(markup).not.toContain("Path change queue");
+    expect(markup).toContain("folder-navigation--without-queue");
+  });
+});

--- a/apps/desktop/src/features/folder-navigation/ui/FolderNavigationWorkspace.test.tsx
+++ b/apps/desktop/src/features/folder-navigation/ui/FolderNavigationWorkspace.test.tsx
@@ -21,21 +21,38 @@ describe("getFolderNavigationWorkspaceClassName", () => {
 });
 
 describe("FolderNavigationWorkspaceContent", () => {
-  it("renders the path change queue in development mode", () => {
+  it("hides the path change queue by default in development mode and shows the toggle", () => {
     const markup = renderToStaticMarkup(
-      <FolderNavigationWorkspaceContent showPathChangeQueue={true} />,
+      <FolderNavigationWorkspaceContent isDevelopmentMode={true} />,
     );
 
+    expect(markup).toContain("Show path change diagnostics");
+    expect(markup).not.toContain("Pending path changes");
+    expect(markup).not.toContain("Path change queue");
+    expect(markup).toContain("folder-navigation--without-queue");
+  });
+
+  it("renders the path change queue when development diagnostics are expanded", () => {
+    const markup = renderToStaticMarkup(
+      <FolderNavigationWorkspaceContent
+        isDevelopmentMode={true}
+        initialPathChangeQueueVisibility={true}
+      />,
+    );
+
+    expect(markup).toContain("Hide path change diagnostics");
     expect(markup).toContain("Pending path changes");
     expect(markup).toContain("Path change queue");
     expect(markup).toContain("folder-navigation--with-queue");
   });
 
-  it("hides the path change queue in production mode", () => {
+  it("hides both the queue and the diagnostics toggle in production mode", () => {
     const markup = renderToStaticMarkup(
-      <FolderNavigationWorkspaceContent showPathChangeQueue={false} />,
+      <FolderNavigationWorkspaceContent isDevelopmentMode={false} />,
     );
 
+    expect(markup).not.toContain("Show path change diagnostics");
+    expect(markup).not.toContain("Hide path change diagnostics");
     expect(markup).not.toContain("Pending path changes");
     expect(markup).not.toContain("Path change queue");
     expect(markup).toContain("folder-navigation--without-queue");

--- a/apps/desktop/src/features/folder-navigation/ui/FolderNavigationWorkspace.tsx
+++ b/apps/desktop/src/features/folder-navigation/ui/FolderNavigationWorkspace.tsx
@@ -119,6 +119,9 @@ type ActivePaneProps = {
   onDiscardDraft: () => void;
   deleteBlockedReason: string | null;
   onDeleteSelectedNote: () => void;
+  isDevelopmentMode: boolean;
+  isPathChangeQueueVisible: boolean;
+  onTogglePathChangeQueue: () => void;
 };
 
 type MoveNoteControlProps = {
@@ -757,6 +760,9 @@ function ActivePane({
   onDiscardDraft,
   deleteBlockedReason,
   onDeleteSelectedNote,
+  isDevelopmentMode,
+  isPathChangeQueueVisible,
+  onTogglePathChangeQueue,
 }: ActivePaneProps) {
   const selectedNote = notes.find((note) => note.id === selectedNoteId) ?? notes[0];
   const [operationMessage, setOperationMessage] = useState<string>(
@@ -766,7 +772,20 @@ function ActivePane({
   return (
     <section className="folder-navigation__pane">
       <p className="folder-navigation__eyebrow">Active pane</p>
-      <h2 className="folder-navigation__heading">{selectedNote?.title ?? "No note selected"}</h2>
+      <div className="folder-navigation__pane-heading">
+        <h2 className="folder-navigation__heading">{selectedNote?.title ?? "No note selected"}</h2>
+        {isDevelopmentMode ? (
+          <button
+            type="button"
+            className="folder-navigation__queue-toggle"
+            onClick={onTogglePathChangeQueue}
+          >
+            {isPathChangeQueueVisible
+              ? "Hide path change diagnostics"
+              : "Show path change diagnostics"}
+          </button>
+        ) : null}
+      </div>
       <div className="folder-navigation__editor">
         {selectedNote === undefined ? (
           <p>Select a note to manage its workspace path.</p>
@@ -1532,18 +1551,12 @@ export function FolderNavigationWorkspaceContent({
         onDeleteSelectedNote={() => {
           void deleteSelectedNote();
         }}
+        isDevelopmentMode={isDevelopmentMode}
+        isPathChangeQueueVisible={isPathChangeQueueVisible}
+        onTogglePathChangeQueue={() => {
+          setIsPathChangeQueueVisible((currentVisibility) => !currentVisibility);
+        }}
       />
-      {isDevelopmentMode ? (
-        <button
-          type="button"
-          className="folder-navigation__queue-toggle"
-          onClick={() => {
-            setIsPathChangeQueueVisible((currentVisibility) => !currentVisibility);
-          }}
-        >
-          {isPathChangeQueueVisible ? "Hide path change diagnostics" : "Show path change diagnostics"}
-        </button>
-      ) : null}
       {isDevelopmentMode && isPathChangeQueueVisible ? (
         <PathChangeQueue
           operations={pathChangeOperations}

--- a/apps/desktop/src/features/folder-navigation/ui/FolderNavigationWorkspace.tsx
+++ b/apps/desktop/src/features/folder-navigation/ui/FolderNavigationWorkspace.tsx
@@ -142,6 +142,10 @@ type PathChangeQueueProps = {
   onRetryStep: (operationId: string, stepId: FolderWorkspaceOperationStepId) => void;
 };
 
+type FolderNavigationWorkspaceContentProps = {
+  showPathChangeQueue: boolean;
+};
+
 type WorkspaceScanState = {
   status: "loading" | "ready" | "failed";
   errorMessage: string | null;
@@ -922,7 +926,15 @@ function PathChangeQueue({
   );
 }
 
-export function FolderNavigationWorkspace() {
+export function getFolderNavigationWorkspaceClassName(showPathChangeQueue: boolean): string {
+  return showPathChangeQueue
+    ? "folder-navigation folder-navigation--with-queue"
+    : "folder-navigation folder-navigation--without-queue";
+}
+
+export function FolderNavigationWorkspaceContent({
+  showPathChangeQueue,
+}: FolderNavigationWorkspaceContentProps) {
   const [workspaceState, setWorkspaceState] = useState<FolderWorkspaceState>(initialWorkspaceState);
   const [selectedNoteId, setSelectedNoteId] = useState<string>("");
   const [noteEditBuffer, setNoteEditBuffer] = useState<NoteEditBuffer | null>(null);
@@ -1465,7 +1477,7 @@ export function FolderNavigationWorkspace() {
   }, [noteEditBuffer, pathChangeOperations, saveSelectedNoteDraft]);
 
   return (
-    <section className="folder-navigation">
+    <section className={getFolderNavigationWorkspaceClassName(showPathChangeQueue)}>
       <Sidebar
         noteCount={notes.length}
         folderTree={folderTree}
@@ -1514,15 +1526,21 @@ export function FolderNavigationWorkspace() {
           void deleteSelectedNote();
         }}
       />
-      <PathChangeQueue
-        operations={pathChangeOperations}
-        runningOperationIds={runningOperationIds}
-        onClearCompletedOperations={clearCompletedPathChanges}
-        onRunNextStep={(operationId) => {
-          void runNextPathChangeStep(operationId);
-        }}
-        onRetryStep={retryPathChangeStep}
-      />
+      {showPathChangeQueue ? (
+        <PathChangeQueue
+          operations={pathChangeOperations}
+          runningOperationIds={runningOperationIds}
+          onClearCompletedOperations={clearCompletedPathChanges}
+          onRunNextStep={(operationId) => {
+            void runNextPathChangeStep(operationId);
+          }}
+          onRetryStep={retryPathChangeStep}
+        />
+      ) : null}
     </section>
   );
+}
+
+export function FolderNavigationWorkspace() {
+  return <FolderNavigationWorkspaceContent showPathChangeQueue={import.meta.env.DEV} />;
 }

--- a/apps/desktop/src/features/folder-navigation/ui/FolderNavigationWorkspace.tsx
+++ b/apps/desktop/src/features/folder-navigation/ui/FolderNavigationWorkspace.tsx
@@ -143,7 +143,8 @@ type PathChangeQueueProps = {
 };
 
 type FolderNavigationWorkspaceContentProps = {
-  showPathChangeQueue: boolean;
+  isDevelopmentMode: boolean;
+  initialPathChangeQueueVisibility?: boolean;
 };
 
 type WorkspaceScanState = {
@@ -933,8 +934,12 @@ export function getFolderNavigationWorkspaceClassName(showPathChangeQueue: boole
 }
 
 export function FolderNavigationWorkspaceContent({
-  showPathChangeQueue,
+  isDevelopmentMode,
+  initialPathChangeQueueVisibility = false,
 }: FolderNavigationWorkspaceContentProps) {
+  const [isPathChangeQueueVisible, setIsPathChangeQueueVisible] = useState(
+    initialPathChangeQueueVisibility,
+  );
   const [workspaceState, setWorkspaceState] = useState<FolderWorkspaceState>(initialWorkspaceState);
   const [selectedNoteId, setSelectedNoteId] = useState<string>("");
   const [noteEditBuffer, setNoteEditBuffer] = useState<NoteEditBuffer | null>(null);
@@ -1477,7 +1482,9 @@ export function FolderNavigationWorkspaceContent({
   }, [noteEditBuffer, pathChangeOperations, saveSelectedNoteDraft]);
 
   return (
-    <section className={getFolderNavigationWorkspaceClassName(showPathChangeQueue)}>
+    <section
+      className={getFolderNavigationWorkspaceClassName(isDevelopmentMode && isPathChangeQueueVisible)}
+    >
       <Sidebar
         noteCount={notes.length}
         folderTree={folderTree}
@@ -1526,7 +1533,18 @@ export function FolderNavigationWorkspaceContent({
           void deleteSelectedNote();
         }}
       />
-      {showPathChangeQueue ? (
+      {isDevelopmentMode ? (
+        <button
+          type="button"
+          className="folder-navigation__queue-toggle"
+          onClick={() => {
+            setIsPathChangeQueueVisible((currentVisibility) => !currentVisibility);
+          }}
+        >
+          {isPathChangeQueueVisible ? "Hide path change diagnostics" : "Show path change diagnostics"}
+        </button>
+      ) : null}
+      {isDevelopmentMode && isPathChangeQueueVisible ? (
         <PathChangeQueue
           operations={pathChangeOperations}
           runningOperationIds={runningOperationIds}
@@ -1542,5 +1560,5 @@ export function FolderNavigationWorkspaceContent({
 }
 
 export function FolderNavigationWorkspace() {
-  return <FolderNavigationWorkspaceContent showPathChangeQueue={import.meta.env.DEV} />;
+  return <FolderNavigationWorkspaceContent isDevelopmentMode={import.meta.env.DEV} />;
 }


### PR DESCRIPTION
## Summary
- render the desktop path change queue only when the app is running in development mode
- collapse the folder navigation workspace from four columns to three when the queue panel is hidden
- add coverage for the development/production layout variants in the folder navigation workspace UI tests

## Testing
- pnpm --filter @grove/desktop test
- pnpm --filter @grove/desktop typecheck
- pnpm test
- pnpm typecheck
- pnpm lint
- pnpm --filter @grove/desktop build
- git diff --check

Refs #67
