### PR TITLE
Simplify desktop editor actions and note details

### DIFF
--- a/apps/desktop/src/features/folder-navigation/ui/FolderNavigationWorkspace.css
+++ b/apps/desktop/src/features/folder-navigation/ui/FolderNavigationWorkspace.css
@@ -255,6 +255,21 @@
   gap: 0.75rem;
 }
 
+.folder-navigation__details,
+.folder-navigation__detail-block {
+  display: grid;
+  gap: 0.75rem;
+}
+
+.folder-navigation__path-value {
+  color: #5f6d64;
+  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", monospace;
+  font-size: 0.75rem;
+  line-height: 1.5;
+  margin: 0;
+  overflow-wrap: anywhere;
+}
+
 .folder-navigation__editor-stack {
   display: grid;
   gap: 0.75rem;

--- a/apps/desktop/src/features/folder-navigation/ui/FolderNavigationWorkspace.test.tsx
+++ b/apps/desktop/src/features/folder-navigation/ui/FolderNavigationWorkspace.test.tsx
@@ -174,6 +174,9 @@ describe("ActivePane", () => {
 
     expect(markup).toContain("Move selected note");
     expect(markup).toContain("Delete note");
+    expect(markup).toContain(
+      "Path changes refresh the folder tree and note list immediately. File and index work runs in the background.",
+    );
   });
 
   it("shows folder actions when the folder disclosure starts open", () => {

--- a/apps/desktop/src/features/folder-navigation/ui/FolderNavigationWorkspace.test.tsx
+++ b/apps/desktop/src/features/folder-navigation/ui/FolderNavigationWorkspace.test.tsx
@@ -139,14 +139,24 @@ describe("ActivePane", () => {
   }
 
   it("shows resolved links, unresolved references, and backlinks in the note pane", () => {
-    const markup = renderActivePaneMarkup();
+    const markup = renderActivePaneMarkup({ initialDetailsOpen: true });
 
     expect(markup).toContain("Links");
     expect(markup).toContain("Backlinks");
+    expect(markup).toContain("Path");
     expect(markup).toContain("Research");
     expect(markup).toContain("Untriaged -&gt; Missing");
     expect(markup).toContain("Review via Project plan");
     expect(markup).toContain("Unresolved");
+  });
+
+  it("hides path, links, and backlinks by default", () => {
+    const markup = renderActivePaneMarkup();
+
+    expect(markup).toContain("Details");
+    expect(markup).not.toContain("Path");
+    expect(markup).not.toContain("Links");
+    expect(markup).not.toContain("Backlinks");
   });
 
   it("hides move, rename, and delete controls by default", () => {
@@ -187,6 +197,7 @@ describe("ActivePane", () => {
     });
 
     expect(markup).not.toContain("Note actions");
+    expect(markup).not.toContain("Details");
     expect(markup).toContain("Folder actions");
   });
 });

--- a/apps/desktop/src/features/folder-navigation/ui/FolderNavigationWorkspace.tsx
+++ b/apps/desktop/src/features/folder-navigation/ui/FolderNavigationWorkspace.tsx
@@ -913,7 +913,9 @@ export function ActivePane({
   initialFolderActionsOpen = false,
 }: ActivePaneProps) {
   const selectedNote = notes.find((note) => note.id === selectedNoteId) ?? notes[0];
-  const [operationMessage, setOperationMessage] = useState<string>(defaultOperationMessage);
+  const [noteOperationMessage, setNoteOperationMessage] = useState<string>(defaultOperationMessage);
+  const [folderOperationMessage, setFolderOperationMessage] =
+    useState<string>(defaultOperationMessage);
 
   return (
     <section className="folder-navigation__pane">
@@ -979,7 +981,7 @@ export function ActivePane({
               folderOptions={folderOptions}
               selectedNoteFolderPath={getFolderPathForNote(selectedNote.path)}
               onMoveSelectedNote={onMoveSelectedNote}
-              onOperationMessage={setOperationMessage}
+              onOperationMessage={setNoteOperationMessage}
             />
             <div className="folder-navigation__operation">
               <button
@@ -1000,6 +1002,7 @@ export function ActivePane({
                 <p className="folder-navigation__step-error">{deleteState.errorMessage}</p>
               )}
             </div>
+            <p className="folder-navigation__muted">{noteOperationMessage}</p>
           </ActionDisclosure>
         )}
         {isDevelopmentMode && isPathChangeQueueVisible ? (
@@ -1015,9 +1018,9 @@ export function ActivePane({
           <RenameFolderControl
             selectedFolderPath={selectedFolderPath}
             onRenameSelectedFolder={onRenameSelectedFolder}
-            onOperationMessage={setOperationMessage}
+            onOperationMessage={setFolderOperationMessage}
           />
-          <p className="folder-navigation__muted">{operationMessage}</p>
+          <p className="folder-navigation__muted">{folderOperationMessage}</p>
         </ActionDisclosure>
       </div>
     </section>

--- a/apps/desktop/src/features/folder-navigation/ui/FolderNavigationWorkspace.tsx
+++ b/apps/desktop/src/features/folder-navigation/ui/FolderNavigationWorkspace.tsx
@@ -134,6 +134,7 @@ type ActivePaneProps = {
   selectedNoteLinks: readonly ResolvedWikiLink[];
   selectedNoteBacklinks: readonly ResolvedWikiLink[];
   noteTitlesById: ReadonlyMap<string, string>;
+  initialDetailsOpen?: boolean;
   initialNoteActionsOpen?: boolean;
   initialFolderActionsOpen?: boolean;
 };
@@ -907,6 +908,7 @@ export function ActivePane({
   selectedNoteLinks,
   selectedNoteBacklinks,
   noteTitlesById,
+  initialDetailsOpen = false,
   initialNoteActionsOpen = false,
   initialFolderActionsOpen = false,
 }: ActivePaneProps) {
@@ -935,7 +937,6 @@ export function ActivePane({
           <p>Select a note to manage its workspace path.</p>
         ) : (
           <>
-            <p>Path: {selectedNote.path}</p>
             <NoteEditor
               selectedNote={selectedNote}
               noteEditBuffer={noteEditBuffer}
@@ -946,22 +947,30 @@ export function ActivePane({
               saveBlockedReason={saveBlockedReason}
               onDiscardDraft={onDiscardDraft}
             />
-            <div className="folder-navigation__link-sections">
-              <NoteLinkList
-                kind="outgoing"
-                heading="Links"
-                emptyMessage="No WikiLinks in this note yet."
-                links={selectedNoteLinks}
-                noteTitlesById={noteTitlesById}
-              />
-              <NoteLinkList
-                kind="backlinks"
-                heading="Backlinks"
-                emptyMessage="No backlinks point to this note yet."
-                links={selectedNoteBacklinks}
-                noteTitlesById={noteTitlesById}
-              />
-            </div>
+            <ActionDisclosure title="Details" initiallyOpen={initialDetailsOpen}>
+              <div className="folder-navigation__details">
+                <div className="folder-navigation__detail-block">
+                  <p className="folder-navigation__link-heading">Path</p>
+                  <p className="folder-navigation__path-value">{selectedNote.path}</p>
+                </div>
+                <div className="folder-navigation__link-sections">
+                  <NoteLinkList
+                    kind="outgoing"
+                    heading="Links"
+                    emptyMessage="No WikiLinks in this note yet."
+                    links={selectedNoteLinks}
+                    noteTitlesById={noteTitlesById}
+                  />
+                  <NoteLinkList
+                    kind="backlinks"
+                    heading="Backlinks"
+                    emptyMessage="No backlinks point to this note yet."
+                    links={selectedNoteBacklinks}
+                    noteTitlesById={noteTitlesById}
+                  />
+                </div>
+              </div>
+            </ActionDisclosure>
           </>
         )}
         {selectedNote === undefined ? null : (


### PR DESCRIPTION
## Summary
- move desktop note move, folder rename, and note delete controls behind contextual disclosures
- hide note path, links, and backlinks behind a Details disclosure so the default editor surface stays focused
- keep development-only path change diagnostics opt-in and preserve existing workspace guardrails

## Testing
- pnpm --filter @grove/desktop test -- FolderNavigationWorkspace.test.tsx
- pnpm --filter @grove/desktop test
- pnpm --filter @grove/desktop build
- pnpm --filter @grove/desktop typecheck
- pnpm lint
- git diff --check

Refs #72
Refs #73
Refs #75
