### PR TITLE
Move desktop workspace actions into contextual disclosures

### DIFF
--- a/apps/desktop/src/features/folder-navigation/ui/FolderNavigationWorkspace.css
+++ b/apps/desktop/src/features/folder-navigation/ui/FolderNavigationWorkspace.css
@@ -228,6 +228,33 @@
   padding: 1rem;
 }
 
+.folder-navigation__disclosure {
+  background: #f7f8f5;
+  border: 1px solid #dce4dd;
+  border-radius: 8px;
+  display: grid;
+  gap: 0.75rem;
+  padding: 0.75rem;
+}
+
+.folder-navigation__disclosure-toggle {
+  align-items: center;
+  background: transparent;
+  border: 0;
+  color: #17211b;
+  cursor: pointer;
+  display: flex;
+  justify-content: space-between;
+  padding: 0;
+  text-align: left;
+  width: 100%;
+}
+
+.folder-navigation__disclosure-content {
+  display: grid;
+  gap: 0.75rem;
+}
+
 .folder-navigation__editor-stack {
   display: grid;
   gap: 0.75rem;

--- a/apps/desktop/src/features/folder-navigation/ui/FolderNavigationWorkspace.test.tsx
+++ b/apps/desktop/src/features/folder-navigation/ui/FolderNavigationWorkspace.test.tsx
@@ -1,4 +1,4 @@
-import { normalizeNoteFilePath } from "@grove/core";
+import { normalizeFolderPath, normalizeNoteFilePath } from "@grove/core";
 import { renderToStaticMarkup } from "react-dom/server";
 import { describe, expect, it } from "vitest";
 
@@ -58,8 +58,10 @@ describe("FolderNavigationWorkspaceContent", () => {
 });
 
 describe("ActivePane", () => {
-  it("shows resolved links, unresolved references, and backlinks in the note pane", () => {
-    const markup = renderToStaticMarkup(
+  function renderActivePaneMarkup(
+    overrides?: Partial<React.ComponentProps<typeof ActivePane>>,
+  ): string {
+    return renderToStaticMarkup(
       <ActivePane
         notes={[
           {
@@ -70,8 +72,10 @@ describe("ActivePane", () => {
             updatedLabel: "Apr 19",
           },
         ]}
-        folderOptions={[]}
-        selectedFolderPath={null}
+        folderOptions={[
+          { path: normalizeFolderPath("Projects/Grove"), label: "Projects/Grove" },
+        ]}
+        selectedFolderPath={normalizeFolderPath("Projects/Grove")}
         selectedNoteId="note-plan"
         noteEditBuffer={null}
         editorLoadState={{ status: "idle" }}
@@ -129,8 +133,13 @@ describe("ActivePane", () => {
             ["note-review", "Review"],
           ])
         }
+        {...overrides}
       />,
     );
+  }
+
+  it("shows resolved links, unresolved references, and backlinks in the note pane", () => {
+    const markup = renderActivePaneMarkup();
 
     expect(markup).toContain("Links");
     expect(markup).toContain("Backlinks");
@@ -138,5 +147,46 @@ describe("ActivePane", () => {
     expect(markup).toContain("Untriaged -&gt; Missing");
     expect(markup).toContain("Review via Project plan");
     expect(markup).toContain("Unresolved");
+  });
+
+  it("hides move, rename, and delete controls by default", () => {
+    const markup = renderActivePaneMarkup();
+
+    expect(markup).toContain("Note actions");
+    expect(markup).toContain("Folder actions");
+    expect(markup).not.toContain("Move selected note");
+    expect(markup).not.toContain("Rename selected folder");
+    expect(markup).not.toContain("Delete note");
+  });
+
+  it("shows note actions when the note disclosure starts open", () => {
+    const markup = renderActivePaneMarkup({ initialNoteActionsOpen: true });
+
+    expect(markup).toContain("Move selected note");
+    expect(markup).toContain("Delete note");
+  });
+
+  it("shows folder actions when the folder disclosure starts open", () => {
+    const markup = renderActivePaneMarkup({ initialFolderActionsOpen: true });
+
+    expect(markup).toContain("Rename selected folder");
+    expect(markup).toContain(
+      "Path changes refresh the folder tree and note list immediately. File and index work runs in the background.",
+    );
+  });
+
+  it("hides note actions entirely when no note is selected", () => {
+    const markup = renderActivePaneMarkup({
+      notes: [],
+      folderOptions: [],
+      selectedFolderPath: null,
+      selectedNoteId: "",
+      selectedNoteLinks: [],
+      selectedNoteBacklinks: [],
+      noteTitlesById: new Map(),
+    });
+
+    expect(markup).not.toContain("Note actions");
+    expect(markup).toContain("Folder actions");
   });
 });

--- a/apps/desktop/src/features/folder-navigation/ui/FolderNavigationWorkspace.tsx
+++ b/apps/desktop/src/features/folder-navigation/ui/FolderNavigationWorkspace.tsx
@@ -12,6 +12,7 @@ import {
 import type { FolderScope, FolderTreeNode, ResolvedWikiLink } from "@grove/core";
 import type { MarkdownCommand, MarkdownSelection } from "@grove/editor";
 import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from "react";
+import type { ReactNode } from "react";
 
 import {
   createMarkdownNote,
@@ -133,6 +134,8 @@ type ActivePaneProps = {
   selectedNoteLinks: readonly ResolvedWikiLink[];
   selectedNoteBacklinks: readonly ResolvedWikiLink[];
   noteTitlesById: ReadonlyMap<string, string>;
+  initialNoteActionsOpen?: boolean;
+  initialFolderActionsOpen?: boolean;
 };
 
 type MoveNoteControlProps = {
@@ -332,6 +335,8 @@ function getNoteIndexRefreshErrorMessage(error: unknown): string {
 }
 
 const noteSaveBlockedMessage = "Wait for this note's path change to finish before saving.";
+const defaultOperationMessage =
+  "Path changes refresh the folder tree and note list immediately. File and index work runs in the background.";
 
 const markdownToolbarCommands: readonly { command: MarkdownCommand; label: string }[] = [
   { command: "bold", label: "Bold" },
@@ -849,6 +854,31 @@ function NoteLinkList({ kind, heading, emptyMessage, links, noteTitlesById }: No
   );
 }
 
+type ActionDisclosureProps = {
+  title: string;
+  initiallyOpen?: boolean;
+  children: ReactNode;
+};
+
+function ActionDisclosure({ title, initiallyOpen = false, children }: ActionDisclosureProps) {
+  const [isOpen, setIsOpen] = useState(initiallyOpen);
+
+  return (
+    <section className="folder-navigation__disclosure">
+      <button
+        type="button"
+        className="folder-navigation__disclosure-toggle"
+        onClick={() => setIsOpen((currentIsOpen) => !currentIsOpen)}
+        aria-expanded={isOpen}
+      >
+        <span>{title}</span>
+        <span>{isOpen ? "Hide" : "Show"}</span>
+      </button>
+      {isOpen ? <div className="folder-navigation__disclosure-content">{children}</div> : null}
+    </section>
+  );
+}
+
 export function ActivePane({
   notes,
   folderOptions,
@@ -877,11 +907,11 @@ export function ActivePane({
   selectedNoteLinks,
   selectedNoteBacklinks,
   noteTitlesById,
+  initialNoteActionsOpen = false,
+  initialFolderActionsOpen = false,
 }: ActivePaneProps) {
   const selectedNote = notes.find((note) => note.id === selectedNoteId) ?? notes[0];
-  const [operationMessage, setOperationMessage] = useState<string>(
-    "Path changes refresh the folder tree and note list immediately. File and index work runs in the background.",
-  );
+  const [operationMessage, setOperationMessage] = useState<string>(defaultOperationMessage);
 
   return (
     <section className="folder-navigation__pane">
@@ -932,6 +962,10 @@ export function ActivePane({
                 noteTitlesById={noteTitlesById}
               />
             </div>
+          </>
+        )}
+        {selectedNote === undefined ? null : (
+          <ActionDisclosure title="Note actions" initiallyOpen={initialNoteActionsOpen}>
             <MoveNoteControl
               folderOptions={folderOptions}
               selectedNoteFolderPath={getFolderPathForNote(selectedNote.path)}
@@ -957,7 +991,7 @@ export function ActivePane({
                 <p className="folder-navigation__step-error">{deleteState.errorMessage}</p>
               )}
             </div>
-          </>
+          </ActionDisclosure>
         )}
         {isDevelopmentMode && isPathChangeQueueVisible ? (
           <PathChangeQueue
@@ -968,12 +1002,14 @@ export function ActivePane({
             onRetryStep={onRetryStep}
           />
         ) : null}
-        <RenameFolderControl
-          selectedFolderPath={selectedFolderPath}
-          onRenameSelectedFolder={onRenameSelectedFolder}
-          onOperationMessage={setOperationMessage}
-        />
-        <p className="folder-navigation__muted">{operationMessage}</p>
+        <ActionDisclosure title="Folder actions" initiallyOpen={initialFolderActionsOpen}>
+          <RenameFolderControl
+            selectedFolderPath={selectedFolderPath}
+            onRenameSelectedFolder={onRenameSelectedFolder}
+            onOperationMessage={setOperationMessage}
+          />
+          <p className="folder-navigation__muted">{operationMessage}</p>
+        </ActionDisclosure>
       </div>
     </section>
   );

--- a/docs/superpowers/specs/2026-04-19-issue-75-desktop-contextual-actions-design.md
+++ b/docs/superpowers/specs/2026-04-19-issue-75-desktop-contextual-actions-design.md
@@ -1,0 +1,124 @@
+# Issue 75 Desktop Contextual Actions Design
+
+## Summary
+Simplify the desktop editor surface by removing always-visible workspace-management controls from the main pane. Keep note move, folder rename, and note delete available through explicit contextual disclosure panels so the default state stays focused on reading and editing Markdown.
+
+## Scope
+- Move the always-visible `Move selected note` form out of the default editor flow.
+- Move the always-visible `Rename selected folder` form out of the default editor flow.
+- Move `Delete note` behind the same contextual disclosure pattern instead of leaving it permanently visible.
+- Preserve existing dirty-draft, pending-path-change, and path-conflict guardrails.
+
+## Out Of Scope
+- Redesigning the two-pane layout introduced by issue #74.
+- Changing the underlying folder workspace mutation model or path change queue semantics.
+- Hiding tags, links, backlinks, or diagnostics by default beyond what is necessary to keep the action sections contextual.
+- Introducing a new modal or dialog infrastructure.
+
+## Current State
+`ActivePane` in `apps/desktop/src/features/folder-navigation/ui/FolderNavigationWorkspace.tsx` renders the editor together with:
+- the note path
+- the links/backlinks sections
+- the move-note form
+- the delete-note action
+- the rename-folder form
+
+This keeps workspace-management controls in view even when the user only wants to read or edit a note.
+
+## Goals
+The default right-pane state should read as:
+- note title
+- save state and edit controls
+- Markdown editor
+
+Secondary actions should still be reachable without moving them to a different pane or changing the existing mutation logic.
+
+## Chosen Approach
+Use inline disclosure sections in the right pane:
+- `Note actions`
+- `Folder actions`
+
+The disclosures are collapsed by default. Users opt in to seeing move / delete / rename controls by expanding the relevant section.
+
+This approach is preferred because it:
+- preserves the existing two-pane information architecture from issue #74
+- keeps actions close to the edited note and current folder context
+- avoids adding modal state or new shared UI primitives for a narrowly scoped cleanup
+- leaves a natural place for future details-oriented UI work in issue #73
+
+## Component Design
+### ActivePane
+`ActivePane` will remain responsible for the right-pane composition, but its default visible stack will be reduced.
+
+Default visible content:
+- active note heading
+- development-only path change diagnostics toggle
+- note path text, unchanged in the default view for this issue
+- `NoteEditor`
+
+Contextual content:
+- `Note actions` disclosure
+- `Folder actions` disclosure
+- development-only path change queue when expanded
+
+### Note Actions Disclosure
+Visible only when a note is selected.
+
+Contents:
+- existing move-note control
+- existing delete-note action block
+
+Behavior:
+- collapsed by default
+- keeps the current move mutation flow
+- keeps the current delete blocking and error messages
+- delete copy should remain explicit that the Markdown file is permanently removed
+
+### Folder Actions Disclosure
+Visible regardless of note selection because folder context comes from the selected folder.
+
+Contents:
+- existing rename-folder control
+- operation feedback message currently shown below the editor
+
+Behavior:
+- collapsed by default
+- workspace root keeps the rename input and button disabled
+- descendant-path validation remains unchanged
+
+## Guardrails To Preserve
+- Dirty note drafts must still block workspace changes through the existing note buffer checks.
+- Pending path changes must still block save and delete when the existing model says they should.
+- Existing path-conflict validation for move / rename must stay in the folder workspace model.
+- Path change queue execution remains automatic and development-only diagnostics remain opt-in.
+
+## Testing Strategy
+Update `apps/desktop/src/features/folder-navigation/ui/FolderNavigationWorkspace.test.tsx` first.
+
+Add or adjust tests to verify:
+- default `ActivePane` markup does not include always-visible move / rename / delete controls
+- expanded `Note actions` markup includes move and delete controls
+- expanded `Folder actions` markup includes rename controls and operation messaging
+- the diagnostics toggle behavior from issue #74 still works
+
+Implementation should follow TDD:
+1. write or update failing UI markup tests
+2. run the focused desktop test file and confirm the expected failure
+3. implement the minimal disclosure UI changes
+4. rerun the focused tests
+5. run broader desktop verification as needed
+
+## Risks And Mitigations
+- Risk: action controls become harder to discover
+  - Mitigation: use explicit disclosure labels (`Note actions`, `Folder actions`) instead of ambiguous icon-only menus
+- Risk: disclosure state adds noise to `ActivePane`
+  - Mitigation: keep state local and minimal, without changing workspace model boundaries
+- Risk: accidental behavior regression in move / rename / delete flows
+  - Mitigation: reuse existing handlers and preserve validation paths instead of rewriting mutations
+
+## Acceptance Criteria
+- the primary editor surface shows only reading/editing controls by default
+- move, rename, and delete remain available through deliberate contextual interaction
+- delete remains a clearly destructive action
+- existing save/path-change guardrails still apply
+- the implementation can land independently after issue #74 without waiting on issue #73


### PR DESCRIPTION
## Summary
- move note and folder management controls behind collapsed disclosures in the desktop active pane
- keep the default editor surface focused on the note path, editing controls, and Markdown content
- preserve existing move, rename, delete, and path-change guardrails while reducing persistent UI noise

## Testing
- pnpm --filter @grove/desktop test -- FolderNavigationWorkspace.test.tsx
- pnpm --filter @grove/desktop typecheck
- pnpm --filter @grove/desktop build

Refs #75
