### PR TITLE
Simplify desktop workspace to two panes

### DIFF
--- a/apps/desktop/src/features/folder-navigation/ui/FolderNavigationWorkspace.css
+++ b/apps/desktop/src/features/folder-navigation/ui/FolderNavigationWorkspace.css
@@ -2,16 +2,16 @@
   background: #f7f8f5;
   color: #17211b;
   display: grid;
+  grid-template-columns: minmax(18rem, 24rem) minmax(24rem, 1fr);
   min-height: 100vh;
   overflow-x: auto;
 }
 
-.folder-navigation--with-queue {
-  grid-template-columns: 18rem minmax(20rem, 26rem) minmax(20rem, 1fr) minmax(18rem, 24rem);
-}
-
-.folder-navigation--without-queue {
-  grid-template-columns: 18rem minmax(20rem, 26rem) minmax(20rem, 1fr);
+.folder-navigation__navigation {
+  border-right: 1px solid #dce4dd;
+  display: grid;
+  gap: 1.25rem;
+  padding: 1.25rem;
 }
 
 .folder-navigation__sidebar,
@@ -21,10 +21,14 @@
   padding: 1.25rem;
 }
 
-.folder-navigation__sidebar,
-.folder-navigation__note-list,
 .folder-navigation__pane {
-  border-right: 1px solid #dce4dd;
+  border-right: 0;
+}
+
+.folder-navigation__sidebar,
+.folder-navigation__note-list {
+  border: 1px solid #dce4dd;
+  border-radius: 12px;
 }
 
 .folder-navigation__eyebrow {
@@ -453,8 +457,7 @@
     grid-template-columns: minmax(18rem, 1fr);
   }
 
