### PR TITLE
Implement WikiLink parsing and backlinks

### DIFF
--- a/apps/desktop/src-tauri/src/main.rs
+++ b/apps/desktop/src-tauri/src/main.rs
@@ -73,6 +73,7 @@ struct IndexRefreshSidecarEntry {
 struct ScannedMarkdownNote {
     path: String,
     title: String,
+    content: String,
     updated_at_unix_ms: u128,
 }
 
@@ -361,19 +362,6 @@ fn system_time_to_unix_ms(time: SystemTime) -> u128 {
         .map_or(0, |duration| duration.as_millis())
 }
 
-async fn read_note_title(path: &Path) -> anyhow::Result<String> {
-    let fallback_title = path
-        .file_stem()
-        .and_then(|file_stem| file_stem.to_str())
-        .unwrap_or("Untitled")
-        .trim()
-        .to_string();
-
-    let content = read_markdown_file(path).await?;
-
-    Ok(derive_markdown_title(&content, &fallback_title))
-}
-
 async fn read_markdown_file(path: &Path) -> anyhow::Result<String> {
     let mut file = tokio::fs::File::open(path).await?;
     let mut content = String::new();
@@ -511,11 +499,19 @@ async fn summarize_markdown_file(
     let relative_path = get_workspace_relative_markdown_path(workspace_root, markdown_path)?;
     let metadata = tokio::fs::metadata(markdown_path).await?;
     let updated_at_unix_ms = system_time_to_unix_ms(metadata.modified()?);
-    let title = read_note_title(markdown_path).await?;
+    let content = read_markdown_file(markdown_path).await?;
+    let fallback_title = markdown_path
+        .file_stem()
+        .and_then(|file_stem| file_stem.to_str())
+        .unwrap_or("Untitled")
+        .trim()
+        .to_string();
+    let title = derive_markdown_title(&content, &fallback_title);
 
     Ok(ScannedMarkdownNote {
         path: relative_path,
         title,
+        content,
         updated_at_unix_ms,
     })
 }
@@ -820,8 +816,10 @@ mod tests {
             assert_eq!(notes.len(), 2);
             assert_eq!(notes[0].path, "Inbox.MD");
             assert_eq!(notes[0].title, "Inbox");
+            assert_eq!(notes[0].content, "no heading");
             assert_eq!(notes[1].path, "Projects/Plan.md");
             assert_eq!(notes[1].title, "Plan");
+            assert_eq!(notes[1].content, "# Plan\nbody");
             tokio::fs::remove_dir_all(&workspace_dir).await?;
             anyhow::Ok(())
         })

--- a/apps/desktop/src/features/folder-navigation/model/folderWorkspaceState.ts
+++ b/apps/desktop/src/features/folder-navigation/model/folderWorkspaceState.ts
@@ -11,6 +11,7 @@ export type FolderNavigationNote = {
   id: string;
   title: string;
   path: NoteFilePath;
+  content?: string;
   updatedLabel: string;
 };
 

--- a/apps/desktop/src/features/folder-navigation/model/noteSave.test.ts
+++ b/apps/desktop/src/features/folder-navigation/model/noteSave.test.ts
@@ -18,12 +18,14 @@ const workspaceState: FolderWorkspaceState = {
       id: "note-plan",
       path: normalizeNoteFilePath("Projects/Grove/Plan.md"),
       title: "Plan",
+      content: "# Plan",
       updatedLabel: "Apr 12",
     },
     {
       id: "note-research",
       path: normalizeNoteFilePath("Projects/Grove/Research.md"),
       title: "Research",
+      content: "# Research",
       updatedLabel: "Apr 11",
     },
   ],
@@ -40,6 +42,7 @@ describe("applySavedNoteMetadataToWorkspaceState", () => {
       savedNote: {
         path: "Projects/Grove/Plan.md",
         title: "Updated plan",
+        content: "# Updated plan\n\n[[Research]]",
         updatedAtUnixMs: Date.UTC(2026, 3, 15),
       },
     });
@@ -48,6 +51,7 @@ describe("applySavedNoteMetadataToWorkspaceState", () => {
       id: "note-plan",
       path: "Projects/Grove/Plan.md",
       title: "Updated plan",
+      content: "# Updated plan\n\n[[Research]]",
       updatedLabel: "Apr 15",
     });
   });
