### PR TITLE
Redesign desktop library navigation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ node_modules
 dist
 coverage
 .turbo
+.superpowers/
 apps/mobile/.expo
 apps/mobile/.expo-shared
 apps/mobile/android/.gradle

--- a/apps/desktop/src/features/folder-navigation/ui/FolderNavigationWorkspace.css
+++ b/apps/desktop/src/features/folder-navigation/ui/FolderNavigationWorkspace.css
@@ -2,22 +2,17 @@
   background: #f7f8f5;
   color: #17211b;
   display: grid;
-  grid-template-columns: minmax(18rem, 24rem) minmax(24rem, 1fr);
+  grid-template-columns: minmax(14rem, 18rem) minmax(18rem, 24rem) minmax(24rem, 1fr);
   min-height: 100vh;
   overflow-x: auto;
 }
 
 .folder-navigation__navigation {
-  background: #ffffff;
-  border-right: 1px solid #dce4dd;
-  box-sizing: border-box;
-  display: grid;
-  gap: 1.25rem;
-  padding: 1.25rem;
+  display: contents;
 }
 
-.folder-navigation__sidebar,
-.folder-navigation__note-list,
+.folder-navigation__library-column,
+.folder-navigation__notes-column,
 .folder-navigation__pane,
 .folder-navigation__queue {
   padding: 1.25rem;
@@ -27,14 +22,43 @@
   border-right: 0;
 }
 