-  .folder-navigation__sidebar,
-  .folder-navigation__note-list,
+  .folder-navigation__navigation,
   .folder-navigation__pane {
     border-bottom: 1px solid #dce4dd;
     border-right: 0;

--- a/apps/desktop/src/features/folder-navigation/ui/FolderNavigationWorkspace.test.tsx
+++ b/apps/desktop/src/features/folder-navigation/ui/FolderNavigationWorkspace.test.tsx
@@ -9,16 +9,12 @@ import {
 } from "./FolderNavigationWorkspace";
 
 describe("getFolderNavigationWorkspaceClassName", () => {
-  it("uses the four-column layout when the queue is visible", () => {
-    expect(getFolderNavigationWorkspaceClassName(true)).toBe(
-      "folder-navigation folder-navigation--with-queue",
-    );
+  it("keeps the same two-pane layout when the queue is visible", () => {
+    expect(getFolderNavigationWorkspaceClassName(true)).toBe("folder-navigation");
   });
 
-  it("uses the three-column layout when the queue is hidden", () => {
-    expect(getFolderNavigationWorkspaceClassName(false)).toBe(
-      "folder-navigation folder-navigation--without-queue",
-    );
+  it("keeps the same two-pane layout when the queue is hidden", () => {
+    expect(getFolderNavigationWorkspaceClassName(false)).toBe("folder-navigation");
   });
 });
 
@@ -31,7 +27,7 @@ describe("FolderNavigationWorkspaceContent", () => {
     expect(markup).toContain("Show path change diagnostics");
     expect(markup).not.toContain("Pending path changes");
     expect(markup).not.toContain("Path change queue");
-    expect(markup).toContain("folder-navigation--without-queue");
+    expect(markup).toContain("folder-navigation__navigation");
   });
 
   it("renders the path change queue when development diagnostics are expanded", () => {
@@ -45,7 +41,7 @@ describe("FolderNavigationWorkspaceContent", () => {
     expect(markup).toContain("Hide path change diagnostics");
     expect(markup).toContain("Pending path changes");
     expect(markup).toContain("Path change queue");
-    expect(markup).toContain("folder-navigation--with-queue");
+    expect(markup).toContain("folder-navigation__navigation");
   });
 
   it("hides both the queue and the diagnostics toggle in production mode", () => {
@@ -57,7 +53,7 @@ describe("FolderNavigationWorkspaceContent", () => {
     expect(markup).not.toContain("Hide path change diagnostics");
     expect(markup).not.toContain("Pending path changes");
     expect(markup).not.toContain("Path change queue");
-    expect(markup).toContain("folder-navigation--without-queue");
+    expect(markup).toContain("folder-navigation__navigation");
   });
 });
 
@@ -96,6 +92,11 @@ describe("ActivePane", () => {
         isDevelopmentMode={false}
         isPathChangeQueueVisible={false}
         onTogglePathChangeQueue={() => {}}
+        pathChangeOperations={[]}
+        runningOperationIds={[]}
+        onClearCompletedOperations={() => {}}
+        onRunNextStep={() => {}}
+        onRetryStep={() => {}}
         selectedNoteLinks={[
           {
             target: "Research",

--- a/apps/desktop/src/features/folder-navigation/ui/FolderNavigationWorkspace.tsx
+++ b/apps/desktop/src/features/folder-navigation/ui/FolderNavigationWorkspace.tsx
@@ -98,6 +98,8 @@ type NoteListProps = {
   onSelectNote: (noteId: string) => void;
 };
 
+type NavigationPaneProps = SidebarProps & NoteListProps;
+
 type FolderOption = {
   path: FolderScope;
   label: string;
@@ -123,6 +125,11 @@ type ActivePaneProps = {
   isDevelopmentMode: boolean;
   isPathChangeQueueVisible: boolean;
   onTogglePathChangeQueue: () => void;
+  pathChangeOperations: readonly FolderWorkspacePathChangeOperation[];
+  runningOperationIds: readonly string[];
+  onClearCompletedOperations: () => void;
+  onRunNextStep: (operationId: string) => void;
+  onRetryStep: (operationId: string, stepId: FolderWorkspaceOperationStepId) => void;
   selectedNoteLinks: readonly ResolvedWikiLink[];
   selectedNoteBacklinks: readonly ResolvedWikiLink[];
   noteTitlesById: ReadonlyMap<string, string>;
@@ -476,6 +483,47 @@ function Sidebar({
   );
 }
 
+function NavigationPane({
+  noteCount,
+  folderTree,
+  selectedFolderPath,
+  expandedFolderPaths,
+  onSelect,
+  onToggle,
+  scopedNotes,
+  selectedNoteId,
+  scanState,
+  createState,
+  createTitle,
+  onCreateTitleChange,
+  onCreateNote,
+  onSelectNote,
+}: NavigationPaneProps) {
+  return (
+    <aside className="folder-navigation__navigation">
+      <Sidebar
+        noteCount={noteCount}
+        folderTree={folderTree}
+        selectedFolderPath={selectedFolderPath}
+        expandedFolderPaths={expandedFolderPaths}
+        onSelect={onSelect}
+        onToggle={onToggle}
+      />
+      <NoteList
+        selectedFolderPath={selectedFolderPath}
+        scopedNotes={scopedNotes}
+        selectedNoteId={selectedNoteId}
+        scanState={scanState}
+        createState={createState}
+        createTitle={createTitle}
+        onCreateTitleChange={onCreateTitleChange}
+        onCreateNote={onCreateNote}
+        onSelectNote={onSelectNote}
+      />
+    </aside>
+  );
+}
+
 function NoteList({
   selectedFolderPath,
   scopedNotes,
@@ -821,6 +869,11 @@ export function ActivePane({
   isDevelopmentMode,
   isPathChangeQueueVisible,
   onTogglePathChangeQueue,
+  pathChangeOperations,
+  runningOperationIds,
+  onClearCompletedOperations,
+  onRunNextStep,
+  onRetryStep,
   selectedNoteLinks,
   selectedNoteBacklinks,
   noteTitlesById,
@@ -906,6 +959,15 @@ export function ActivePane({
             </div>
           </>
         )}
+        {isDevelopmentMode && isPathChangeQueueVisible ? (
+          <PathChangeQueue
+            operations={pathChangeOperations}
+            runningOperationIds={runningOperationIds}
+            onClearCompletedOperations={onClearCompletedOperations}
+            onRunNextStep={onRunNextStep}
+            onRetryStep={onRetryStep}
+          />
+        ) : null}
         <RenameFolderControl
           selectedFolderPath={selectedFolderPath}
           onRenameSelectedFolder={onRenameSelectedFolder}
@@ -1024,9 +1086,8 @@ function PathChangeQueue({
 }
 
 export function getFolderNavigationWorkspaceClassName(showPathChangeQueue: boolean): string {
-  return showPathChangeQueue
-    ? "folder-navigation folder-navigation--with-queue"
-    : "folder-navigation folder-navigation--without-queue";
+  void showPathChangeQueue;
+  return "folder-navigation";
 }
 
 export function FolderNavigationWorkspaceContent({
@@ -1599,16 +1660,13 @@ export function FolderNavigationWorkspaceContent({
     <section
       className={getFolderNavigationWorkspaceClassName(isDevelopmentMode && isPathChangeQueueVisible)}
     >
-      <Sidebar
+      <NavigationPane
         noteCount={notes.length}
         folderTree={folderTree}
         selectedFolderPath={selectedFolderPath}
         expandedFolderPaths={expandedFolderPaths}
         onSelect={selectFolder}
         onToggle={toggleFolder}
-      />
-      <NoteList
-        selectedFolderPath={selectedFolderPath}
         scopedNotes={scopedNotes}
         selectedNoteId={selectedNoteId}
         scanState={scanState}
@@ -1651,21 +1709,17 @@ export function FolderNavigationWorkspaceContent({
         onTogglePathChangeQueue={() => {
           setIsPathChangeQueueVisible((currentVisibility) => !currentVisibility);
         }}
+        pathChangeOperations={pathChangeOperations}
+        runningOperationIds={runningOperationIds}
+        onClearCompletedOperations={clearCompletedPathChanges}
+        onRunNextStep={(operationId) => {
+          void runNextPathChangeStep(operationId);
+        }}
+        onRetryStep={retryPathChangeStep}
         selectedNoteLinks={selectedResolvedNoteLinks?.links ?? []}
         selectedNoteBacklinks={selectedResolvedNoteLinks?.backlinks ?? []}
         noteTitlesById={noteTitlesById}
       />
-      {isDevelopmentMode && isPathChangeQueueVisible ? (
-        <PathChangeQueue
-          operations={pathChangeOperations}
-          runningOperationIds={runningOperationIds}
-          onClearCompletedOperations={clearCompletedPathChanges}
-          onRunNextStep={(operationId) => {
-            void runNextPathChangeStep(operationId);
-          }}
-          onRetryStep={retryPathChangeStep}
-        />
-      ) : null}
     </section>
   );
 }


### PR DESCRIPTION
## Summary
- merge the desktop folder tree and note list into a single navigation pane
- keep the editor as the second pane and move the path change queue into the editor surface instead of a separate column
- update workspace layout tests to assert the new two-pane structure

## Testing
- pnpm --filter @grove/desktop test -- FolderNavigationWorkspace
- pnpm --filter @grove/desktop typecheck
- pnpm lint
- pnpm --filter @grove/desktop build
- git diff --check

Refs #74