@@ -71,6 +75,7 @@ describe("applySavedNoteMetadataToWorkspaceState", () => {
       savedNote: {
         path: "Projects/Grove/Plan.md",
         title: "Updated plan",
+        content: "# Updated plan",
         updatedAtUnixMs: Date.UTC(2026, 3, 15),
       },
     });

--- a/apps/desktop/src/features/folder-navigation/model/workspaceScan.test.ts
+++ b/apps/desktop/src/features/folder-navigation/model/workspaceScan.test.ts
@@ -9,6 +9,7 @@ describe("mapScannedMarkdownNotes", () => {
         {
           path: "Projects\\Grove//Plan.md",
           title: " Workspace plan ",
+          content: "# Workspace plan",
           updatedAtUnixMs: Date.UTC(2026, 3, 15),
         },
       ]),
@@ -17,6 +18,7 @@ describe("mapScannedMarkdownNotes", () => {
         id: "Projects/Grove/Plan.md",
         path: "Projects/Grove/Plan.md",
         title: "Workspace plan",
+        content: "# Workspace plan",
         updatedLabel: "Apr 15",
       },
     ]);
@@ -28,6 +30,7 @@ describe("mapScannedMarkdownNotes", () => {
         {
           path: "Inbox.md",
           title: " ",
+          content: "",
           updatedAtUnixMs: Date.UTC(2026, 0, 2),
         },
       ]),
@@ -45,6 +48,7 @@ describe("mapScannedMarkdownNotes", () => {
         {
           path: "/Users/me/Notes/Plan.md",
           title: "Plan",
+          content: "",
           updatedAtUnixMs: Date.UTC(2026, 3, 15),
         },
       ]),

--- a/apps/desktop/src/features/folder-navigation/model/workspaceScan.ts
+++ b/apps/desktop/src/features/folder-navigation/model/workspaceScan.ts
@@ -24,6 +24,7 @@ function mapScannedMarkdownNote(scannedNote: ScannedMarkdownNote): FolderNavigat
     id: path,
     path,
     title,
+    content: scannedNote.content,
     updatedLabel: formatUpdatedLabel(scannedNote.updatedAtUnixMs),
   };
 }

--- a/apps/desktop/src/features/folder-navigation/ui/FolderNavigationWorkspace.css
+++ b/apps/desktop/src/features/folder-navigation/ui/FolderNavigationWorkspace.css
@@ -223,6 +223,57 @@
   gap: 0.75rem;
 }
 