-.folder-navigation__sidebar,
-.folder-navigation__note-list {
-  padding: 0;
+.folder-navigation__library-column,
+.folder-navigation__notes-column {
+  background: #ffffff;
+  border-right: 1px solid #dce4dd;
+  box-sizing: border-box;
 }
 
-.folder-navigation__sidebar {
-  border-bottom: 1px solid #dce4dd;
-  padding-bottom: 1.25rem;
+.folder-navigation__library-column {
+  display: grid;
+  grid-template-rows: minmax(0, 1fr) auto;
+  min-height: 100vh;
+}
+
+.folder-navigation__library-content {
+  align-content: start;
+  display: grid;
+  gap: 1rem;
+}
+
+.folder-navigation__folder-group {
+  display: grid;
+  gap: 0.5rem;
+}
+
+.folder-navigation__group-heading {
+  color: #4d6959;
+  font-size: 0.75rem;
+  font-weight: 700;
+  letter-spacing: 0;
+  margin: 0;
+  text-transform: uppercase;
+}
+
+.folder-navigation__notes-column {
+  align-content: start;
+  display: grid;
+  gap: 1rem;
 }
 
 .folder-navigation__eyebrow {
@@ -127,7 +151,7 @@
 }
 
 .folder-navigation__tree--root {
-  margin-top: 1rem;
+  margin-top: 0;
 }
 
 .folder-navigation__folder-row {
@@ -491,11 +515,89 @@
   width: fit-content;
 }
 
+.folder-navigation__workspace-switcher {
+  position: relative;
+}
+
+.folder-navigation__workspace-switcher-button {
+  background: #f7f8f5;
+  border: 1px solid #c8d3ca;
+  border-radius: 8px;
+  color: #17211b;
+  cursor: pointer;
+  display: grid;
+  gap: 0.25rem;
+  padding: 0.75rem;
+  text-align: left;
+  width: 100%;
+}
+
+.folder-navigation__workspace-name {
+  font-weight: 700;
+}
+
+.folder-navigation__workspace-hint {
+  color: #5f6d64;
+  font-size: 0.875rem;
+}
+
+.folder-navigation__workspace-popover {
+  background: #ffffff;
+  border: 1px solid #c8d3ca;
+  border-radius: 8px;
+  bottom: calc(100% + 0.5rem);
+  box-shadow: 0 1rem 2rem rgb(23 33 27 / 14%);
+  display: grid;
+  gap: 0.875rem;
+  left: 0;
+  min-width: 16rem;
+  padding: 0.875rem;
+  position: absolute;
+  z-index: 2;
+}
+
+.folder-navigation__workspace-popover-title {
+  font-weight: 700;
+  margin: 0;
+}
+
+.folder-navigation__workspace-popover-section,
+.folder-navigation__workspace-popover-actions {
+  display: grid;
+  gap: 0.5rem;
+}
+
+.folder-navigation__workspace-list {
+  display: grid;
+  gap: 0.25rem;
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.folder-navigation__workspace-action {
+  background: #ffffff;
+  border: 1px solid transparent;
+  border-radius: 8px;
+  color: #17211b;
+  cursor: pointer;
+  min-height: 2rem;
+  padding: 0 0.5rem;
+  text-align: left;
+  width: 100%;
+}
+
+.folder-navigation__workspace-action:hover {
+  background: #eef1ec;
+  border-color: #c8d3ca;
+}
+
 .folder-navigation__action:disabled,
 .folder-navigation__secondary-action:disabled,
 .folder-navigation__format-action:disabled,
 .folder-navigation__input:disabled,
-.folder-navigation__queue-toggle:disabled {
+.folder-navigation__queue-toggle:disabled,
+.folder-navigation__workspace-switcher-button:disabled {
   cursor: not-allowed;
   opacity: 0.55;
 }
@@ -505,13 +607,14 @@
     grid-template-columns: minmax(18rem, 1fr);
   }
 
-  .folder-navigation__navigation,
+  .folder-navigation__library-column,
+  .folder-navigation__notes-column,
   .folder-navigation__pane {
     border-bottom: 1px solid #dce4dd;
     border-right: 0;
   }
 
-  .folder-navigation__navigation {
-    padding-bottom: 1.5rem;
+  .folder-navigation__library-column {
+    min-height: auto;
   }
 }

--- a/apps/desktop/src/features/folder-navigation/ui/FolderNavigationWorkspace.test.tsx
+++ b/apps/desktop/src/features/folder-navigation/ui/FolderNavigationWorkspace.test.tsx
@@ -1,10 +1,12 @@
-import { normalizeFolderPath, normalizeNoteFilePath } from "@grove/core";
+import { buildFolderTree, normalizeFolderPath, normalizeNoteFilePath } from "@grove/core";
 import { renderToStaticMarkup } from "react-dom/server";
 import { describe, expect, it } from "vitest";
 
 import {
   ActivePane,
   FolderNavigationWorkspaceContent,
+  NavigationPane,
+  WorkspaceSwitcher,
   getFolderNavigationWorkspaceClassName,
 } from "./FolderNavigationWorkspace";
 
@@ -57,6 +59,100 @@ describe("FolderNavigationWorkspaceContent", () => {
   });
 });
 
+describe("NavigationPane", () => {
+  const notes = [
+    {
+      id: "note-plan",
+      path: normalizeNoteFilePath("Projects/Grove/Plan.md"),
+      title: "Plan",
+      content: "",
+      updatedLabel: "Apr 19",
+    },
+    {
+      id: "note-personal",
+      path: normalizeNoteFilePath("Personal/Journal.md"),
+      title: "Journal",
+      content: "",
+      updatedLabel: "Apr 18",
+    },
+  ];
+  const selectedFolderPath = normalizeFolderPath("Projects/Grove");
+
+  function renderNavigationPaneMarkup(
+    overrides?: Partial<React.ComponentProps<typeof NavigationPane>>,
+  ): string {
+    return renderToStaticMarkup(
+      <NavigationPane
+        noteCount={notes.length}
+        folderTree={buildFolderTree(
+          notes.map((note) => note.path),
+          [],
+        )}
+        selectedFolderPath={selectedFolderPath}
+        expandedFolderPaths={[normalizeFolderPath("Projects"), selectedFolderPath]}
+        onSelect={() => {}}
+        onToggle={() => {}}
+        scopedNotes={notes.filter((note) => note.path.startsWith("Projects/Grove/"))}
+        selectedNoteId="note-plan"
+        scanState={{ status: "ready", errorMessage: null }}
+        createState={{ status: "idle", errorMessage: null }}
+        createTitle=""
+        onCreateTitleChange={() => {}}
+        onCreateNote={() => {}}
+        onSelectNote={() => {}}
+        {...overrides}
+      />,
+    );
+  }
+
+  it("renders Library and Notes as separate desktop navigation columns", () => {
+    const markup = renderNavigationPaneMarkup();
+
+    expect(markup).toContain("folder-navigation__library-column");
+    expect(markup).toContain("folder-navigation__notes-column");
+    expect(markup).toContain("All notes");
+    expect(markup).toContain("Folders");
+    expect(markup).toContain("Projects");
+  });
+
+  it("renders notes for the selected folder scope in the Notes column", () => {
+    const markup = renderNavigationPaneMarkup();
+
+    expect(markup).toContain("Grove");
+    expect(markup).toContain("Plan");
+    expect(markup).not.toContain("Journal");
+  });
+
+  it("places the workspace switcher in the Library column", () => {
+    const markup = renderNavigationPaneMarkup();
+
+    expect(markup).toContain("folder-navigation__workspace-switcher");
+    expect(markup).toContain("Personal Notes");
+    expect(markup).toContain("Switch workspace");
+  });
+});
+
+describe("WorkspaceSwitcher", () => {
+  it("opens a lightweight popover with workspace actions and no sync copy", () => {
+    const markup = renderToStaticMarkup(
+      <WorkspaceSwitcher
+        currentWorkspaceName="Personal Notes"
+        recentWorkspaceNames={["Research", "Archive"]}
+        initiallyOpen={true}
+      />,
+    );
+
+    expect(markup).toContain("Current workspace");
+    expect(markup).toContain("Research");
+    expect(markup).toContain("Archive");
+    expect(markup).toContain("Add workspace");
+    expect(markup).toContain("Workspace settings");
+    expect(markup).not.toContain("Synced");
+    expect(markup).not.toContain("Sync status");
+    expect(markup).not.toContain("Cloud status");
+  });
+});
+
 describe("ActivePane", () => {
   function renderActivePaneMarkup(
     overrides?: Partial<React.ComponentProps<typeof ActivePane>>,
@@ -72,9 +168,7 @@ describe("ActivePane", () => {
             updatedLabel: "Apr 19",
           },
         ]}
-        folderOptions={[
-          { path: normalizeFolderPath("Projects/Grove"), label: "Projects/Grove" },
-        ]}
+        folderOptions={[{ path: normalizeFolderPath("Projects/Grove"), label: "Projects/Grove" }]}
         selectedFolderPath={normalizeFolderPath("Projects/Grove")}
         selectedNoteId="note-plan"
         noteEditBuffer={null}

--- a/apps/desktop/src/features/folder-navigation/ui/FolderNavigationWorkspace.test.tsx
+++ b/apps/desktop/src/features/folder-navigation/ui/FolderNavigationWorkspace.test.tsx
@@ -141,11 +141,34 @@ describe("WorkspaceSwitcher", () => {
         initiallyOpen={true}
       />,
     );
+    const controlsMatch = markup.match(/aria-controls="([^"]+)"/);
+    const idMatch = markup.match(/id="([^"]+)"/);
 
     expect(markup).toContain('aria-haspopup="dialog"');
-    expect(markup).toContain('aria-controls="workspace-switcher-popover"');
-    expect(markup).toContain('id="workspace-switcher-popover"');
     expect(markup).toContain('role="dialog"');
+    expect(controlsMatch?.[1]).toBe(idMatch?.[1]);
+  });
+
+  it("uses unique popover ids when more than one switcher is rendered", () => {
+    const markup = renderToStaticMarkup(
+      <>
+        <WorkspaceSwitcher
+          currentWorkspaceName="Personal Notes"
+          recentWorkspaceNames={[]}
+          initiallyOpen={true}
+        />
+        <WorkspaceSwitcher
+          currentWorkspaceName="Archive"
+          recentWorkspaceNames={[]}
+          initiallyOpen={true}
+        />
+      </>,
+    );
+
+    const popoverIds = Array.from(markup.matchAll(/id="([^"]+)"/g), (match) => match[1]);
+
+    expect(popoverIds).toHaveLength(2);
+    expect(new Set(popoverIds).size).toBe(2);
   });
 
   it("opens a lightweight popover with workspace actions and no sync copy", () => {

--- a/apps/desktop/src/features/folder-navigation/ui/FolderNavigationWorkspace.test.tsx
+++ b/apps/desktop/src/features/folder-navigation/ui/FolderNavigationWorkspace.test.tsx
@@ -133,6 +133,21 @@ describe("NavigationPane", () => {
 });
 
 describe("WorkspaceSwitcher", () => {
+  it("connects the trigger to the workspace popover for assistive technology", () => {
+    const markup = renderToStaticMarkup(
+      <WorkspaceSwitcher
+        currentWorkspaceName="Personal Notes"
+        recentWorkspaceNames={[]}
+        initiallyOpen={true}
+      />,
+    );
+
+    expect(markup).toContain('aria-haspopup="dialog"');
+    expect(markup).toContain('aria-controls="workspace-switcher-popover"');
+    expect(markup).toContain('id="workspace-switcher-popover"');
+    expect(markup).toContain('role="dialog"');
+  });
+
   it("opens a lightweight popover with workspace actions and no sync copy", () => {
     const markup = renderToStaticMarkup(
       <WorkspaceSwitcher

--- a/apps/desktop/src/features/folder-navigation/ui/FolderNavigationWorkspace.tsx
+++ b/apps/desktop/src/features/folder-navigation/ui/FolderNavigationWorkspace.tsx
@@ -107,6 +107,12 @@ type WorkspaceSwitcherProps = {
   initiallyOpen?: boolean;
 };
 
+type WorkspaceSwitcherPopoverProps = {
+  id: string;
+  currentWorkspaceName: string;
+  recentWorkspaceNames: readonly string[];
+};
+
 type FolderOption = {
   path: FolderScope;
   label: string;
@@ -344,6 +350,7 @@ function getNoteIndexRefreshErrorMessage(error: unknown): string {
 const noteSaveBlockedMessage = "Wait for this note's path change to finish before saving.";
 const defaultOperationMessage =
   "Path changes refresh the folder tree and note list immediately. File and index work runs in the background.";
+const workspaceSwitcherPopoverId = "workspace-switcher-popover";
 
 const markdownToolbarCommands: readonly { command: MarkdownCommand; label: string }[] = [
   { command: "bold", label: "Bold" },
@@ -515,40 +522,61 @@ export function WorkspaceSwitcher({
         className="folder-navigation__workspace-switcher-button"
         onClick={() => setIsOpen((currentIsOpen) => !currentIsOpen)}
         aria-expanded={isOpen}
+        aria-haspopup="dialog"
+        aria-controls={isOpen ? workspaceSwitcherPopoverId : undefined}
       >
         <span className="folder-navigation__workspace-name">{currentWorkspaceName}</span>
         <span className="folder-navigation__workspace-hint">Switch workspace</span>
       </button>
       {isOpen ? (
-        <div className="folder-navigation__workspace-popover">
-          <p className="folder-navigation__eyebrow">Current workspace</p>
-          <p className="folder-navigation__workspace-popover-title">{currentWorkspaceName}</p>
-          <div className="folder-navigation__workspace-popover-section">
-            <p className="folder-navigation__group-heading">Recent workspaces</p>
-            {recentWorkspaceNames.length > 0 ? (
-              <ul className="folder-navigation__workspace-list">
-                {recentWorkspaceNames.map((workspaceName) => (
-                  <li key={workspaceName}>
-                    <button type="button" className="folder-navigation__workspace-action">
-                      {workspaceName}
-                    </button>
-                  </li>
-                ))}
-              </ul>
-            ) : (
-              <p className="folder-navigation__muted">No recent workspaces yet.</p>
-            )}
-          </div>
-          <div className="folder-navigation__workspace-popover-actions">
-            <button type="button" className="folder-navigation__workspace-action">
-              Add workspace
-            </button>
-            <button type="button" className="folder-navigation__workspace-action">
-              Workspace settings
-            </button>
-          </div>
-        </div>
+        <WorkspaceSwitcherPopover
+          id={workspaceSwitcherPopoverId}
+          currentWorkspaceName={currentWorkspaceName}
+          recentWorkspaceNames={recentWorkspaceNames}
+        />
       ) : null}
+    </div>
+  );
+}
+
+function WorkspaceSwitcherPopover({
+  id,
+  currentWorkspaceName,
+  recentWorkspaceNames,
+}: WorkspaceSwitcherPopoverProps) {
+  return (
+    <div
+      id={id}
+      className="folder-navigation__workspace-popover"
+      role="dialog"
+      aria-label="Workspace switcher"
+    >
+      <p className="folder-navigation__eyebrow">Current workspace</p>
+      <p className="folder-navigation__workspace-popover-title">{currentWorkspaceName}</p>
+      <div className="folder-navigation__workspace-popover-section">
+        <p className="folder-navigation__group-heading">Recent workspaces</p>
+        {recentWorkspaceNames.length > 0 ? (
+          <ul className="folder-navigation__workspace-list">
+            {recentWorkspaceNames.map((workspaceName) => (
+              <li key={workspaceName}>
+                <button type="button" className="folder-navigation__workspace-action">
+                  {workspaceName}
+                </button>
+              </li>
+            ))}
+          </ul>
+        ) : (
+          <p className="folder-navigation__muted">No recent workspaces yet.</p>
+        )}
+      </div>
+      <div className="folder-navigation__workspace-popover-actions">
+        <button type="button" className="folder-navigation__workspace-action">
+          Add workspace
+        </button>
+        <button type="button" className="folder-navigation__workspace-action">
+          Workspace settings
+        </button>
+      </div>
     </div>
   );
 }

--- a/apps/desktop/src/features/folder-navigation/ui/FolderNavigationWorkspace.tsx
+++ b/apps/desktop/src/features/folder-navigation/ui/FolderNavigationWorkspace.tsx
@@ -101,6 +101,12 @@ type NoteListProps = {
 
 type NavigationPaneProps = SidebarProps & NoteListProps;
 
+type WorkspaceSwitcherProps = {
+  currentWorkspaceName: string;
+  recentWorkspaceNames: readonly string[];
+  initiallyOpen?: boolean;
+};
+
 type FolderOption = {
   path: FolderScope;
   label: string;
@@ -448,7 +454,7 @@ function FolderNode({
   );
 }
 
-function Sidebar({
+function LibraryColumn({
   noteCount,
   folderTree,
   selectedFolderPath,
@@ -457,39 +463,97 @@ function Sidebar({
   onToggle,
 }: SidebarProps) {
   return (
-    <aside className="folder-navigation__sidebar">
-      <p className="folder-navigation__eyebrow">{appName}</p>
-      <h1 className="folder-navigation__title">Library</h1>
-      <button
-        type="button"
-        className={
-          selectedFolderPath === null
-            ? "folder-navigation__root-button folder-navigation__root-button--selected"
-            : "folder-navigation__root-button"
-        }
-        onClick={() => onSelect(null)}
-        aria-pressed={selectedFolderPath === null}
-      >
-        <span>All notes</span>
-        <span>{noteCount}</span>
-      </button>
-      <ol className="folder-navigation__tree folder-navigation__tree--root">
-        {folderTree.map((node) => (
-          <FolderNode
-            key={node.path}
-            node={node}
-            selectedFolderPath={selectedFolderPath}
-            expandedFolderPaths={expandedFolderPaths}
-            onSelect={onSelect}
-            onToggle={onToggle}
-          />
-        ))}
-      </ol>
+    <aside className="folder-navigation__library-column" aria-label="Library">
+      <div className="folder-navigation__library-content">
+        <p className="folder-navigation__eyebrow">{appName}</p>
+        <h1 className="folder-navigation__title">Library</h1>
+        <button
+          type="button"
+          className={
+            selectedFolderPath === null
+              ? "folder-navigation__root-button folder-navigation__root-button--selected"
+              : "folder-navigation__root-button"
+          }
+          onClick={() => onSelect(null)}
+          aria-pressed={selectedFolderPath === null}
+        >
+          <span>All notes</span>
+          <span>{noteCount}</span>
+        </button>
+        <section className="folder-navigation__folder-group" aria-label="Folders">
+          <h2 className="folder-navigation__group-heading">Folders</h2>
+          <ol className="folder-navigation__tree folder-navigation__tree--root">
+            {folderTree.map((node) => (
+              <FolderNode
+                key={node.path}
+                node={node}
+                selectedFolderPath={selectedFolderPath}
+                expandedFolderPaths={expandedFolderPaths}
+                onSelect={onSelect}
+                onToggle={onToggle}
+              />
+            ))}
+          </ol>
+        </section>
+      </div>
+      <WorkspaceSwitcher currentWorkspaceName="Personal Notes" recentWorkspaceNames={[]} />
     </aside>
   );
 }
 
-function NavigationPane({
+export function WorkspaceSwitcher({
+  currentWorkspaceName,
+  recentWorkspaceNames,
+  initiallyOpen = false,
+}: WorkspaceSwitcherProps) {
+  const [isOpen, setIsOpen] = useState(initiallyOpen);
+
+  return (
+    <div className="folder-navigation__workspace-switcher">
+      <button
+        type="button"
+        className="folder-navigation__workspace-switcher-button"
+        onClick={() => setIsOpen((currentIsOpen) => !currentIsOpen)}
+        aria-expanded={isOpen}
+      >
+        <span className="folder-navigation__workspace-name">{currentWorkspaceName}</span>
+        <span className="folder-navigation__workspace-hint">Switch workspace</span>
+      </button>
+      {isOpen ? (
+        <div className="folder-navigation__workspace-popover">
+          <p className="folder-navigation__eyebrow">Current workspace</p>
+          <p className="folder-navigation__workspace-popover-title">{currentWorkspaceName}</p>
+          <div className="folder-navigation__workspace-popover-section">
+            <p className="folder-navigation__group-heading">Recent workspaces</p>
+            {recentWorkspaceNames.length > 0 ? (
+              <ul className="folder-navigation__workspace-list">
+                {recentWorkspaceNames.map((workspaceName) => (
+                  <li key={workspaceName}>
+                    <button type="button" className="folder-navigation__workspace-action">
+                      {workspaceName}
+                    </button>
+                  </li>
+                ))}
+              </ul>
+            ) : (
+              <p className="folder-navigation__muted">No recent workspaces yet.</p>
+            )}
+          </div>
+          <div className="folder-navigation__workspace-popover-actions">
+            <button type="button" className="folder-navigation__workspace-action">
+              Add workspace
+            </button>
+            <button type="button" className="folder-navigation__workspace-action">
+              Workspace settings
+            </button>
+          </div>
+        </div>
+      ) : null}
+    </div>
+  );
+}
+
+export function NavigationPane({
   noteCount,
   folderTree,
   selectedFolderPath,
@@ -506,8 +570,8 @@ function NavigationPane({
   onSelectNote,
 }: NavigationPaneProps) {
   return (
-    <aside className="folder-navigation__navigation">
-      <Sidebar
+    <div className="folder-navigation__navigation">
+      <LibraryColumn
         noteCount={noteCount}
         folderTree={folderTree}
         selectedFolderPath={selectedFolderPath}
@@ -526,7 +590,7 @@ function NavigationPane({
         onCreateNote={onCreateNote}
         onSelectNote={onSelectNote}
       />
-    </aside>
+    </div>
   );
 }
 
@@ -542,7 +606,7 @@ function NoteList({
   onSelectNote,
 }: NoteListProps) {
   return (
-    <section className="folder-navigation__note-list" aria-label="Notes">
+    <section className="folder-navigation__notes-column" aria-label="Notes">
       <p className="folder-navigation__eyebrow">{getFolderLabel(selectedFolderPath)}</p>
       <h2 className="folder-navigation__heading">Notes</h2>
       <WorkspaceScanBanner scanState={scanState} />
@@ -1206,7 +1270,7 @@ export function FolderNavigationWorkspaceContent({
     return new Map(notes.map((note) => [note.id, note.title]));
   }, [notes]);
   const selectedResolvedNoteLinks = selectedNote
-    ? resolvedNoteLinksByNoteId.get(selectedNote.id) ?? null
+    ? (resolvedNoteLinksByNoteId.get(selectedNote.id) ?? null)
     : null;
   const saveBlockedReason =
     !canSaveNoteEditBuffer(noteEditBuffer) ||
@@ -1706,7 +1770,9 @@ export function FolderNavigationWorkspaceContent({
 
   return (
     <section
-      className={getFolderNavigationWorkspaceClassName(isDevelopmentMode && isPathChangeQueueVisible)}
+      className={getFolderNavigationWorkspaceClassName(
+        isDevelopmentMode && isPathChangeQueueVisible,
+      )}
     >
       <NavigationPane
         noteCount={notes.length}

--- a/apps/desktop/src/features/folder-navigation/ui/FolderNavigationWorkspace.tsx
+++ b/apps/desktop/src/features/folder-navigation/ui/FolderNavigationWorkspace.tsx
@@ -11,7 +11,7 @@ import {
 } from "@grove/core";
 import type { FolderScope, FolderTreeNode, ResolvedWikiLink } from "@grove/core";
 import type { MarkdownCommand, MarkdownSelection } from "@grove/editor";
-import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from "react";
+import { useCallback, useEffect, useId, useLayoutEffect, useMemo, useRef, useState } from "react";
 import type { ReactNode } from "react";
 
 import {
@@ -350,8 +350,6 @@ function getNoteIndexRefreshErrorMessage(error: unknown): string {
 const noteSaveBlockedMessage = "Wait for this note's path change to finish before saving.";
 const defaultOperationMessage =
   "Path changes refresh the folder tree and note list immediately. File and index work runs in the background.";
-const workspaceSwitcherPopoverId = "workspace-switcher-popover";
-
 const markdownToolbarCommands: readonly { command: MarkdownCommand; label: string }[] = [
   { command: "bold", label: "Bold" },
   { command: "italic", label: "Italic" },
@@ -513,6 +511,7 @@ export function WorkspaceSwitcher({
   recentWorkspaceNames,
   initiallyOpen = false,
 }: WorkspaceSwitcherProps) {
+  const popoverId = useId();
   const [isOpen, setIsOpen] = useState(initiallyOpen);
 
   return (
@@ -523,14 +522,14 @@ export function WorkspaceSwitcher({
         onClick={() => setIsOpen((currentIsOpen) => !currentIsOpen)}
         aria-expanded={isOpen}
         aria-haspopup="dialog"
-        aria-controls={isOpen ? workspaceSwitcherPopoverId : undefined}
+        aria-controls={isOpen ? popoverId : undefined}
       >
         <span className="folder-navigation__workspace-name">{currentWorkspaceName}</span>
         <span className="folder-navigation__workspace-hint">Switch workspace</span>
       </button>
       {isOpen ? (
         <WorkspaceSwitcherPopover
-          id={workspaceSwitcherPopoverId}
+          id={popoverId}
           currentWorkspaceName={currentWorkspaceName}
           recentWorkspaceNames={recentWorkspaceNames}
         />

--- a/docs/superpowers/specs/2026-04-20-desktop-library-notes-workspace-switcher-design.md
+++ b/docs/superpowers/specs/2026-04-20-desktop-library-notes-workspace-switcher-design.md
@@ -1,0 +1,180 @@
+# Desktop Library Notes Workspace Switcher Design
+
+## Summary
+Unify the desktop `Library` and `Notes` experience around an Inkdrop-style structure while keeping Grove's own visual language. The left side becomes the navigation area, the middle column shows notes for the selected scope, and the right pane remains the Markdown editor. Add a small bottom-left workspace switcher that opens a popover for switching and managing workspaces.
+
+## Scope
+- Restructure the desktop navigation surface into three visible regions:
+  - Library navigation
+  - scoped note list
+  - editor pane
+- Keep the current folder scope model: selecting a folder changes the note list scope.
+- Add a bottom-left workspace switcher entry to the Library navigation area.
+- Make the workspace switcher open a lightweight popover.
+- Remove sync timestamp/status copy from the default workspace switcher UI.
+
+## Out Of Scope
+- Implementing non-plugin sync behavior.
+- Showing sync timestamps or sync status in the workspace switcher.
+- Adding bundled sync providers.
+- Redesigning the editor internals.
+- Changing Markdown file path semantics, folder path normalization, or path change queue behavior.
+- Adding mobile navigation changes.
+
+## Current State
+`apps/desktop/src/features/folder-navigation/ui/FolderNavigationWorkspace.tsx` already composes a folder tree, a scoped note list, and an editor pane. Recent work simplified the desktop surface toward a two-pane layout, with `Sidebar` and `NoteList` grouped inside a single navigation column.
+
+The current UI labels the folder tree as `Library` and the note list as `Notes`. This is directionally correct, but the experience should read less like two unrelated sections and more like one coherent navigation system.
+
+## Goals
+- Make `Library` and `Notes` feel like one desktop navigation flow.
+- Keep folder selection and note selection visually distinct enough to remain understandable.
+- Reserve the left-bottom area for current workspace identity and switching.
+- Avoid implying that Grove has built-in sync when sync is plugin-only.
+- Preserve existing local-first folder and note state boundaries.
+
+## Chosen Approach
+Adopt the structure of Inkdrop's desktop UI, but not its dark visual style.
+
+The chosen layout:
+- left column: `Library`
+- middle column: `Notes`
+- right column: editor
+
+The Library column contains workspace-wide navigation and folder scope controls. The Notes column contains notes for the selected folder or all-notes scope. This gives the product the integrated feel of Inkdrop without copying its palette or density.
+
+This approach is preferred because it:
+- matches Grove's existing folder scope model
+- keeps folder navigation and note browsing visible at the same time
+- avoids hiding core navigation behind a hamburger menu or modal
+- creates a stable home for workspace switching
+- can be implemented by reshaping the existing `FolderNavigationWorkspace` UI instead of replacing the feature model
+
+## Layout Design
+### Library Column
+The Library column is the leftmost column.
+
+Default contents:
+- Grove app label
+- `Library` heading
+- `All Notes`
+- `Pinned Notes` placeholder if supported by the current UI slice, otherwise leave it out until the model exists
+- `Folders` group
+- folder tree with note counts
+- `Tools` group for existing non-folder destinations when available
+- bottom-left workspace switcher
+
+The Library column should use Grove's light visual treatment:
+- light background
+- subtle borders
+- selected folder or all-notes state using the existing green accent
+- no dark Inkdrop-style sidebar
+
+### Notes Column
+The Notes column sits between Library and the editor.
+
+Default contents:
+- selected scope label, such as `All Notes`, `Projects`, or `Mobile app`
+- `Notes` heading
+- search field scoped to the current folder selection
+- `New` action for creating a note in the current scope
+- note list for `scopedNotes`
+
+Selecting a folder updates the Notes column but does not close the active editor content. This preserves the existing distinction between browse scope and active note editing.
+
+### Editor Pane
+The editor pane remains the rightmost pane.
+
+The design does not require editor behavior changes. Existing note load, save, dirty buffer, path change blocking, note links, backlinks, and contextual action behavior remain governed by the current folder-navigation feature model.
+
+## Workspace Switcher
+The workspace switcher is fixed at the bottom of the Library column.
+
+Collapsed state:
+- shows the current workspace name
+- shows a neutral action hint such as `Switch workspace`
+- does not show sync timestamps
+- does not show sync state
+
+Example copy:
+
+```text
+Personal Notes
+Switch workspace
+```
+
+Popover contents:
+- current workspace name
+- recent workspaces
+- `Add workspace`
+- `Workspace settings`
+
+The popover should be lightweight and local to the desktop shell. It should not become a full workspace management page for this slice.
+
+## Sync Display Policy
+Do not show sync date, sync status, or cloud status in this design.
+
+Reason:
+- Grove currently has no built-in sync outside plugins.
+- Sync is default-off and provider-backed by plugins.
+- Showing `Synced at ...` would imply a first-party sync system exists.
+
+Future plugin-backed sync UI can add provider-specific status later through a dedicated plugin or sync surface. The workspace switcher may link to sync settings in the future, but it should not display sync state until the product has an explicit source for that state.
+
+## State And Data Flow
+Preserve the current folder-navigation state boundaries:
+- `selectedFolderPath` controls the note list scope.
+- `expandedFolderPaths` controls folder tree expansion.
+- `scopedNotes` is derived from `notes` and `selectedFolderPath`.
+- active editor content remains selected by note id and note edit buffer state.
+
+Workspace switcher state should be separate from folder navigation state:
+- current workspace identity belongs to workspace state
+- popover open/closed state can stay local to the UI component
+- recent workspaces belong to workspace management state once that model exists
+
+Do not store absolute workspace paths in folder navigation state. If a workspace path is displayed later, derive a shortened display label from workspace state rather than mixing it into folder path semantics.
+
+## Component Direction
+Expected UI decomposition:
+- `LibraryColumn`
+- `FolderTree`
+- `WorkspaceSwitcher`
+- `WorkspaceSwitcherPopover`
+- `NotesColumn`
+- existing editor pane components
+
+`FolderNavigationWorkspace` can remain the feature entry point. The internal component names can change as needed, but FSD boundaries should remain unchanged under `features/folder-navigation`.
+
+## Testing Strategy
+Add or update focused component tests for `FolderNavigationWorkspace`.
+
+Test coverage should verify:
+- the Library column contains all-notes and folder navigation
+- selecting a folder changes the Notes column scope
+- the Notes column renders notes for the selected folder scope
+- the workspace switcher is visible at the bottom of the Library column
+- opening the workspace switcher shows recent workspace, add workspace, and settings actions once those props/state exist
+- the workspace switcher does not render sync timestamp or sync status copy
+- existing note selection and editor loading behavior still works
+
+Model tests should only be added if workspace switching introduces a new workspace state helper. This design should not require changes to `packages/core` folder semantics.
+
+## Risks And Mitigations
+- Risk: the UI appears like a three-column regression after recent two-pane simplification.
+  - Mitigation: treat the left and middle columns as one navigation system visually, with consistent spacing and shared hierarchy.
+- Risk: workspace switching scope grows into full workspace management.
+  - Mitigation: keep this slice to a bottom-left trigger and a small popover.
+- Risk: sync copy leaks back into the UI.
+  - Mitigation: make "no sync timestamp/status" an explicit acceptance criterion and test assertion.
+- Risk: `Pinned Notes` or `Tools` imply unavailable features.
+  - Mitigation: only render items backed by current behavior, or mark them as separate follow-up slices.
+
+## Acceptance Criteria
+- Library and Notes read as a unified desktop navigation experience.
+- The desktop layout follows the structure: Library column, Notes column, editor pane.
+- Grove keeps a light visual style rather than an Inkdrop dark sidebar.
+- The bottom-left workspace switcher is present.
+- Clicking the workspace switcher opens a popover for recent workspaces, adding a workspace, and workspace settings.
+- The workspace switcher does not show sync timestamps or sync status.
+- Existing folder selection, note selection, note creation, save, delete, move, rename, and path-change guardrails remain intact.

--- a/docs/superpowers/specs/2026-04-20-desktop-library-notes-workspace-switcher-design.md
+++ b/docs/superpowers/specs/2026-04-20-desktop-library-notes-workspace-switcher-design.md
@@ -1,9 +1,11 @@
 # Desktop Library Notes Workspace Switcher Design
 
 ## Summary
+
 Unify the desktop `Library` and `Notes` experience around an Inkdrop-style structure while keeping Grove's own visual language. The left side becomes the navigation area, the middle column shows notes for the selected scope, and the right pane remains the Markdown editor. Add a small bottom-left workspace switcher that opens a popover for switching and managing workspaces.
 
 ## Scope
+
 - Restructure the desktop navigation surface into three visible regions:
   - Library navigation
   - scoped note list
@@ -14,6 +16,7 @@ Unify the desktop `Library` and `Notes` experience around an Inkdrop-style struc
 - Remove sync timestamp/status copy from the default workspace switcher UI.
 
 ## Out Of Scope
+
 - Implementing non-plugin sync behavior.
 - Showing sync timestamps or sync status in the workspace switcher.
 - Adding bundled sync providers.
@@ -22,11 +25,13 @@ Unify the desktop `Library` and `Notes` experience around an Inkdrop-style struc
 - Adding mobile navigation changes.
 
 ## Current State
+
 `apps/desktop/src/features/folder-navigation/ui/FolderNavigationWorkspace.tsx` already composes a folder tree, a scoped note list, and an editor pane. Recent work simplified the desktop surface toward a two-pane layout, with `Sidebar` and `NoteList` grouped inside a single navigation column.
 
 The current UI labels the folder tree as `Library` and the note list as `Notes`. This is directionally correct, but the experience should read less like two unrelated sections and more like one coherent navigation system.
 
 ## Goals
+
 - Make `Library` and `Notes` feel like one desktop navigation flow.
 - Keep folder selection and note selection visually distinct enough to remain understandable.
 - Reserve the left-bottom area for current workspace identity and switching.
@@ -34,9 +39,11 @@ The current UI labels the folder tree as `Library` and the note list as `Notes`.
 - Preserve existing local-first folder and note state boundaries.
 
 ## Chosen Approach
+
 Adopt the structure of Inkdrop's desktop UI, but not its dark visual style.
 
 The chosen layout:
+
 - left column: `Library`
 - middle column: `Notes`
 - right column: editor
@@ -44,6 +51,7 @@ The chosen layout:
 The Library column contains workspace-wide navigation and folder scope controls. The Notes column contains notes for the selected folder or all-notes scope. This gives the product the integrated feel of Inkdrop without copying its palette or density.
 
 This approach is preferred because it:
+
 - matches Grove's existing folder scope model
 - keeps folder navigation and note browsing visible at the same time
 - avoids hiding core navigation behind a hamburger menu or modal
@@ -51,10 +59,13 @@ This approach is preferred because it:
 - can be implemented by reshaping the existing `FolderNavigationWorkspace` UI instead of replacing the feature model
 
 ## Layout Design
+
 ### Library Column
+
 The Library column is the leftmost column.
 
 Default contents:
+
 - Grove app label
 - `Library` heading
 - `All Notes`
@@ -65,15 +76,18 @@ Default contents:
 - bottom-left workspace switcher
 
 The Library column should use Grove's light visual treatment:
+
 - light background
 - subtle borders
 - selected folder or all-notes state using the existing green accent
 - no dark Inkdrop-style sidebar
 
 ### Notes Column
+
 The Notes column sits between Library and the editor.
 
 Default contents:
+
 - selected scope label, such as `All Notes`, `Projects`, or `Mobile app`
 - `Notes` heading
 - search field scoped to the current folder selection
@@ -83,14 +97,17 @@ Default contents:
 Selecting a folder updates the Notes column but does not close the active editor content. This preserves the existing distinction between browse scope and active note editing.
 
 ### Editor Pane
+
 The editor pane remains the rightmost pane.
 
 The design does not require editor behavior changes. Existing note load, save, dirty buffer, path change blocking, note links, backlinks, and contextual action behavior remain governed by the current folder-navigation feature model.
 
 ## Workspace Switcher
+
 The workspace switcher is fixed at the bottom of the Library column.
 
 Collapsed state:
+
 - shows the current workspace name
 - shows a neutral action hint such as `Switch workspace`
 - does not show sync timestamps
@@ -104,6 +121,7 @@ Switch workspace
 ```
 
 Popover contents:
+
 - current workspace name
 - recent workspaces
 - `Add workspace`
@@ -112,9 +130,11 @@ Popover contents:
 The popover should be lightweight and local to the desktop shell. It should not become a full workspace management page for this slice.
 
 ## Sync Display Policy
+
 Do not show sync date, sync status, or cloud status in this design.
 
 Reason:
+
 - Grove currently has no built-in sync outside plugins.
 - Sync is default-off and provider-backed by plugins.
 - Showing `Synced at ...` would imply a first-party sync system exists.
@@ -122,13 +142,16 @@ Reason:
 Future plugin-backed sync UI can add provider-specific status later through a dedicated plugin or sync surface. The workspace switcher may link to sync settings in the future, but it should not display sync state until the product has an explicit source for that state.
 
 ## State And Data Flow
+
 Preserve the current folder-navigation state boundaries:
+
 - `selectedFolderPath` controls the note list scope.
 - `expandedFolderPaths` controls folder tree expansion.
 - `scopedNotes` is derived from `notes` and `selectedFolderPath`.
 - active editor content remains selected by note id and note edit buffer state.
 
 Workspace switcher state should be separate from folder navigation state:
+
 - current workspace identity belongs to workspace state
 - popover open/closed state can stay local to the UI component
 - recent workspaces belong to workspace management state once that model exists
@@ -136,7 +159,9 @@ Workspace switcher state should be separate from folder navigation state:
 Do not store absolute workspace paths in folder navigation state. If a workspace path is displayed later, derive a shortened display label from workspace state rather than mixing it into folder path semantics.
 
 ## Component Direction
+
 Expected UI decomposition:
+
 - `LibraryColumn`
 - `FolderTree`
 - `WorkspaceSwitcher`
@@ -147,9 +172,11 @@ Expected UI decomposition:
 `FolderNavigationWorkspace` can remain the feature entry point. The internal component names can change as needed, but FSD boundaries should remain unchanged under `features/folder-navigation`.
 
 ## Testing Strategy
+
 Add or update focused component tests for `FolderNavigationWorkspace`.
 
 Test coverage should verify:
+
 - the Library column contains all-notes and folder navigation
 - selecting a folder changes the Notes column scope
 - the Notes column renders notes for the selected folder scope
@@ -161,6 +188,7 @@ Test coverage should verify:
 Model tests should only be added if workspace switching introduces a new workspace state helper. This design should not require changes to `packages/core` folder semantics.
 
 ## Risks And Mitigations
+
 - Risk: the UI appears like a three-column regression after recent two-pane simplification.
   - Mitigation: treat the left and middle columns as one navigation system visually, with consistent spacing and shared hierarchy.
 - Risk: workspace switching scope grows into full workspace management.
@@ -171,6 +199,7 @@ Model tests should only be added if workspace switching introduces a new workspa
   - Mitigation: only render items backed by current behavior, or mark them as separate follow-up slices.
 
 ## Acceptance Criteria
+
 - Library and Notes read as a unified desktop navigation experience.
 - The desktop layout follows the structure: Library column, Notes column, editor pane.
 - Grove keeps a light visual style rather than an Inkdrop dark sidebar.


### PR DESCRIPTION
## Summary
- split the desktop surface into Library, scoped Notes, and editor regions while preserving folder and note selection behavior
- add a bottom-left workspace switcher with a lightweight popover for recent workspaces, add workspace, and settings actions
- add focused FolderNavigationWorkspace tests for the new navigation columns, scoped notes, workspace switcher, and no-sync-copy policy

## Testing
- pnpm test
- pnpm typecheck
- pnpm lint
- pnpm --filter @grove/desktop build
- pnpm --filter @grove/desktop test -- FolderNavigationWorkspace.test.tsx
- pnpm --filter @grove/desktop typecheck
- pnpm exec oxfmt --check apps/desktop/src/features/folder-navigation/ui/FolderNavigationWorkspace.tsx apps/desktop/src/features/folder-navigation/ui/FolderNavigationWorkspace.test.tsx apps/desktop/src/features/folder-navigation/ui/FolderNavigationWorkspace.css
- git diff --check
- git diff --cached --check

## Notes
- `pnpm format` still reports pre-existing formatting issues in untouched docs/tmp files, so this PR verified formatting for the changed files directly.

Refs #80