+.folder-navigation__link-sections {
+  display: grid;
+  gap: 0.75rem;
+  grid-template-columns: repeat(auto-fit, minmax(14rem, 1fr));
+}
+
+.folder-navigation__link-section {
+  background: #f7f8f5;
+  border: 1px solid #dce4dd;
+  border-radius: 8px;
+  display: grid;
+  gap: 0.625rem;
+  padding: 0.875rem;
+}
+
+.folder-navigation__link-heading {
+  color: #17211b;
+  font-size: 0.875rem;
+  margin: 0;
+}
+
+.folder-navigation__link-list {
+  display: grid;
+  gap: 0.5rem;
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.folder-navigation__link-list li {
+  align-items: center;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}
+
+.folder-navigation__link-status {
+  background: #ddf3e7;
+  border: 1px solid #1f7a5c;
+  border-radius: 999px;
+  color: #1d5a45;
+  font-size: 0.75rem;
+  padding: 0.125rem 0.5rem;
+}
+
+.folder-navigation__link-status--unresolved {
+  background: #fff0d7;
+  border-color: #b7791f;
+  color: #74480e;
+}
+
 .folder-navigation__editor-toolbar {
   align-items: center;
   display: flex;

--- a/apps/desktop/src/features/folder-navigation/ui/FolderNavigationWorkspace.test.tsx
+++ b/apps/desktop/src/features/folder-navigation/ui/FolderNavigationWorkspace.test.tsx
@@ -1,7 +1,9 @@
+import { normalizeNoteFilePath } from "@grove/core";
 import { renderToStaticMarkup } from "react-dom/server";
 import { describe, expect, it } from "vitest";
 
 import {
+  ActivePane,
   FolderNavigationWorkspaceContent,
   getFolderNavigationWorkspaceClassName,
 } from "./FolderNavigationWorkspace";
@@ -56,5 +58,84 @@ describe("FolderNavigationWorkspaceContent", () => {
     expect(markup).not.toContain("Pending path changes");
     expect(markup).not.toContain("Path change queue");
     expect(markup).toContain("folder-navigation--without-queue");
+  });
+});
+
+describe("ActivePane", () => {
+  it("shows resolved links, unresolved references, and backlinks in the note pane", () => {
+    const markup = renderToStaticMarkup(
+      <ActivePane
+        notes={[
+          {
+            id: "note-plan",
+            path: normalizeNoteFilePath("Projects/Grove/Plan.md"),
+            title: "Plan",
+            content: "[[Research]] [[Missing|Untriaged]]",
+            updatedLabel: "Apr 19",
+          },
+        ]}
+        folderOptions={[]}
+        selectedFolderPath={null}
+        selectedNoteId="note-plan"
+        noteEditBuffer={null}
+        editorLoadState={{ status: "idle" }}
+        editorNotice={null}
+        deleteState={{ status: "idle", errorMessage: null }}
+        onMoveSelectedNote={() => {
+          throw new Error("not implemented in test");
+        }}
+        onRenameSelectedFolder={() => {
+          throw new Error("not implemented in test");
+        }}
+        onEditContent={() => {}}
+        onSaveDraft={() => {}}
+        saveBlockedReason={null}
+        onDiscardDraft={() => {}}
+        deleteBlockedReason={null}
+        onDeleteSelectedNote={() => {}}
+        isDevelopmentMode={false}
+        isPathChangeQueueVisible={false}
+        onTogglePathChangeQueue={() => {}}
+        selectedNoteLinks={[
+          {
+            target: "Research",
+            alias: null,
+            fromId: "note-plan",
+            toId: "note-research",
+            isResolved: true,
+          },
+          {
+            target: "Missing",
+            alias: "Untriaged",
+            fromId: "note-plan",
+            toId: null,
+            isResolved: false,
+          },
+        ]}
+        selectedNoteBacklinks={[
+          {
+            target: "Plan",
+            alias: "Project plan",
+            fromId: "note-review",
+            toId: "note-plan",
+            isResolved: true,
+          },
+        ]}
+        noteTitlesById={
+          new Map([
+            ["note-plan", "Plan"],
+            ["note-research", "Research"],
+            ["note-review", "Review"],
+          ])
+        }
+      />,
+    );
+
+    expect(markup).toContain("Links");
+    expect(markup).toContain("Backlinks");
+    expect(markup).toContain("Research");
+    expect(markup).toContain("Untriaged -&gt; Missing");
+    expect(markup).toContain("Review via Project plan");
+    expect(markup).toContain("Unresolved");
   });
 });

--- a/apps/desktop/src/features/folder-navigation/ui/FolderNavigationWorkspace.tsx
+++ b/apps/desktop/src/features/folder-navigation/ui/FolderNavigationWorkspace.tsx
@@ -7,8 +7,9 @@ import {
   isNoteInFolderScope,
   normalizeFolderPath,
   normalizeFolderScope,
+  resolveWikiLinks,
 } from "@grove/core";
-import type { FolderScope, FolderTreeNode } from "@grove/core";
+import type { FolderScope, FolderTreeNode, ResolvedWikiLink } from "@grove/core";
 import type { MarkdownCommand, MarkdownSelection } from "@grove/editor";
 import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from "react";
 
@@ -122,6 +123,9 @@ type ActivePaneProps = {
   isDevelopmentMode: boolean;
   isPathChangeQueueVisible: boolean;
   onTogglePathChangeQueue: () => void;
+  selectedNoteLinks: readonly ResolvedWikiLink[];
+  selectedNoteBacklinks: readonly ResolvedWikiLink[];
+  noteTitlesById: ReadonlyMap<string, string>;
 };
 
 type MoveNoteControlProps = {
@@ -180,6 +184,14 @@ type NoteEditorProps = {
   onDiscardDraft: () => void;
 };
 
+type NoteLinkListProps = {
+  kind: "outgoing" | "backlinks";
+  heading: string;
+  emptyMessage: string;
+  links: readonly ResolvedWikiLink[];
+  noteTitlesById: ReadonlyMap<string, string>;
+};
+
 const initialWorkspaceState: FolderWorkspaceState = {
   notes: [],
   explicitFolders: [],
@@ -229,6 +241,24 @@ function getPathChangeSummary(pathChanges: readonly FolderWorkspacePathChange[])
 
   const noun = pathChanges.length === 1 ? "change" : "changes";
   return `${pathChanges.length} file path ${noun} queued for file move and index refresh.`;
+}
+
+function getNoteLinkLabel(
+  link: ResolvedWikiLink,
+  noteTitlesById: ReadonlyMap<string, string>,
+  kind: NoteLinkListProps["kind"],
+): string {
+  if (kind === "backlinks") {
+    const sourceTitle = noteTitlesById.get(link.fromId) ?? link.fromId;
+    return link.alias === null ? sourceTitle : `${sourceTitle} via ${link.alias}`;
+  }
+
+  if (link.toId === null) {
+    return link.alias === null ? link.target : `${link.alias} -> ${link.target}`;
+  }
+
+  const targetTitle = noteTitlesById.get(link.toId) ?? link.target;
+  return link.alias === null ? targetTitle : `${link.alias} -> ${targetTitle}`;
 }
 
 function getOperationReasonLabel(reason: FolderWorkspacePathChangeOperation["reason"]): string {
@@ -743,7 +773,35 @@ function NoteEditor({
   );
 }
 
-function ActivePane({
+function NoteLinkList({ kind, heading, emptyMessage, links, noteTitlesById }: NoteLinkListProps) {
+  return (
+    <section className="folder-navigation__link-section" aria-label={heading}>
+      <h3 className="folder-navigation__link-heading">{heading}</h3>
+      {links.length === 0 ? (
+        <p className="folder-navigation__muted">{emptyMessage}</p>
+      ) : (
+        <ul className="folder-navigation__link-list">
+          {links.map((link, index) => (
+            <li key={`${link.fromId}-${link.target}-${link.alias ?? "no-alias"}-${index}`}>
+              <span
+                className={
+                  link.isResolved
+                    ? "folder-navigation__link-status"
+                    : "folder-navigation__link-status folder-navigation__link-status--unresolved"
+                }
+              >
+                {link.isResolved ? "Resolved" : "Unresolved"}
+              </span>
+              <span>{getNoteLinkLabel(link, noteTitlesById, kind)}</span>
+            </li>
+          ))}
+        </ul>
+      )}
+    </section>
+  );
+}
+
+export function ActivePane({
   notes,
   folderOptions,
   selectedFolderPath,
@@ -763,6 +821,9 @@ function ActivePane({
   isDevelopmentMode,
   isPathChangeQueueVisible,
   onTogglePathChangeQueue,
+  selectedNoteLinks,
+  selectedNoteBacklinks,
+  noteTitlesById,
 }: ActivePaneProps) {
   const selectedNote = notes.find((note) => note.id === selectedNoteId) ?? notes[0];
   const [operationMessage, setOperationMessage] = useState<string>(
@@ -802,6 +863,22 @@ function ActivePane({
               saveBlockedReason={saveBlockedReason}
               onDiscardDraft={onDiscardDraft}
             />
+            <div className="folder-navigation__link-sections">
+              <NoteLinkList
+                kind="outgoing"
+                heading="Links"
+                emptyMessage="No WikiLinks in this note yet."
+                links={selectedNoteLinks}
+                noteTitlesById={noteTitlesById}
+              />
+              <NoteLinkList
+                kind="backlinks"
+                heading="Backlinks"
+                emptyMessage="No backlinks point to this note yet."
+                links={selectedNoteBacklinks}
+                noteTitlesById={noteTitlesById}
+              />
+            </div>
             <MoveNoteControl
               folderOptions={folderOptions}
               selectedNoteFolderPath={getFolderPathForNote(selectedNote.path)}
@@ -1004,6 +1081,24 @@ export function FolderNavigationWorkspaceContent({
   const selectedNote = useMemo(() => {
     return notes.find((note) => note.id === selectedNoteId) ?? notes[0];
   }, [notes, selectedNoteId]);
+  const resolvedNoteLinks = useMemo(() => {
+    return resolveWikiLinks(
+      notes.map((note) => ({
+        id: note.id,
+        title: note.title,
+        content: note.content ?? "",
+      })),
+    );
+  }, [notes]);
+  const resolvedNoteLinksByNoteId = useMemo(() => {
+    return new Map(resolvedNoteLinks.map((noteLinks) => [noteLinks.noteId, noteLinks]));
+  }, [resolvedNoteLinks]);
+  const noteTitlesById = useMemo(() => {
+    return new Map(notes.map((note) => [note.id, note.title]));
+  }, [notes]);
+  const selectedResolvedNoteLinks = selectedNote
+    ? resolvedNoteLinksByNoteId.get(selectedNote.id) ?? null
+    : null;
   const saveBlockedReason =
     !canSaveNoteEditBuffer(noteEditBuffer) ||
     !isNoteSaveBlockedByPathChange(pathChangeOperations, noteEditBuffer.noteId)
@@ -1556,6 +1651,9 @@ export function FolderNavigationWorkspaceContent({
         onTogglePathChangeQueue={() => {
           setIsPathChangeQueueVisible((currentVisibility) => !currentVisibility);
         }}
+        selectedNoteLinks={selectedResolvedNoteLinks?.links ?? []}
+        selectedNoteBacklinks={selectedResolvedNoteLinks?.backlinks ?? []}
+        noteTitlesById={noteTitlesById}
       />
       {isDevelopmentMode && isPathChangeQueueVisible ? (
         <PathChangeQueue

--- a/apps/desktop/src/shared/api/commands.test.ts
+++ b/apps/desktop/src/shared/api/commands.test.ts
@@ -61,6 +61,7 @@ describe("desktop command wrappers", () => {
       {
         path: "Projects/Grove/Plan.md",
         title: "Workspace plan",
+        content: "# Workspace plan\n\nDraft",
         updatedAtUnixMs: 1776265200000,
       },
     ]);
@@ -69,6 +70,7 @@ describe("desktop command wrappers", () => {
       {
         path: "Projects/Grove/Plan.md",
         title: "Workspace plan",
+        content: "# Workspace plan\n\nDraft",
         updatedAtUnixMs: 1776265200000,
       },
     ]);
@@ -79,6 +81,7 @@ describe("desktop command wrappers", () => {
     invokeMock.mockResolvedValue({
       path: "Projects/Grove/Plan.md",
       title: "Plan",
+      content: "",
       updatedAtUnixMs: 1776265200000,
     });
 
@@ -90,6 +93,7 @@ describe("desktop command wrappers", () => {
     ).resolves.toStrictEqual({
       path: "Projects/Grove/Plan.md",
       title: "Plan",
+      content: "",
       updatedAtUnixMs: 1776265200000,
     });
     expect(invokeMock).toHaveBeenCalledWith("create_markdown_note", {
@@ -117,6 +121,7 @@ describe("desktop command wrappers", () => {
     invokeMock.mockResolvedValue({
       path: "Projects/Grove/Plan.md",
       title: "Workspace plan",
+      content: "# Workspace plan\n\nSaved",
       updatedAtUnixMs: 1776265200000,
     });
 
@@ -128,6 +133,7 @@ describe("desktop command wrappers", () => {
     ).resolves.toStrictEqual({
       path: "Projects/Grove/Plan.md",
       title: "Workspace plan",
+      content: "# Workspace plan\n\nSaved",
       updatedAtUnixMs: 1776265200000,
     });
     expect(invokeMock).toHaveBeenCalledWith("write_markdown_note", {
@@ -180,6 +186,7 @@ describe("desktop command wrappers", () => {
       {
         path: "Projects/Grove/Plan.md",
         title: "Plan",
+        content: "",
         updatedAtUnixMs: Number.POSITIVE_INFINITY,
       },
     ]);

--- a/apps/desktop/src/shared/api/commands.ts
+++ b/apps/desktop/src/shared/api/commands.ts
@@ -14,6 +14,7 @@ export type RefreshNoteIndexesCommand = {
 export type ScannedMarkdownNote = {
   path: string;
   title: string;
+  content: string;
   updatedAtUnixMs: number;
 };
 
@@ -143,6 +144,8 @@ function isScannedMarkdownNote(value: unknown): value is ScannedMarkdownNote {
     typeof value.path === "string" &&
     "title" in value &&
     typeof value.title === "string" &&
+    "content" in value &&
+    typeof value.content === "string" &&
     "updatedAtUnixMs" in value &&
     typeof value.updatedAtUnixMs === "number" &&
     Number.isFinite(value.updatedAtUnixMs) &&

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -16,6 +16,8 @@ export {
 export type { FolderPath, FolderScope, FolderTreeNode, NoteFilePath } from "./folders";
 export { deriveNoteTitle, renameNoteFilePath } from "./titles";
 export type { DerivedNoteTitle, DerivedNoteTitleSource } from "./titles";
+export { parseWikiLinks, resolveWikiLinks } from "./wikiLinks";
+export type { ParsedWikiLink, ResolvedNoteLinks, ResolvedWikiLink, WikiLinkNote } from "./wikiLinks";
 
 export type NoteLink = {
   fromId: string;

--- a/packages/core/src/wikiLinks.test.ts
+++ b/packages/core/src/wikiLinks.test.ts
@@ -1,0 +1,147 @@
+import { describe, expect, it } from "vitest";
+
+import { parseWikiLinks, resolveWikiLinks } from "./index";
+
+describe("parseWikiLinks", () => {
+  it("parses plain and aliased WikiLinks from Markdown content", () => {
+    expect(parseWikiLinks("See [[Plan]] and [[Project Roadmap|Roadmap]].")).toStrictEqual([
+      {
+        target: "Plan",
+        alias: null,
+      },
+      {
+        target: "Project Roadmap",
+        alias: "Roadmap",
+      },
+    ]);
+  });
+
+  it("ignores empty WikiLink targets", () => {
+    expect(parseWikiLinks("[[]] [[ | Alias ]] [[Plan| ]]")).toStrictEqual([
+      {
+        target: "Plan",
+        alias: null,
+      },
+    ]);
+  });
+});
+
+describe("resolveWikiLinks", () => {
+  it("resolves outgoing links and derives backlinks", () => {
+    const resolved = resolveWikiLinks([
+      {
+        id: "note-plan",
+        title: "Plan",
+        content: "Links to [[Research]] and [[Unknown]].",
+      },
+      {
+        id: "note-research",
+        title: "Research",
+        content: "See [[Plan|the plan]].",
+      },
+    ]);
+
+    expect(resolved).toStrictEqual([
+      {
+        noteId: "note-plan",
+        links: [
+          {
+            target: "Research",
+            alias: null,
+            fromId: "note-plan",
+            toId: "note-research",
+            isResolved: true,
+          },
+          {
+            target: "Unknown",
+            alias: null,
+            fromId: "note-plan",
+            toId: null,
+            isResolved: false,
+          },
+        ],
+        backlinks: [
+          {
+            target: "Plan",
+            alias: "the plan",
+            fromId: "note-research",
+            toId: "note-plan",
+            isResolved: true,
+          },
+        ],
+      },
+      {
+        noteId: "note-research",
+        links: [
+          {
+            target: "Plan",
+            alias: "the plan",
+            fromId: "note-research",
+            toId: "note-plan",
+            isResolved: true,
+          },
+        ],
+        backlinks: [
+          {
+            target: "Research",
+            alias: null,
+            fromId: "note-plan",
+            toId: "note-research",
+            isResolved: true,
+          },
+        ],
+      },
+    ]);
+  });
+
+  it("resolves duplicate titles predictably by keeping the first matching note", () => {
+    const [firstNote, secondNote, linkSource] = resolveWikiLinks([
+      {
+        id: "note-plan-a",
+        title: "Plan",
+        content: "",
+      },
+      {
+        id: "note-plan-b",
+        title: "Plan",
+        content: "",
+      },
+      {
+        id: "note-source",
+        title: "Source",
+        content: "[[Plan]]",
+      },
+    ]);
+
+    expect(firstNote.backlinks).toHaveLength(1);
+    expect(firstNote.backlinks[0]?.fromId).toBe("note-source");
+    expect(secondNote.backlinks).toHaveLength(0);
+    expect(linkSource.links[0]?.toId).toBe("note-plan-a");
+  });
+
+  it("keeps unresolved links visible without crashing resolution", () => {
+    expect(
+      resolveWikiLinks([
+        {
+          id: "note-plan",
+          title: "Plan",
+          content: "[[Missing]]",
+        },
+      ]),
+    ).toStrictEqual([
+      {
+        noteId: "note-plan",
+        links: [
+          {
+            target: "Missing",
+            alias: null,
+            fromId: "note-plan",
+            toId: null,
+            isResolved: false,
+          },
+        ],
+        backlinks: [],
+      },
+    ]);
+  });
+});

--- a/packages/core/src/wikiLinks.ts
+++ b/packages/core/src/wikiLinks.ts
@@ -1,0 +1,99 @@
+export type ParsedWikiLink = {
+  target: string;
+  alias: string | null;
+};
+
+export type WikiLinkNote = {
+  id: string;
+  title: string;
+  content: string;
+};
+
+export type ResolvedWikiLink = ParsedWikiLink & {
+  fromId: string;
+  toId: string | null;
+  isResolved: boolean;
+};
+
+export type ResolvedNoteLinks = {
+  noteId: string;
+  links: readonly ResolvedWikiLink[];
+  backlinks: readonly ResolvedWikiLink[];
+};
+
+const WIKI_LINK_PATTERN = /\[\[([^[\]\r\n]+?)\]\]/gu;
+
+export function parseWikiLinks(content: string): ParsedWikiLink[] {
+  const wikiLinks: ParsedWikiLink[] = [];
+
+  for (const match of content.matchAll(WIKI_LINK_PATTERN)) {
+    const rawLink = match[1]?.trim() ?? "";
+
+    if (rawLink.length === 0) {
+      continue;
+    }
+
+    const [rawTarget, ...rawAliasParts] = rawLink.split("|");
+    const target = rawTarget?.trim() ?? "";
+
+    if (target.length === 0) {
+      continue;
+    }
+
+    const aliasValue = rawAliasParts.join("|").trim();
+
+    wikiLinks.push({
+      target,
+      alias: aliasValue.length === 0 ? null : aliasValue,
+    });
+  }
+
+  return wikiLinks;
+}
+
+export function resolveWikiLinks(notes: readonly WikiLinkNote[]): ResolvedNoteLinks[] {
+  const canonicalNoteIdsByTitle = new Map<string, string>();
+
+  for (const note of notes) {
+    const canonicalTitle = note.title.trim().toLocaleLowerCase();
+
+    if (canonicalTitle.length === 0 || canonicalNoteIdsByTitle.has(canonicalTitle)) {
+      continue;
+    }
+
+    canonicalNoteIdsByTitle.set(canonicalTitle, note.id);
+  }
+
+  const outgoingLinksByNoteId = new Map<string, ResolvedWikiLink[]>();
+  const backlinksByNoteId = new Map<string, ResolvedWikiLink[]>();
+
+  for (const note of notes) {
+    const resolvedLinks = parseWikiLinks(note.content).map((wikiLink) => {
+      const resolvedNoteId = canonicalNoteIdsByTitle.get(wikiLink.target.toLocaleLowerCase()) ?? null;
+
+      return {
+        ...wikiLink,
+        fromId: note.id,
+        toId: resolvedNoteId,
+        isResolved: resolvedNoteId !== null,
+      };
+    });
+
+    outgoingLinksByNoteId.set(note.id, resolvedLinks);
+
+    for (const resolvedLink of resolvedLinks) {
+      if (resolvedLink.toId === null) {
+        continue;
+      }
+
+      const backlinks = backlinksByNoteId.get(resolvedLink.toId) ?? [];
+      backlinksByNoteId.set(resolvedLink.toId, [...backlinks, resolvedLink]);
+    }
+  }
+
+  return notes.map((note) => ({
+    noteId: note.id,
+    links: outgoingLinksByNoteId.get(note.id) ?? [],
+    backlinks: backlinksByNoteId.get(note.id) ?? [],
+  }));
+}


### PR DESCRIPTION
## Summary
- add core WikiLink parsing and deterministic link resolution with derived backlinks
- include Markdown content in desktop scan/save metadata so links and backlinks can be recomputed from the loaded note collection
- show resolved and unresolved links plus backlinks in the desktop note pane with regression coverage

## Testing
- pnpm test
- pnpm typecheck
- pnpm lint
- pnpm --filter @grove/desktop build
- cargo test

Refs #56
