### PR TITLE
Add desktop workspace registry commands

### DIFF
--- a/apps/desktop/src-tauri/Cargo.toml
+++ b/apps/desktop/src-tauri/Cargo.toml
@@ -13,4 +13,4 @@ anyhow = "1"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 tauri = { version = "2.0.0", features = [] }
-tokio = { version = "1", features = ["fs", "io-util", "rt"] }
+tokio = { version = "1", features = ["fs", "io-util", "rt", "sync"] }

--- a/apps/desktop/src-tauri/src/main.rs
+++ b/apps/desktop/src-tauri/src/main.rs
@@ -50,6 +50,26 @@ struct DeleteMarkdownNoteRequest {
     path: String,
 }
 
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct AddWorkspaceRequest {
+    name: String,
+    root_path: PathBuf,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct WorkspaceIdRequest {
+    id: String,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct RenameWorkspaceRequest {
+    id: String,
+    name: String,
+}
+
 #[derive(Debug, Deserialize, Serialize)]
 #[serde(rename_all = "kebab-case")]
 enum IndexRefreshReason {
@@ -77,6 +97,22 @@ struct ScannedMarkdownNote {
     updated_at_unix_ms: u128,
 }
 
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct DesktopWorkspace {
+    id: String,
+    name: String,
+    root_path: PathBuf,
+    last_opened_at_unix_ms: u128,
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct WorkspaceRegistry {
+    active_workspace_id: String,
+    workspaces: Vec<DesktopWorkspace>,
+}
+
 #[derive(Debug, Serialize)]
 #[serde(rename_all = "camelCase")]
 struct CommandError {
@@ -93,6 +129,74 @@ impl CommandError {
     }
 }
 
+impl std::fmt::Display for CommandError {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(formatter, "{}: {}", self.code, self.message)
+    }
+}
+
+impl std::error::Error for CommandError {}
+
+#[tauri::command]
+async fn list_workspaces(
+    app_handle: tauri::AppHandle,
+) -> Result<Vec<DesktopWorkspace>, CommandError> {
+    let registry = load_or_create_app_workspace_registry(&app_handle).await?;
+
+    Ok(registry.workspaces)
+}
+
+#[tauri::command]
+async fn get_active_workspace(
+    app_handle: tauri::AppHandle,
+) -> Result<DesktopWorkspace, CommandError> {
+    let registry = load_or_create_app_workspace_registry(&app_handle).await?;
+
+    find_active_workspace(&registry).cloned().ok_or_else(|| {
+        CommandError::new(
+            "active_workspace_unavailable",
+            "The active workspace is unavailable.",
+        )
+    })
+}
+
+#[tauri::command]
+async fn add_workspace(
+    app_handle: tauri::AppHandle,
+    workspace: AddWorkspaceRequest,
+) -> Result<DesktopWorkspace, CommandError> {
+    add_workspace_to_registry(
+        &app_data_dir(&app_handle)?,
+        &workspace.name,
+        workspace.root_path,
+    )
+    .await
+}
+
+#[tauri::command]
+async fn switch_workspace(
+    app_handle: tauri::AppHandle,
+    workspace: WorkspaceIdRequest,
+) -> Result<DesktopWorkspace, CommandError> {
+    switch_active_workspace_in_registry(&app_data_dir(&app_handle)?, &workspace.id).await
+}
+
+#[tauri::command]
+async fn rename_workspace(
+    app_handle: tauri::AppHandle,
+    workspace: RenameWorkspaceRequest,
+) -> Result<DesktopWorkspace, CommandError> {
+    rename_workspace_in_registry(&app_data_dir(&app_handle)?, &workspace.id, &workspace.name).await
+}
+
+#[tauri::command]
+async fn remove_workspace(
+    app_handle: tauri::AppHandle,
+    workspace: WorkspaceIdRequest,
+) -> Result<(), CommandError> {
+    remove_workspace_from_registry(&app_data_dir(&app_handle)?, &workspace.id).await
+}
+
 #[tauri::command]
 async fn move_markdown_file(
     app_handle: tauri::AppHandle,
@@ -105,7 +209,7 @@ async fn move_markdown_file(
         ));
     }
 
-    let workspace_root = default_workspace_root(&app_handle)?;
+    let workspace_root = active_workspace_root(&app_handle).await?;
     let previous_path = resolve_markdown_path(&workspace_root, &change.previous_path)?;
     let next_path = resolve_markdown_path(&workspace_root, &change.next_path)?;
 
@@ -139,7 +243,7 @@ async fn refresh_note_indexes(
 async fn scan_markdown_workspace(
     app_handle: tauri::AppHandle,
 ) -> Result<Vec<ScannedMarkdownNote>, CommandError> {
-    let workspace_root = default_workspace_root(&app_handle)?;
+    let workspace_root = active_workspace_root(&app_handle).await?;
 
     tokio::fs::create_dir_all(&workspace_root)
         .await
@@ -155,7 +259,7 @@ async fn read_markdown_note(
     app_handle: tauri::AppHandle,
     note: ReadMarkdownNoteRequest,
 ) -> Result<String, CommandError> {
-    let workspace_root = default_workspace_root(&app_handle)?;
+    let workspace_root = active_workspace_root(&app_handle).await?;
     let note_path = resolve_markdown_path(&workspace_root, &note.path)?;
 
     read_markdown_file(&note_path)
@@ -168,7 +272,7 @@ async fn create_markdown_note(
     app_handle: tauri::AppHandle,
     note: CreateMarkdownNoteRequest,
 ) -> Result<ScannedMarkdownNote, CommandError> {
-    let workspace_root = default_workspace_root(&app_handle)?;
+    let workspace_root = active_workspace_root(&app_handle).await?;
     let note_path = resolve_markdown_path(&workspace_root, &note.path)?;
 
     create_markdown_file(&note_path, note.content.as_bytes())
@@ -185,7 +289,7 @@ async fn write_markdown_note(
     app_handle: tauri::AppHandle,
     note: WriteMarkdownNoteRequest,
 ) -> Result<ScannedMarkdownNote, CommandError> {
-    let workspace_root = default_workspace_root(&app_handle)?;
+    let workspace_root = active_workspace_root(&app_handle).await?;
     let note_path = resolve_markdown_path(&workspace_root, &note.path)?;
 
     write_markdown_file(&note_path, note.content.as_bytes())
@@ -202,7 +306,7 @@ async fn delete_markdown_note(
     app_handle: tauri::AppHandle,
     note: DeleteMarkdownNoteRequest,
 ) -> Result<(), CommandError> {
-    let workspace_root = default_workspace_root(&app_handle)?;
+    let workspace_root = active_workspace_root(&app_handle).await?;
     let note_path = resolve_markdown_path(&workspace_root, &note.path)?;
 
     delete_markdown_file(&note_path)
@@ -213,12 +317,18 @@ async fn delete_markdown_note(
 fn main() {
     if let Err(error) = tauri::Builder::default()
         .invoke_handler(tauri::generate_handler![
+            add_workspace,
             create_markdown_note,
             delete_markdown_note,
+            get_active_workspace,
+            list_workspaces,
             move_markdown_file,
             read_markdown_note,
             refresh_note_indexes,
+            remove_workspace,
+            rename_workspace,
             scan_markdown_workspace,
+            switch_workspace,
             write_markdown_note
         ])
         .run(tauri::generate_context!())
@@ -227,12 +337,321 @@ fn main() {
     }
 }
 
-fn default_workspace_root(app_handle: &tauri::AppHandle) -> Result<PathBuf, CommandError> {
+fn app_data_dir(app_handle: &tauri::AppHandle) -> Result<PathBuf, CommandError> {
     app_handle
         .path()
         .app_data_dir()
-        .map(|path| path.join("workspaces").join("default"))
-        .map_err(|error| CommandError::new("workspace_root_unavailable", error.to_string()))
+        .map_err(|error| CommandError::new("app_data_dir_unavailable", error.to_string()))
+}
+
+async fn active_workspace_root(app_handle: &tauri::AppHandle) -> Result<PathBuf, CommandError> {
+    let registry = load_or_create_app_workspace_registry(app_handle).await?;
+    let workspace = find_active_workspace(&registry).ok_or_else(|| {
+        CommandError::new(
+            "active_workspace_unavailable",
+            "The active workspace is unavailable.",
+        )
+    })?;
+
+    tokio::fs::create_dir_all(&workspace.root_path)
+        .await
+        .map_err(|error| CommandError::new("workspace_root_unavailable", error.to_string()))?;
+
+    Ok(workspace.root_path.clone())
+}
+
+async fn load_or_create_app_workspace_registry(
+    app_handle: &tauri::AppHandle,
+) -> Result<WorkspaceRegistry, CommandError> {
+    load_or_create_workspace_registry(&app_data_dir(app_handle)?).await
+}
+
+fn default_workspace_root_from_app_data_dir(app_data_dir: &Path) -> PathBuf {
+    app_data_dir.join("workspaces").join("default")
+}
+
+fn workspace_registry_path(app_data_dir: &Path) -> PathBuf {
+    app_data_dir.join("workspace-registry.json")
+}
+
+fn default_workspace(app_data_dir: &Path, last_opened_at_unix_ms: u128) -> DesktopWorkspace {
+    DesktopWorkspace {
+        id: "default".to_string(),
+        name: "Personal Notes".to_string(),
+        root_path: default_workspace_root_from_app_data_dir(app_data_dir),
+        last_opened_at_unix_ms,
+    }
+}
+
+async fn load_or_create_workspace_registry(
+    app_data_dir: &Path,
+) -> Result<WorkspaceRegistry, CommandError> {
+    let registry_path = workspace_registry_path(app_data_dir);
+
+    if !tokio::fs::try_exists(&registry_path)
+        .await
+        .map_err(|error| CommandError::new("workspace_registry_unavailable", error.to_string()))?
+    {
+        let registry = WorkspaceRegistry {
+            active_workspace_id: "default".to_string(),
+            workspaces: vec![default_workspace(app_data_dir, current_unix_ms()?)],
+        };
+        tokio::fs::create_dir_all(default_workspace_root_from_app_data_dir(app_data_dir))
+            .await
+            .map_err(|error| CommandError::new("workspace_root_unavailable", error.to_string()))?;
+        save_workspace_registry(app_data_dir, &registry).await?;
+        return Ok(registry);
+    }
+
+    let registry_content = tokio::fs::read_to_string(&registry_path)
+        .await
+        .map_err(|error| CommandError::new("workspace_registry_unavailable", error.to_string()))?;
+    let mut registry: WorkspaceRegistry = serde_json::from_str(&registry_content)
+        .map_err(|error| CommandError::new("workspace_registry_invalid", error.to_string()))?;
+
+    if registry.workspaces.is_empty() {
+        registry.active_workspace_id = "default".to_string();
+        registry
+            .workspaces
+            .push(default_workspace(app_data_dir, current_unix_ms()?));
+        save_workspace_registry(app_data_dir, &registry).await?;
+    }
+
+    if find_active_workspace(&registry).is_none() {
+        registry.active_workspace_id = registry.workspaces[0].id.clone();
+        save_workspace_registry(app_data_dir, &registry).await?;
+    }
+
+    Ok(registry)
+}
+
+async fn add_workspace_to_registry(
+    app_data_dir: &Path,
+    name: &str,
+    root_path: PathBuf,
+) -> Result<DesktopWorkspace, CommandError> {
+    let mut registry = load_or_create_workspace_registry(app_data_dir).await?;
+    let name = validate_workspace_name(name)?;
+    let root_path = validate_workspace_root(root_path).await?;
+
+    if registry
+        .workspaces
+        .iter()
+        .any(|workspace| workspace.root_path == root_path)
+    {
+        return Err(CommandError::new(
+            "workspace_root_exists",
+            "That workspace root is already registered.",
+        ));
+    }
+
+    let workspace = DesktopWorkspace {
+        id: create_workspace_id(&name, &registry.workspaces),
+        name,
+        root_path,
+        last_opened_at_unix_ms: current_unix_ms()?,
+    };
+    registry.active_workspace_id = workspace.id.clone();
+    registry.workspaces.push(workspace.clone());
+    save_workspace_registry(app_data_dir, &registry).await?;
+
+    Ok(workspace)
+}
+
+async fn switch_active_workspace_in_registry(
+    app_data_dir: &Path,
+    workspace_id: &str,
+) -> Result<DesktopWorkspace, CommandError> {
+    let mut registry = load_or_create_workspace_registry(app_data_dir).await?;
+    let workspace_index = find_workspace_index(&registry, workspace_id)?;
+    registry.active_workspace_id = workspace_id.to_string();
+    registry.workspaces[workspace_index].last_opened_at_unix_ms = current_unix_ms()?;
+    let workspace = registry.workspaces[workspace_index].clone();
+    tokio::fs::create_dir_all(&workspace.root_path)
+        .await
+        .map_err(|error| CommandError::new("workspace_root_unavailable", error.to_string()))?;
+    save_workspace_registry(app_data_dir, &registry).await?;
+
+    Ok(workspace)
+}
+
+async fn rename_workspace_in_registry(
+    app_data_dir: &Path,
+    workspace_id: &str,
+    name: &str,
+) -> Result<DesktopWorkspace, CommandError> {
+    let mut registry = load_or_create_workspace_registry(app_data_dir).await?;
+    let workspace_index = find_workspace_index(&registry, workspace_id)?;
+    registry.workspaces[workspace_index].name = validate_workspace_name(name)?;
+    let workspace = registry.workspaces[workspace_index].clone();
+    save_workspace_registry(app_data_dir, &registry).await?;
+
+    Ok(workspace)
+}
+
+async fn remove_workspace_from_registry(
+    app_data_dir: &Path,
+    workspace_id: &str,
+) -> Result<(), CommandError> {
+    let mut registry = load_or_create_workspace_registry(app_data_dir).await?;
+    find_workspace_index(&registry, workspace_id)?;
+    registry
+        .workspaces
+        .retain(|workspace| workspace.id != workspace_id);
+
+    if registry.workspaces.is_empty() {
+        registry.active_workspace_id = "default".to_string();
+        registry
+            .workspaces
+            .push(default_workspace(app_data_dir, current_unix_ms()?));
+    } else if registry.active_workspace_id == workspace_id {
+        let active_workspace_id = registry
+            .workspaces
+            .iter()
+            .max_by_key(|workspace| workspace.last_opened_at_unix_ms)
+            .map(|workspace| workspace.id.clone())
+            .ok_or_else(|| {
+                CommandError::new(
+                    "active_workspace_unavailable",
+                    "The active workspace is unavailable.",
+                )
+            })?;
+        registry.active_workspace_id = active_workspace_id;
+    }
+
+    save_workspace_registry(app_data_dir, &registry).await
+}
+
+async fn save_workspace_registry(
+    app_data_dir: &Path,
+    registry: &WorkspaceRegistry,
+) -> Result<(), CommandError> {
+    tokio::fs::create_dir_all(app_data_dir)
+        .await
+        .map_err(|error| CommandError::new("workspace_registry_unavailable", error.to_string()))?;
+
+    let registry_path = workspace_registry_path(app_data_dir);
+    let registry_json = serde_json::to_vec_pretty(registry)
+        .map_err(|error| CommandError::new("workspace_registry_invalid", error.to_string()))?;
+    let temporary_path = registry_path.with_extension("json.tmp");
+
+    tokio::fs::write(&temporary_path, registry_json)
+        .await
+        .map_err(|error| CommandError::new("workspace_registry_unavailable", error.to_string()))?;
+    replace_file_with_temporary_path(&temporary_path, &registry_path)
+        .await
+        .map_err(|error| CommandError::new("workspace_registry_unavailable", error.to_string()))
+}
+
+async fn validate_workspace_root(root_path: PathBuf) -> Result<PathBuf, CommandError> {
+    if root_path.as_os_str().is_empty() || !root_path.is_absolute() {
+        return Err(CommandError::new(
+            "invalid_workspace_root",
+            "Workspace roots must be absolute paths.",
+        ));
+    }
+
+    if tokio::fs::try_exists(&root_path)
+        .await
+        .map_err(|error| CommandError::new("invalid_workspace_root", error.to_string()))?
+        && !tokio::fs::metadata(&root_path)
+            .await
+            .map_err(|error| CommandError::new("invalid_workspace_root", error.to_string()))?
+            .is_dir()
+    {
+        return Err(CommandError::new(
+            "invalid_workspace_root",
+            "Workspace roots must point to a directory.",
+        ));
+    }
+
+    tokio::fs::create_dir_all(&root_path)
+        .await
+        .map_err(|error| CommandError::new("invalid_workspace_root", error.to_string()))?;
+
+    Ok(root_path)
+}
+
+fn validate_workspace_name(name: &str) -> Result<String, CommandError> {
+    let name = name.trim();
+
+    if name.is_empty() {
+        return Err(CommandError::new(
+            "invalid_workspace_name",
+            "A workspace name is required.",
+        ));
+    }
+
+    Ok(name.to_string())
+}
+
+fn find_workspace_index(
+    registry: &WorkspaceRegistry,
+    workspace_id: &str,
+) -> Result<usize, CommandError> {
+    registry
+        .workspaces
+        .iter()
+        .position(|workspace| workspace.id == workspace_id)
+        .ok_or_else(|| {
+            CommandError::new(
+                "workspace_not_found",
+                "The requested workspace is not registered.",
+            )
+        })
+}
+
+fn find_active_workspace(registry: &WorkspaceRegistry) -> Option<&DesktopWorkspace> {
+    registry
+        .workspaces
+        .iter()
+        .find(|workspace| workspace.id == registry.active_workspace_id)
+}
+
+fn create_workspace_id(name: &str, workspaces: &[DesktopWorkspace]) -> String {
+    let base_id = slugify_workspace_name(name);
+    let mut candidate = base_id.clone();
+    let mut suffix = 2;
+
+    while workspaces.iter().any(|workspace| workspace.id == candidate) {
+        candidate = format!("{base_id}-{suffix}");
+        suffix += 1;
+    }
+
+    candidate
+}
+
+fn slugify_workspace_name(name: &str) -> String {
+    let mut slug = String::new();
+    let mut previous_was_separator = false;
+
+    for character in name.chars().flat_map(char::to_lowercase) {
+        if character.is_ascii_alphanumeric() {
+            slug.push(character);
+            previous_was_separator = false;
+            continue;
+        }
+
+        if !slug.is_empty() && !previous_was_separator {
+            slug.push('-');
+            previous_was_separator = true;
+        }
+    }
+
+    let slug = slug.trim_matches('-');
+
+    if slug.is_empty() {
+        return "workspace".to_string();
+    }
+
+    slug.to_string()
+}
+
+fn current_unix_ms() -> Result<u128, CommandError> {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|duration| duration.as_millis())
+        .map_err(|error| CommandError::new("system_time_unavailable", error.to_string()))
 }
 
 fn resolve_markdown_path(workspace_root: &Path, path: &str) -> Result<PathBuf, CommandError> {
@@ -670,10 +1089,12 @@ mod tests {
     };
 
     use super::{
-        create_markdown_file, delete_markdown_file, derive_markdown_title, find_first_markdown_heading,
-        get_temporary_write_path,
-        get_workspace_relative_markdown_path, move_file_without_overwrite, read_markdown_file,
-        scan_markdown_files, system_time_to_unix_ms, validate_markdown_path, write_markdown_file,
+        add_workspace_to_registry, create_markdown_file, delete_markdown_file,
+        derive_markdown_title, find_first_markdown_heading, get_temporary_write_path,
+        get_workspace_relative_markdown_path, load_or_create_workspace_registry,
+        move_file_without_overwrite, read_markdown_file, remove_workspace_from_registry,
+        rename_workspace_in_registry, scan_markdown_files, switch_active_workspace_in_registry,
+        system_time_to_unix_ms, validate_markdown_path, write_markdown_file,
     };
 
     fn run_async<F>(future: F) -> F::Output
@@ -738,6 +1159,103 @@ mod tests {
     }
 
     #[test]
+    fn creates_a_default_workspace_registry_on_first_run() {
+        run_async(async {
+            let app_data_dir = unique_test_dir("creates-default-workspace-registry");
+
+            let registry = load_or_create_workspace_registry(&app_data_dir).await?;
+
+            assert_eq!(registry.active_workspace_id, "default");
+            assert_eq!(registry.workspaces.len(), 1);
+            assert_eq!(registry.workspaces[0].id, "default");
+            assert_eq!(registry.workspaces[0].name, "Personal Notes");
+            assert_eq!(
+                registry.workspaces[0].root_path,
+                app_data_dir.join("workspaces").join("default")
+            );
+            assert!(tokio::fs::try_exists(app_data_dir.join("workspace-registry.json")).await?);
+            assert!(tokio::fs::try_exists(&registry.workspaces[0].root_path).await?);
+            tokio::fs::remove_dir_all(&app_data_dir).await?;
+            anyhow::Ok(())
+        })
+        .expect("default workspace registry should be created");
+    }
+
+    #[test]
+    fn persists_added_workspace_and_switches_active_workspace() {
+        run_async(async {
+            let app_data_dir = unique_test_dir("persists-added-workspace");
+            let workspace_root = unique_test_dir("external-workspace-root");
+            tokio::fs::create_dir_all(&workspace_root).await?;
+            load_or_create_workspace_registry(&app_data_dir).await?;
+
+            let added_workspace =
+                add_workspace_to_registry(&app_data_dir, "Research", workspace_root.clone())
+                    .await?;
+            switch_active_workspace_in_registry(&app_data_dir, &added_workspace.id).await?;
+            let registry = load_or_create_workspace_registry(&app_data_dir).await?;
+
+            assert_eq!(registry.active_workspace_id, added_workspace.id);
+            assert!(registry
+                .workspaces
+                .iter()
+                .any(|workspace| workspace.name == "Research"
+                    && workspace.root_path == workspace_root));
+            tokio::fs::remove_dir_all(&app_data_dir).await?;
+            tokio::fs::remove_dir_all(&workspace_root).await?;
+            anyhow::Ok(())
+        })
+        .expect("added workspace should persist and become switchable");
+    }
+
+    #[test]
+    fn renames_and_removes_workspaces_without_deleting_markdown_files() {
+        run_async(async {
+            let app_data_dir = unique_test_dir("renames-and-removes-workspace");
+            let workspace_root = unique_test_dir("workspace-to-remove");
+            let note_path = workspace_root.join("Plan.md");
+            tokio::fs::create_dir_all(&workspace_root).await?;
+            tokio::fs::write(&note_path, "# Plan").await?;
+            load_or_create_workspace_registry(&app_data_dir).await?;
+            let added_workspace =
+                add_workspace_to_registry(&app_data_dir, "Research", workspace_root.clone())
+                    .await?;
+
+            rename_workspace_in_registry(&app_data_dir, &added_workspace.id, "Archive").await?;
+            remove_workspace_from_registry(&app_data_dir, &added_workspace.id).await?;
+            let registry = load_or_create_workspace_registry(&app_data_dir).await?;
+
+            assert!(!registry
+                .workspaces
+                .iter()
+                .any(|workspace| workspace.id == added_workspace.id));
+            assert!(tokio::fs::try_exists(&note_path).await?);
+            tokio::fs::remove_dir_all(&app_data_dir).await?;
+            tokio::fs::remove_dir_all(&workspace_root).await?;
+            anyhow::Ok(())
+        })
+        .expect("workspace metadata removal should preserve files");
+    }
+
+    #[test]
+    fn rejects_invalid_workspace_roots() {
+        run_async(async {
+            let app_data_dir = unique_test_dir("rejects-invalid-workspace-roots");
+            load_or_create_workspace_registry(&app_data_dir).await?;
+
+            let error =
+                add_workspace_to_registry(&app_data_dir, "Relative", PathBuf::from("Notes"))
+                    .await
+                    .expect_err("relative workspace roots should be rejected");
+
+            assert_eq!(error.code, "invalid_workspace_root");
+            tokio::fs::remove_dir_all(&app_data_dir).await?;
+            anyhow::Ok(())
+        })
+        .expect("invalid workspace root test should run");
+    }
+
+    #[test]
     fn derives_workspace_relative_markdown_paths() {
         let workspace_dir = PathBuf::from("/workspace");
         let markdown_path = workspace_dir.join("Projects").join("Grove").join("Plan.md");
@@ -784,7 +1302,10 @@ mod tests {
 
     #[test]
     fn derives_title_from_first_h1_before_the_file_stem() {
-        assert_eq!(derive_markdown_title("## Context\n# Plan ###", "Fallback"), "Plan");
+        assert_eq!(
+            derive_markdown_title("## Context\n# Plan ###", "Fallback"),
+            "Plan"
+        );
     }
 
     #[test]

--- a/apps/desktop/src-tauri/src/main.rs
+++ b/apps/desktop/src-tauri/src/main.rs
@@ -182,7 +182,8 @@ async fn add_workspace(
         .map_err(|error| CommandError::new("workspace_add_failed", error.to_string()))?;
 
     run_locked_workspace_registry_mutation(lock.inner(), || async move {
-        add_workspace_to_registry(&app_data_dir, &workspace.name, workspace.root_path).await
+        add_and_activate_workspace_in_registry(&app_data_dir, &workspace.name, workspace.root_path)
+            .await
     })
     .await
     .map_err(|error| CommandError::new("workspace_add_failed", error.to_string()))
@@ -518,22 +519,20 @@ async fn load_or_create_workspace_registry(
     Ok(registry)
 }
 
-async fn add_workspace_to_registry(
+async fn add_and_activate_workspace_in_registry(
     app_data_dir: &Path,
     name: &str,
     root_path: PathBuf,
 ) -> anyhow::Result<DesktopWorkspace> {
     let mut registry = load_or_create_workspace_registry(app_data_dir).await?;
     let name = validate_workspace_name(name)?;
-    let root_path = validate_workspace_root(root_path).await?;
+    let root_path = validate_workspace_root_path(root_path)?;
 
-    if registry
-        .workspaces
-        .iter()
-        .any(|workspace| workspace.root_path == root_path)
-    {
+    if workspace_root_is_registered(&registry, &root_path).await? {
         bail!("That workspace root is already registered.");
     }
+
+    let root_path = prepare_workspace_root(root_path).await?;
 
     let workspace = DesktopWorkspace {
         id: create_workspace_id(&name, &registry.workspaces),
@@ -648,11 +647,33 @@ async fn save_workspace_registry(
         })
 }
 
-async fn validate_workspace_root(root_path: PathBuf) -> anyhow::Result<PathBuf> {
+fn validate_workspace_root_path(root_path: PathBuf) -> anyhow::Result<PathBuf> {
     if root_path.as_os_str().is_empty() || !root_path.is_absolute() {
         bail!("Workspace roots must be absolute paths.");
     }
 
+    Ok(lexically_normalize_path(&root_path))
+}
+
+fn lexically_normalize_path(path: &Path) -> PathBuf {
+    let mut normalized_path = PathBuf::new();
+
+    for component in path.components() {
+        match component {
+            Component::Prefix(prefix) => normalized_path.push(prefix.as_os_str()),
+            Component::RootDir => normalized_path.push(component.as_os_str()),
+            Component::CurDir => {}
+            Component::ParentDir => {
+                let _ = normalized_path.pop();
+            }
+            Component::Normal(segment) => normalized_path.push(segment),
+        }
+    }
+
+    normalized_path
+}
+
+async fn prepare_workspace_root(root_path: PathBuf) -> anyhow::Result<PathBuf> {
     if tokio::fs::try_exists(&root_path)
         .await
         .with_context(|| format!("Workspace root cannot be checked: {}", root_path.display()))?
@@ -678,7 +699,56 @@ async fn validate_workspace_root(root_path: PathBuf) -> anyhow::Result<PathBuf> 
             )
         })?;
 
-    Ok(root_path)
+    tokio::fs::canonicalize(&root_path).await.with_context(|| {
+        format!(
+            "Workspace root could not be resolved: {}",
+            root_path.display()
+        )
+    })
+}
+
+async fn workspace_root_is_registered(
+    registry: &WorkspaceRegistry,
+    root_path: &Path,
+) -> anyhow::Result<bool> {
+    let canonical_root_path = canonicalize_existing_path(root_path).await?;
+
+    for workspace in &registry.workspaces {
+        if workspace.root_path == root_path {
+            return Ok(true);
+        }
+
+        if canonical_root_path
+            .as_ref()
+            .is_some_and(|path| path == &workspace.root_path)
+        {
+            return Ok(true);
+        }
+
+        if let Some(canonical_registered_root_path) =
+            canonicalize_existing_path(&workspace.root_path).await?
+        {
+            if Some(&canonical_registered_root_path) == canonical_root_path.as_ref() {
+                return Ok(true);
+            }
+        }
+    }
+
+    Ok(false)
+}
+
+async fn canonicalize_existing_path(path: &Path) -> anyhow::Result<Option<PathBuf>> {
+    if !tokio::fs::try_exists(path)
+        .await
+        .with_context(|| format!("Workspace root cannot be checked: {}", path.display()))?
+    {
+        return Ok(None);
+    }
+
+    tokio::fs::canonicalize(path)
+        .await
+        .map(Some)
+        .with_context(|| format!("Workspace root could not be resolved: {}", path.display()))
 }
 
 fn validate_workspace_name(name: &str) -> anyhow::Result<String> {
@@ -1197,13 +1267,13 @@ mod tests {
     };
 
     use super::{
-        add_workspace_to_registry, create_markdown_file, delete_markdown_file,
+        add_and_activate_workspace_in_registry, create_markdown_file, delete_markdown_file,
         derive_markdown_title, find_first_markdown_heading, get_temporary_write_path,
         get_workspace_relative_markdown_path, load_or_create_workspace_registry,
         move_file_without_overwrite, read_markdown_file, remove_workspace_from_registry,
         rename_workspace_in_registry, run_locked_workspace_registry_mutation, scan_markdown_files,
-        switch_active_workspace_in_registry, system_time_to_unix_ms, validate_markdown_path,
-        write_markdown_file, WorkspaceRegistryMutationLock,
+        system_time_to_unix_ms, validate_markdown_path, write_markdown_file,
+        WorkspaceRegistryMutationLock,
     };
 
     fn run_async<F>(future: F) -> F::Output
@@ -1291,17 +1361,20 @@ mod tests {
     }
 
     #[test]
-    fn persists_added_workspace_and_switches_active_workspace() {
+    fn adding_workspace_persists_it_and_makes_it_active() {
         run_async(async {
             let app_data_dir = unique_test_dir("persists-added-workspace");
             let workspace_root = unique_test_dir("external-workspace-root");
             tokio::fs::create_dir_all(&workspace_root).await?;
             load_or_create_workspace_registry(&app_data_dir).await?;
+            let canonical_workspace_root = tokio::fs::canonicalize(&workspace_root).await?;
 
-            let added_workspace =
-                add_workspace_to_registry(&app_data_dir, "Research", workspace_root.clone())
-                    .await?;
-            switch_active_workspace_in_registry(&app_data_dir, &added_workspace.id).await?;
+            let added_workspace = add_and_activate_workspace_in_registry(
+                &app_data_dir,
+                "Research",
+                workspace_root.clone(),
+            )
+            .await?;
             let registry = load_or_create_workspace_registry(&app_data_dir).await?;
 
             assert_eq!(registry.active_workspace_id, added_workspace.id);
@@ -1309,7 +1382,7 @@ mod tests {
                 .workspaces
                 .iter()
                 .any(|workspace| workspace.name == "Research"
-                    && workspace.root_path == workspace_root));
+                    && workspace.root_path == canonical_workspace_root));
             tokio::fs::remove_dir_all(&app_data_dir).await?;
             tokio::fs::remove_dir_all(&workspace_root).await?;
             anyhow::Ok(())
@@ -1326,9 +1399,12 @@ mod tests {
             tokio::fs::create_dir_all(&workspace_root).await?;
             tokio::fs::write(&note_path, "# Plan").await?;
             load_or_create_workspace_registry(&app_data_dir).await?;
-            let added_workspace =
-                add_workspace_to_registry(&app_data_dir, "Research", workspace_root.clone())
-                    .await?;
+            let added_workspace = add_and_activate_workspace_in_registry(
+                &app_data_dir,
+                "Research",
+                workspace_root.clone(),
+            )
+            .await?;
 
             rename_workspace_in_registry(&app_data_dir, &added_workspace.id, "Archive").await?;
             remove_workspace_from_registry(&app_data_dir, &added_workspace.id).await?;
@@ -1352,16 +1428,80 @@ mod tests {
             let app_data_dir = unique_test_dir("rejects-invalid-workspace-roots");
             load_or_create_workspace_registry(&app_data_dir).await?;
 
-            let error =
-                add_workspace_to_registry(&app_data_dir, "Relative", PathBuf::from("Notes"))
-                    .await
-                    .expect_err("relative workspace roots should be rejected");
+            let error = add_and_activate_workspace_in_registry(
+                &app_data_dir,
+                "Relative",
+                PathBuf::from("Notes"),
+            )
+            .await
+            .expect_err("relative workspace roots should be rejected");
 
             assert!(error.to_string().contains("absolute paths"));
             tokio::fs::remove_dir_all(&app_data_dir).await?;
             anyhow::Ok(())
         })
         .expect("invalid workspace root test should run");
+    }
+
+    #[test]
+    fn rejects_duplicate_workspace_roots_without_creating_new_directories() {
+        run_async(async {
+            let app_data_dir = unique_test_dir("rejects-duplicate-without-creating");
+            let workspace_root = unique_test_dir("existing-workspace-root");
+            let duplicate_child = workspace_root.join("CreatedByRejectedAdd");
+            let duplicate_root = duplicate_child.join("..");
+            tokio::fs::create_dir_all(&workspace_root).await?;
+            load_or_create_workspace_registry(&app_data_dir).await?;
+            add_and_activate_workspace_in_registry(
+                &app_data_dir,
+                "Research",
+                workspace_root.clone(),
+            )
+            .await?;
+
+            let error = add_and_activate_workspace_in_registry(
+                &app_data_dir,
+                "Duplicate Research",
+                duplicate_root,
+            )
+            .await
+            .expect_err("duplicate workspace roots should be rejected");
+
+            assert!(error.to_string().contains("already registered"));
+            assert!(!tokio::fs::try_exists(&duplicate_child).await?);
+            tokio::fs::remove_dir_all(&app_data_dir).await?;
+            tokio::fs::remove_dir_all(&workspace_root).await?;
+            anyhow::Ok(())
+        })
+        .expect("duplicate workspace root test should run");
+    }
+
+    #[test]
+    fn canonicalizes_workspace_roots_before_persisting() {
+        run_async(async {
+            let app_data_dir = unique_test_dir("canonicalizes-workspace-root");
+            let workspace_root = unique_test_dir("canonical-workspace-root");
+            let nested_root = workspace_root.join("Nested");
+            let noncanonical_root = nested_root.join("..").join("Nested");
+            tokio::fs::create_dir_all(&nested_root).await?;
+            load_or_create_workspace_registry(&app_data_dir).await?;
+
+            let added_workspace = add_and_activate_workspace_in_registry(
+                &app_data_dir,
+                "Research",
+                noncanonical_root,
+            )
+            .await?;
+
+            assert_eq!(
+                added_workspace.root_path,
+                tokio::fs::canonicalize(&nested_root).await?
+            );
+            tokio::fs::remove_dir_all(&app_data_dir).await?;
+            tokio::fs::remove_dir_all(&workspace_root).await?;
+            anyhow::Ok(())
+        })
+        .expect("workspace root should be canonicalized");
     }
 
     #[test]

--- a/apps/desktop/src-tauri/src/main.rs
+++ b/apps/desktop/src-tauri/src/main.rs
@@ -1,6 +1,7 @@
 #![cfg_attr(not(debug_assertions), windows_subsystem = "windows")]
 
 use std::{
+    future::Future,
     path::{Component, Path, PathBuf},
     time::{SystemTime, UNIX_EPOCH},
 };
@@ -114,6 +115,9 @@ struct WorkspaceRegistry {
     workspaces: Vec<DesktopWorkspace>,
 }
 
+#[derive(Default)]
+struct WorkspaceRegistryMutationLock(tokio::sync::Mutex<()>);
+
 #[derive(Debug, Serialize)]
 #[serde(rename_all = "camelCase")]
 struct CommandError {
@@ -141,10 +145,13 @@ impl std::error::Error for CommandError {}
 #[tauri::command]
 async fn list_workspaces(
     app_handle: tauri::AppHandle,
+    lock: tauri::State<'_, WorkspaceRegistryMutationLock>,
 ) -> Result<Vec<DesktopWorkspace>, CommandError> {
-    let registry = load_or_create_app_workspace_registry(&app_handle)
-        .await
-        .map_err(|error| CommandError::new("workspace_registry_unavailable", error.to_string()))?;
+    let registry = run_locked_workspace_registry_mutation(lock.inner(), || async {
+        load_or_create_app_workspace_registry(&app_handle).await
+    })
+    .await
+    .map_err(|error| CommandError::new("workspace_registry_unavailable", error.to_string()))?;
 
     Ok(registry.workspaces)
 }
@@ -152,10 +159,13 @@ async fn list_workspaces(
 #[tauri::command]
 async fn get_active_workspace(
     app_handle: tauri::AppHandle,
+    lock: tauri::State<'_, WorkspaceRegistryMutationLock>,
 ) -> Result<DesktopWorkspace, CommandError> {
-    let registry = load_or_create_app_workspace_registry(&app_handle)
-        .await
-        .map_err(|error| CommandError::new("workspace_registry_unavailable", error.to_string()))?;
+    let registry = run_locked_workspace_registry_mutation(lock.inner(), || async {
+        load_or_create_app_workspace_registry(&app_handle).await
+    })
+    .await
+    .map_err(|error| CommandError::new("workspace_registry_unavailable", error.to_string()))?;
 
     active_workspace_from_registry(&registry)
         .cloned()
@@ -165,58 +175,71 @@ async fn get_active_workspace(
 #[tauri::command]
 async fn add_workspace(
     app_handle: tauri::AppHandle,
+    lock: tauri::State<'_, WorkspaceRegistryMutationLock>,
     workspace: AddWorkspaceRequest,
 ) -> Result<DesktopWorkspace, CommandError> {
     let app_data_dir = app_data_dir(&app_handle)
         .map_err(|error| CommandError::new("workspace_add_failed", error.to_string()))?;
 
-    add_workspace_to_registry(&app_data_dir, &workspace.name, workspace.root_path)
-        .await
-        .map_err(|error| CommandError::new("workspace_add_failed", error.to_string()))
+    run_locked_workspace_registry_mutation(lock.inner(), || async move {
+        add_workspace_to_registry(&app_data_dir, &workspace.name, workspace.root_path).await
+    })
+    .await
+    .map_err(|error| CommandError::new("workspace_add_failed", error.to_string()))
 }
 
 #[tauri::command]
 async fn switch_workspace(
     app_handle: tauri::AppHandle,
+    lock: tauri::State<'_, WorkspaceRegistryMutationLock>,
     workspace: WorkspaceIdRequest,
 ) -> Result<DesktopWorkspace, CommandError> {
     let app_data_dir = app_data_dir(&app_handle)
         .map_err(|error| CommandError::new("workspace_switch_failed", error.to_string()))?;
 
-    switch_active_workspace_in_registry(&app_data_dir, &workspace.id)
-        .await
-        .map_err(|error| CommandError::new("workspace_switch_failed", error.to_string()))
+    run_locked_workspace_registry_mutation(lock.inner(), || async move {
+        switch_active_workspace_in_registry(&app_data_dir, &workspace.id).await
+    })
+    .await
+    .map_err(|error| CommandError::new("workspace_switch_failed", error.to_string()))
 }
 
 #[tauri::command]
 async fn rename_workspace(
     app_handle: tauri::AppHandle,
+    lock: tauri::State<'_, WorkspaceRegistryMutationLock>,
     workspace: RenameWorkspaceRequest,
 ) -> Result<DesktopWorkspace, CommandError> {
     let app_data_dir = app_data_dir(&app_handle)
         .map_err(|error| CommandError::new("workspace_rename_failed", error.to_string()))?;
 
-    rename_workspace_in_registry(&app_data_dir, &workspace.id, &workspace.name)
-        .await
-        .map_err(|error| CommandError::new("workspace_rename_failed", error.to_string()))
+    run_locked_workspace_registry_mutation(lock.inner(), || async move {
+        rename_workspace_in_registry(&app_data_dir, &workspace.id, &workspace.name).await
+    })
+    .await
+    .map_err(|error| CommandError::new("workspace_rename_failed", error.to_string()))
 }
 
 #[tauri::command]
 async fn remove_workspace(
     app_handle: tauri::AppHandle,
+    lock: tauri::State<'_, WorkspaceRegistryMutationLock>,
     workspace: WorkspaceIdRequest,
 ) -> Result<(), CommandError> {
     let app_data_dir = app_data_dir(&app_handle)
         .map_err(|error| CommandError::new("workspace_remove_failed", error.to_string()))?;
 
-    remove_workspace_from_registry(&app_data_dir, &workspace.id)
-        .await
-        .map_err(|error| CommandError::new("workspace_remove_failed", error.to_string()))
+    run_locked_workspace_registry_mutation(lock.inner(), || async move {
+        remove_workspace_from_registry(&app_data_dir, &workspace.id).await
+    })
+    .await
+    .map_err(|error| CommandError::new("workspace_remove_failed", error.to_string()))
 }
 
 #[tauri::command]
 async fn move_markdown_file(
     app_handle: tauri::AppHandle,
+    lock: tauri::State<'_, WorkspaceRegistryMutationLock>,
     change: MarkdownPathChange,
 ) -> Result<(), CommandError> {
     if change.note_id.trim().is_empty() {
@@ -226,9 +249,11 @@ async fn move_markdown_file(
         ));
     }
 
-    let workspace_root = active_workspace_root(&app_handle)
-        .await
-        .map_err(|error| CommandError::new("workspace_root_unavailable", error.to_string()))?;
+    let workspace_root = run_locked_workspace_registry_mutation(lock.inner(), || async {
+        active_workspace_root(&app_handle).await
+    })
+    .await
+    .map_err(|error| CommandError::new("workspace_root_unavailable", error.to_string()))?;
     let previous_path = resolve_markdown_path(&workspace_root, &change.previous_path)?;
     let next_path = resolve_markdown_path(&workspace_root, &change.next_path)?;
 
@@ -261,10 +286,13 @@ async fn refresh_note_indexes(
 #[tauri::command]
 async fn scan_markdown_workspace(
     app_handle: tauri::AppHandle,
+    lock: tauri::State<'_, WorkspaceRegistryMutationLock>,
 ) -> Result<Vec<ScannedMarkdownNote>, CommandError> {
-    let workspace_root = active_workspace_root(&app_handle)
-        .await
-        .map_err(|error| CommandError::new("workspace_scan_failed", error.to_string()))?;
+    let workspace_root = run_locked_workspace_registry_mutation(lock.inner(), || async {
+        active_workspace_root(&app_handle).await
+    })
+    .await
+    .map_err(|error| CommandError::new("workspace_scan_failed", error.to_string()))?;
 
     tokio::fs::create_dir_all(&workspace_root)
         .await
@@ -278,11 +306,14 @@ async fn scan_markdown_workspace(
 #[tauri::command]
 async fn read_markdown_note(
     app_handle: tauri::AppHandle,
+    lock: tauri::State<'_, WorkspaceRegistryMutationLock>,
     note: ReadMarkdownNoteRequest,
 ) -> Result<String, CommandError> {
-    let workspace_root = active_workspace_root(&app_handle)
-        .await
-        .map_err(|error| CommandError::new("note_read_failed", error.to_string()))?;
+    let workspace_root = run_locked_workspace_registry_mutation(lock.inner(), || async {
+        active_workspace_root(&app_handle).await
+    })
+    .await
+    .map_err(|error| CommandError::new("note_read_failed", error.to_string()))?;
     let note_path = resolve_markdown_path(&workspace_root, &note.path)?;
 
     read_markdown_file(&note_path)
@@ -293,11 +324,14 @@ async fn read_markdown_note(
 #[tauri::command]
 async fn create_markdown_note(
     app_handle: tauri::AppHandle,
+    lock: tauri::State<'_, WorkspaceRegistryMutationLock>,
     note: CreateMarkdownNoteRequest,
 ) -> Result<ScannedMarkdownNote, CommandError> {
-    let workspace_root = active_workspace_root(&app_handle)
-        .await
-        .map_err(|error| CommandError::new("note_create_failed", error.to_string()))?;
+    let workspace_root = run_locked_workspace_registry_mutation(lock.inner(), || async {
+        active_workspace_root(&app_handle).await
+    })
+    .await
+    .map_err(|error| CommandError::new("note_create_failed", error.to_string()))?;
     let note_path = resolve_markdown_path(&workspace_root, &note.path)?;
 
     create_markdown_file(&note_path, note.content.as_bytes())
@@ -312,11 +346,14 @@ async fn create_markdown_note(
 #[tauri::command]
 async fn write_markdown_note(
     app_handle: tauri::AppHandle,
+    lock: tauri::State<'_, WorkspaceRegistryMutationLock>,
     note: WriteMarkdownNoteRequest,
 ) -> Result<ScannedMarkdownNote, CommandError> {
-    let workspace_root = active_workspace_root(&app_handle)
-        .await
-        .map_err(|error| CommandError::new("note_write_failed", error.to_string()))?;
+    let workspace_root = run_locked_workspace_registry_mutation(lock.inner(), || async {
+        active_workspace_root(&app_handle).await
+    })
+    .await
+    .map_err(|error| CommandError::new("note_write_failed", error.to_string()))?;
     let note_path = resolve_markdown_path(&workspace_root, &note.path)?;
 
     write_markdown_file(&note_path, note.content.as_bytes())
@@ -331,11 +368,14 @@ async fn write_markdown_note(
 #[tauri::command]
 async fn delete_markdown_note(
     app_handle: tauri::AppHandle,
+    lock: tauri::State<'_, WorkspaceRegistryMutationLock>,
     note: DeleteMarkdownNoteRequest,
 ) -> Result<(), CommandError> {
-    let workspace_root = active_workspace_root(&app_handle)
-        .await
-        .map_err(|error| CommandError::new("note_delete_failed", error.to_string()))?;
+    let workspace_root = run_locked_workspace_registry_mutation(lock.inner(), || async {
+        active_workspace_root(&app_handle).await
+    })
+    .await
+    .map_err(|error| CommandError::new("note_delete_failed", error.to_string()))?;
     let note_path = resolve_markdown_path(&workspace_root, &note.path)?;
 
     delete_markdown_file(&note_path)
@@ -345,6 +385,7 @@ async fn delete_markdown_note(
 
 fn main() {
     if let Err(error) = tauri::Builder::default()
+        .manage(WorkspaceRegistryMutationLock::default())
         .invoke_handler(tauri::generate_handler![
             add_workspace,
             create_markdown_note,
@@ -364,6 +405,19 @@ fn main() {
     {
         eprintln!("failed to run Grove desktop app: {error}");
     }
+}
+
+async fn run_locked_workspace_registry_mutation<T, F, Fut>(
+    lock: &WorkspaceRegistryMutationLock,
+    mutation: F,
+) -> anyhow::Result<T>
+where
+    F: FnOnce() -> Fut,
+    Fut: Future<Output = anyhow::Result<T>>,
+{
+    let _guard = lock.0.lock().await;
+
+    mutation().await
 }
 
 fn app_data_dir(app_handle: &tauri::AppHandle) -> anyhow::Result<PathBuf> {
@@ -1135,6 +1189,10 @@ async fn append_index_refresh_sidecar_entry(
 mod tests {
     use std::{
         path::PathBuf,
+        sync::{
+            atomic::{AtomicUsize, Ordering},
+            Arc,
+        },
         time::{Duration, SystemTime, UNIX_EPOCH},
     };
 
@@ -1143,8 +1201,9 @@ mod tests {
         derive_markdown_title, find_first_markdown_heading, get_temporary_write_path,
         get_workspace_relative_markdown_path, load_or_create_workspace_registry,
         move_file_without_overwrite, read_markdown_file, remove_workspace_from_registry,
-        rename_workspace_in_registry, scan_markdown_files, switch_active_workspace_in_registry,
-        system_time_to_unix_ms, validate_markdown_path, write_markdown_file,
+        rename_workspace_in_registry, run_locked_workspace_registry_mutation, scan_markdown_files,
+        switch_active_workspace_in_registry, system_time_to_unix_ms, validate_markdown_path,
+        write_markdown_file, WorkspaceRegistryMutationLock,
     };
 
     fn run_async<F>(future: F) -> F::Output
@@ -1303,6 +1362,56 @@ mod tests {
             anyhow::Ok(())
         })
         .expect("invalid workspace root test should run");
+    }
+
+    #[test]
+    fn serializes_workspace_registry_mutations() {
+        run_async(async {
+            let lock = WorkspaceRegistryMutationLock::default();
+            let active_mutations = Arc::new(AtomicUsize::new(0));
+            let max_active_mutations = Arc::new(AtomicUsize::new(0));
+
+            let lock = Arc::new(lock);
+            let first_lock = Arc::clone(&lock);
+            let second_lock = Arc::clone(&lock);
+            let first_active_mutations = Arc::clone(&active_mutations);
+            let first_max_active_mutations = Arc::clone(&max_active_mutations);
+            let second_active_mutations = Arc::clone(&active_mutations);
+            let second_max_active_mutations = Arc::clone(&max_active_mutations);
+
+            let first_mutation = tokio::spawn(async move {
+                run_locked_workspace_registry_mutation(&first_lock, || {
+                    let active_mutations = Arc::clone(&first_active_mutations);
+                    let max_active_mutations = Arc::clone(&first_max_active_mutations);
+                    async move {
+                        let active = active_mutations.fetch_add(1, Ordering::SeqCst) + 1;
+                        max_active_mutations.fetch_max(active, Ordering::SeqCst);
+                        tokio::task::yield_now().await;
+                        active_mutations.fetch_sub(1, Ordering::SeqCst);
+                        anyhow::Ok(())
+                    }
+                })
+                .await
+            });
+            let second_mutation = tokio::spawn(async move {
+                let active_mutations = Arc::clone(&second_active_mutations);
+                let max_active_mutations = Arc::clone(&second_max_active_mutations);
+                run_locked_workspace_registry_mutation(&second_lock, || async move {
+                    let active = active_mutations.fetch_add(1, Ordering::SeqCst) + 1;
+                    max_active_mutations.fetch_max(active, Ordering::SeqCst);
+                    tokio::task::yield_now().await;
+                    active_mutations.fetch_sub(1, Ordering::SeqCst);
+                    anyhow::Ok(())
+                })
+                .await
+            });
+
+            first_mutation.await??;
+            second_mutation.await??;
+            assert_eq!(max_active_mutations.load(Ordering::SeqCst), 1);
+            anyhow::Ok(())
+        })
+        .expect("registry mutations should be serialized");
     }
 
     #[test]

--- a/apps/desktop/src-tauri/src/main.rs
+++ b/apps/desktop/src-tauri/src/main.rs
@@ -5,6 +5,7 @@ use std::{
     time::{SystemTime, UNIX_EPOCH},
 };
 
+use anyhow::{bail, Context};
 use serde::{Deserialize, Serialize};
 use tauri::Manager;
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
@@ -141,7 +142,9 @@ impl std::error::Error for CommandError {}
 async fn list_workspaces(
     app_handle: tauri::AppHandle,
 ) -> Result<Vec<DesktopWorkspace>, CommandError> {
-    let registry = load_or_create_app_workspace_registry(&app_handle).await?;
+    let registry = load_or_create_app_workspace_registry(&app_handle)
+        .await
+        .map_err(|error| CommandError::new("workspace_registry_unavailable", error.to_string()))?;
 
     Ok(registry.workspaces)
 }
@@ -150,14 +153,13 @@ async fn list_workspaces(
 async fn get_active_workspace(
     app_handle: tauri::AppHandle,
 ) -> Result<DesktopWorkspace, CommandError> {
-    let registry = load_or_create_app_workspace_registry(&app_handle).await?;
+    let registry = load_or_create_app_workspace_registry(&app_handle)
+        .await
+        .map_err(|error| CommandError::new("workspace_registry_unavailable", error.to_string()))?;
 
-    find_active_workspace(&registry).cloned().ok_or_else(|| {
-        CommandError::new(
-            "active_workspace_unavailable",
-            "The active workspace is unavailable.",
-        )
-    })
+    active_workspace_from_registry(&registry)
+        .cloned()
+        .map_err(|error| CommandError::new("active_workspace_unavailable", error.to_string()))
 }
 
 #[tauri::command]
@@ -165,12 +167,12 @@ async fn add_workspace(
     app_handle: tauri::AppHandle,
     workspace: AddWorkspaceRequest,
 ) -> Result<DesktopWorkspace, CommandError> {
-    add_workspace_to_registry(
-        &app_data_dir(&app_handle)?,
-        &workspace.name,
-        workspace.root_path,
-    )
-    .await
+    let app_data_dir = app_data_dir(&app_handle)
+        .map_err(|error| CommandError::new("workspace_add_failed", error.to_string()))?;
+
+    add_workspace_to_registry(&app_data_dir, &workspace.name, workspace.root_path)
+        .await
+        .map_err(|error| CommandError::new("workspace_add_failed", error.to_string()))
 }
 
 #[tauri::command]
@@ -178,7 +180,12 @@ async fn switch_workspace(
     app_handle: tauri::AppHandle,
     workspace: WorkspaceIdRequest,
 ) -> Result<DesktopWorkspace, CommandError> {
-    switch_active_workspace_in_registry(&app_data_dir(&app_handle)?, &workspace.id).await
+    let app_data_dir = app_data_dir(&app_handle)
+        .map_err(|error| CommandError::new("workspace_switch_failed", error.to_string()))?;
+
+    switch_active_workspace_in_registry(&app_data_dir, &workspace.id)
+        .await
+        .map_err(|error| CommandError::new("workspace_switch_failed", error.to_string()))
 }
 
 #[tauri::command]
@@ -186,7 +193,12 @@ async fn rename_workspace(
     app_handle: tauri::AppHandle,
     workspace: RenameWorkspaceRequest,
 ) -> Result<DesktopWorkspace, CommandError> {
-    rename_workspace_in_registry(&app_data_dir(&app_handle)?, &workspace.id, &workspace.name).await
+    let app_data_dir = app_data_dir(&app_handle)
+        .map_err(|error| CommandError::new("workspace_rename_failed", error.to_string()))?;
+
+    rename_workspace_in_registry(&app_data_dir, &workspace.id, &workspace.name)
+        .await
+        .map_err(|error| CommandError::new("workspace_rename_failed", error.to_string()))
 }
 
 #[tauri::command]
@@ -194,7 +206,12 @@ async fn remove_workspace(
     app_handle: tauri::AppHandle,
     workspace: WorkspaceIdRequest,
 ) -> Result<(), CommandError> {
-    remove_workspace_from_registry(&app_data_dir(&app_handle)?, &workspace.id).await
+    let app_data_dir = app_data_dir(&app_handle)
+        .map_err(|error| CommandError::new("workspace_remove_failed", error.to_string()))?;
+
+    remove_workspace_from_registry(&app_data_dir, &workspace.id)
+        .await
+        .map_err(|error| CommandError::new("workspace_remove_failed", error.to_string()))
 }
 
 #[tauri::command]
@@ -209,7 +226,9 @@ async fn move_markdown_file(
         ));
     }
 
-    let workspace_root = active_workspace_root(&app_handle).await?;
+    let workspace_root = active_workspace_root(&app_handle)
+        .await
+        .map_err(|error| CommandError::new("workspace_root_unavailable", error.to_string()))?;
     let previous_path = resolve_markdown_path(&workspace_root, &change.previous_path)?;
     let next_path = resolve_markdown_path(&workspace_root, &change.next_path)?;
 
@@ -243,7 +262,9 @@ async fn refresh_note_indexes(
 async fn scan_markdown_workspace(
     app_handle: tauri::AppHandle,
 ) -> Result<Vec<ScannedMarkdownNote>, CommandError> {
-    let workspace_root = active_workspace_root(&app_handle).await?;
+    let workspace_root = active_workspace_root(&app_handle)
+        .await
+        .map_err(|error| CommandError::new("workspace_scan_failed", error.to_string()))?;
 
     tokio::fs::create_dir_all(&workspace_root)
         .await
@@ -259,7 +280,9 @@ async fn read_markdown_note(
     app_handle: tauri::AppHandle,
     note: ReadMarkdownNoteRequest,
 ) -> Result<String, CommandError> {
-    let workspace_root = active_workspace_root(&app_handle).await?;
+    let workspace_root = active_workspace_root(&app_handle)
+        .await
+        .map_err(|error| CommandError::new("note_read_failed", error.to_string()))?;
     let note_path = resolve_markdown_path(&workspace_root, &note.path)?;
 
     read_markdown_file(&note_path)
@@ -272,7 +295,9 @@ async fn create_markdown_note(
     app_handle: tauri::AppHandle,
     note: CreateMarkdownNoteRequest,
 ) -> Result<ScannedMarkdownNote, CommandError> {
-    let workspace_root = active_workspace_root(&app_handle).await?;
+    let workspace_root = active_workspace_root(&app_handle)
+        .await
+        .map_err(|error| CommandError::new("note_create_failed", error.to_string()))?;
     let note_path = resolve_markdown_path(&workspace_root, &note.path)?;
 
     create_markdown_file(&note_path, note.content.as_bytes())
@@ -289,7 +314,9 @@ async fn write_markdown_note(
     app_handle: tauri::AppHandle,
     note: WriteMarkdownNoteRequest,
 ) -> Result<ScannedMarkdownNote, CommandError> {
-    let workspace_root = active_workspace_root(&app_handle).await?;
+    let workspace_root = active_workspace_root(&app_handle)
+        .await
+        .map_err(|error| CommandError::new("note_write_failed", error.to_string()))?;
     let note_path = resolve_markdown_path(&workspace_root, &note.path)?;
 
     write_markdown_file(&note_path, note.content.as_bytes())
@@ -306,7 +333,9 @@ async fn delete_markdown_note(
     app_handle: tauri::AppHandle,
     note: DeleteMarkdownNoteRequest,
 ) -> Result<(), CommandError> {
-    let workspace_root = active_workspace_root(&app_handle).await?;
+    let workspace_root = active_workspace_root(&app_handle)
+        .await
+        .map_err(|error| CommandError::new("note_delete_failed", error.to_string()))?;
     let note_path = resolve_markdown_path(&workspace_root, &note.path)?;
 
     delete_markdown_file(&note_path)
@@ -337,32 +366,32 @@ fn main() {
     }
 }
 
-fn app_data_dir(app_handle: &tauri::AppHandle) -> Result<PathBuf, CommandError> {
+fn app_data_dir(app_handle: &tauri::AppHandle) -> anyhow::Result<PathBuf> {
     app_handle
         .path()
         .app_data_dir()
-        .map_err(|error| CommandError::new("app_data_dir_unavailable", error.to_string()))
+        .context("App data directory is unavailable.")
 }
 
-async fn active_workspace_root(app_handle: &tauri::AppHandle) -> Result<PathBuf, CommandError> {
+async fn active_workspace_root(app_handle: &tauri::AppHandle) -> anyhow::Result<PathBuf> {
     let registry = load_or_create_app_workspace_registry(app_handle).await?;
-    let workspace = find_active_workspace(&registry).ok_or_else(|| {
-        CommandError::new(
-            "active_workspace_unavailable",
-            "The active workspace is unavailable.",
-        )
-    })?;
+    let workspace = active_workspace_from_registry(&registry)?;
 
     tokio::fs::create_dir_all(&workspace.root_path)
         .await
-        .map_err(|error| CommandError::new("workspace_root_unavailable", error.to_string()))?;
+        .with_context(|| {
+            format!(
+                "Workspace root is unavailable: {}",
+                workspace.root_path.display()
+            )
+        })?;
 
     Ok(workspace.root_path.clone())
 }
 
 async fn load_or_create_app_workspace_registry(
     app_handle: &tauri::AppHandle,
-) -> Result<WorkspaceRegistry, CommandError> {
+) -> anyhow::Result<WorkspaceRegistry> {
     load_or_create_workspace_registry(&app_data_dir(app_handle)?).await
 }
 
@@ -385,12 +414,17 @@ fn default_workspace(app_data_dir: &Path, last_opened_at_unix_ms: u128) -> Deskt
 
 async fn load_or_create_workspace_registry(
     app_data_dir: &Path,
-) -> Result<WorkspaceRegistry, CommandError> {
+) -> anyhow::Result<WorkspaceRegistry> {
     let registry_path = workspace_registry_path(app_data_dir);
 
     if !tokio::fs::try_exists(&registry_path)
         .await
-        .map_err(|error| CommandError::new("workspace_registry_unavailable", error.to_string()))?
+        .with_context(|| {
+            format!(
+                "Workspace registry is unavailable: {}",
+                registry_path.display()
+            )
+        })?
     {
         let registry = WorkspaceRegistry {
             active_workspace_id: "default".to_string(),
@@ -398,16 +432,21 @@ async fn load_or_create_workspace_registry(
         };
         tokio::fs::create_dir_all(default_workspace_root_from_app_data_dir(app_data_dir))
             .await
-            .map_err(|error| CommandError::new("workspace_root_unavailable", error.to_string()))?;
+            .context("Default workspace root is unavailable.")?;
         save_workspace_registry(app_data_dir, &registry).await?;
         return Ok(registry);
     }
 
     let registry_content = tokio::fs::read_to_string(&registry_path)
         .await
-        .map_err(|error| CommandError::new("workspace_registry_unavailable", error.to_string()))?;
-    let mut registry: WorkspaceRegistry = serde_json::from_str(&registry_content)
-        .map_err(|error| CommandError::new("workspace_registry_invalid", error.to_string()))?;
+        .with_context(|| {
+            format!(
+                "Workspace registry is unavailable: {}",
+                registry_path.display()
+            )
+        })?;
+    let mut registry: WorkspaceRegistry =
+        serde_json::from_str(&registry_content).context("Workspace registry is invalid.")?;
 
     if registry.workspaces.is_empty() {
         registry.active_workspace_id = "default".to_string();
@@ -429,7 +468,7 @@ async fn add_workspace_to_registry(
     app_data_dir: &Path,
     name: &str,
     root_path: PathBuf,
-) -> Result<DesktopWorkspace, CommandError> {
+) -> anyhow::Result<DesktopWorkspace> {
     let mut registry = load_or_create_workspace_registry(app_data_dir).await?;
     let name = validate_workspace_name(name)?;
     let root_path = validate_workspace_root(root_path).await?;
@@ -439,10 +478,7 @@ async fn add_workspace_to_registry(
         .iter()
         .any(|workspace| workspace.root_path == root_path)
     {
-        return Err(CommandError::new(
-            "workspace_root_exists",
-            "That workspace root is already registered.",
-        ));
+        bail!("That workspace root is already registered.");
     }
 
     let workspace = DesktopWorkspace {
@@ -461,7 +497,7 @@ async fn add_workspace_to_registry(
 async fn switch_active_workspace_in_registry(
     app_data_dir: &Path,
     workspace_id: &str,
-) -> Result<DesktopWorkspace, CommandError> {
+) -> anyhow::Result<DesktopWorkspace> {
     let mut registry = load_or_create_workspace_registry(app_data_dir).await?;
     let workspace_index = find_workspace_index(&registry, workspace_id)?;
     registry.active_workspace_id = workspace_id.to_string();
@@ -469,7 +505,12 @@ async fn switch_active_workspace_in_registry(
     let workspace = registry.workspaces[workspace_index].clone();
     tokio::fs::create_dir_all(&workspace.root_path)
         .await
-        .map_err(|error| CommandError::new("workspace_root_unavailable", error.to_string()))?;
+        .with_context(|| {
+            format!(
+                "Workspace root is unavailable: {}",
+                workspace.root_path.display()
+            )
+        })?;
     save_workspace_registry(app_data_dir, &registry).await?;
 
     Ok(workspace)
@@ -479,7 +520,7 @@ async fn rename_workspace_in_registry(
     app_data_dir: &Path,
     workspace_id: &str,
     name: &str,
-) -> Result<DesktopWorkspace, CommandError> {
+) -> anyhow::Result<DesktopWorkspace> {
     let mut registry = load_or_create_workspace_registry(app_data_dir).await?;
     let workspace_index = find_workspace_index(&registry, workspace_id)?;
     registry.workspaces[workspace_index].name = validate_workspace_name(name)?;
@@ -492,7 +533,7 @@ async fn rename_workspace_in_registry(
 async fn remove_workspace_from_registry(
     app_data_dir: &Path,
     workspace_id: &str,
-) -> Result<(), CommandError> {
+) -> anyhow::Result<()> {
     let mut registry = load_or_create_workspace_registry(app_data_dir).await?;
     find_workspace_index(&registry, workspace_id)?;
     registry
@@ -510,12 +551,7 @@ async fn remove_workspace_from_registry(
             .iter()
             .max_by_key(|workspace| workspace.last_opened_at_unix_ms)
             .map(|workspace| workspace.id.clone())
-            .ok_or_else(|| {
-                CommandError::new(
-                    "active_workspace_unavailable",
-                    "The active workspace is unavailable.",
-                )
-            })?;
+            .context("The active workspace is unavailable.")?;
         registry.active_workspace_id = active_workspace_id;
     }
 
@@ -525,80 +561,88 @@ async fn remove_workspace_from_registry(
 async fn save_workspace_registry(
     app_data_dir: &Path,
     registry: &WorkspaceRegistry,
-) -> Result<(), CommandError> {
+) -> anyhow::Result<()> {
     tokio::fs::create_dir_all(app_data_dir)
         .await
-        .map_err(|error| CommandError::new("workspace_registry_unavailable", error.to_string()))?;
+        .with_context(|| {
+            format!(
+                "Workspace registry directory is unavailable: {}",
+                app_data_dir.display()
+            )
+        })?;
 
     let registry_path = workspace_registry_path(app_data_dir);
     let registry_json = serde_json::to_vec_pretty(registry)
-        .map_err(|error| CommandError::new("workspace_registry_invalid", error.to_string()))?;
+        .context("Workspace registry could not be serialized.")?;
     let temporary_path = registry_path.with_extension("json.tmp");
 
     tokio::fs::write(&temporary_path, registry_json)
         .await
-        .map_err(|error| CommandError::new("workspace_registry_unavailable", error.to_string()))?;
+        .with_context(|| {
+            format!(
+                "Workspace registry temporary file is unavailable: {}",
+                temporary_path.display()
+            )
+        })?;
     replace_file_with_temporary_path(&temporary_path, &registry_path)
         .await
-        .map_err(|error| CommandError::new("workspace_registry_unavailable", error.to_string()))
+        .with_context(|| {
+            format!(
+                "Workspace registry file is unavailable: {}",
+                registry_path.display()
+            )
+        })
 }
 
-async fn validate_workspace_root(root_path: PathBuf) -> Result<PathBuf, CommandError> {
+async fn validate_workspace_root(root_path: PathBuf) -> anyhow::Result<PathBuf> {
     if root_path.as_os_str().is_empty() || !root_path.is_absolute() {
-        return Err(CommandError::new(
-            "invalid_workspace_root",
-            "Workspace roots must be absolute paths.",
-        ));
+        bail!("Workspace roots must be absolute paths.");
     }
 
     if tokio::fs::try_exists(&root_path)
         .await
-        .map_err(|error| CommandError::new("invalid_workspace_root", error.to_string()))?
+        .with_context(|| format!("Workspace root cannot be checked: {}", root_path.display()))?
         && !tokio::fs::metadata(&root_path)
             .await
-            .map_err(|error| CommandError::new("invalid_workspace_root", error.to_string()))?
+            .with_context(|| {
+                format!(
+                    "Workspace root metadata is unavailable: {}",
+                    root_path.display()
+                )
+            })?
             .is_dir()
     {
-        return Err(CommandError::new(
-            "invalid_workspace_root",
-            "Workspace roots must point to a directory.",
-        ));
+        bail!("Workspace roots must point to a directory.");
     }
 
     tokio::fs::create_dir_all(&root_path)
         .await
-        .map_err(|error| CommandError::new("invalid_workspace_root", error.to_string()))?;
+        .with_context(|| {
+            format!(
+                "Workspace root could not be created: {}",
+                root_path.display()
+            )
+        })?;
 
     Ok(root_path)
 }
 
-fn validate_workspace_name(name: &str) -> Result<String, CommandError> {
+fn validate_workspace_name(name: &str) -> anyhow::Result<String> {
     let name = name.trim();
 
     if name.is_empty() {
-        return Err(CommandError::new(
-            "invalid_workspace_name",
-            "A workspace name is required.",
-        ));
+        bail!("A workspace name is required.");
     }
 
     Ok(name.to_string())
 }
 
-fn find_workspace_index(
-    registry: &WorkspaceRegistry,
-    workspace_id: &str,
-) -> Result<usize, CommandError> {
+fn find_workspace_index(registry: &WorkspaceRegistry, workspace_id: &str) -> anyhow::Result<usize> {
     registry
         .workspaces
         .iter()
         .position(|workspace| workspace.id == workspace_id)
-        .ok_or_else(|| {
-            CommandError::new(
-                "workspace_not_found",
-                "The requested workspace is not registered.",
-            )
-        })
+        .context("The requested workspace is not registered.")
 }
 
 fn find_active_workspace(registry: &WorkspaceRegistry) -> Option<&DesktopWorkspace> {
@@ -606,6 +650,12 @@ fn find_active_workspace(registry: &WorkspaceRegistry) -> Option<&DesktopWorkspa
         .workspaces
         .iter()
         .find(|workspace| workspace.id == registry.active_workspace_id)
+}
+
+fn active_workspace_from_registry(
+    registry: &WorkspaceRegistry,
+) -> anyhow::Result<&DesktopWorkspace> {
+    find_active_workspace(registry).context("The active workspace is unavailable.")
 }
 
 fn create_workspace_id(name: &str, workspaces: &[DesktopWorkspace]) -> String {
@@ -647,11 +697,11 @@ fn slugify_workspace_name(name: &str) -> String {
     slug.to_string()
 }
 
-fn current_unix_ms() -> Result<u128, CommandError> {
+fn current_unix_ms() -> anyhow::Result<u128> {
     SystemTime::now()
         .duration_since(UNIX_EPOCH)
         .map(|duration| duration.as_millis())
-        .map_err(|error| CommandError::new("system_time_unavailable", error.to_string()))
+        .context("System time is unavailable.")
 }
 
 fn resolve_markdown_path(workspace_root: &Path, path: &str) -> Result<PathBuf, CommandError> {
@@ -1248,7 +1298,7 @@ mod tests {
                     .await
                     .expect_err("relative workspace roots should be rejected");
 
-            assert_eq!(error.code, "invalid_workspace_root");
+            assert!(error.to_string().contains("absolute paths"));
             tokio::fs::remove_dir_all(&app_data_dir).await?;
             anyhow::Ok(())
         })

--- a/apps/desktop/src/shared/api/commands.test.ts
+++ b/apps/desktop/src/shared/api/commands.test.ts
@@ -4,10 +4,16 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import {
   createMarkdownNote,
   deleteMarkdownNote,
+  addWorkspace,
+  getActiveWorkspace,
+  listWorkspaces,
   moveMarkdownFile,
   readMarkdownNote,
   refreshNoteIndexes,
+  removeWorkspace,
+  renameWorkspace,
   scanMarkdownWorkspace,
+  switchWorkspace,
   writeMarkdownNote,
 } from "./commands";
 
@@ -156,6 +162,71 @@ describe("desktop command wrappers", () => {
     });
   });
 
+  it("loads workspace metadata from the desktop host", async () => {
+    invokeMock.mockResolvedValue([
+      {
+        id: "default",
+        name: "Personal Notes",
+        rootPath: "/Users/me/Library/Application Support/grove/workspaces/default",
+        lastOpenedAtUnixMs: 1776265200000,
+      },
+    ]);
+
+    await expect(listWorkspaces()).resolves.toStrictEqual([
+      {
+        id: "default",
+        name: "Personal Notes",
+        rootPath: "/Users/me/Library/Application Support/grove/workspaces/default",
+        lastOpenedAtUnixMs: 1776265200000,
+      },
+    ]);
+    expect(invokeMock).toHaveBeenCalledWith("list_workspaces", {});
+  });
+
+  it("loads the active workspace from the desktop host", async () => {
+    invokeMock.mockResolvedValue({
+      id: "default",
+      name: "Personal Notes",
+      rootPath: "/Users/me/Library/Application Support/grove/workspaces/default",
+      lastOpenedAtUnixMs: 1776265200000,
+    });
+
+    await expect(getActiveWorkspace()).resolves.toStrictEqual({
+      id: "default",
+      name: "Personal Notes",
+      rootPath: "/Users/me/Library/Application Support/grove/workspaces/default",
+      lastOpenedAtUnixMs: 1776265200000,
+    });
+    expect(invokeMock).toHaveBeenCalledWith("get_active_workspace", {});
+  });
+
+  it("invokes workspace mutation commands with typed payloads", async () => {
+    invokeMock.mockResolvedValue({
+      id: "research",
+      name: "Research",
+      rootPath: "/Users/me/Notes/Research",
+      lastOpenedAtUnixMs: 1776265200000,
+    });
+
+    await addWorkspace({ name: "Research", rootPath: "/Users/me/Notes/Research" });
+    await switchWorkspace({ id: "research" });
+    await renameWorkspace({ id: "research", name: "Archive" });
+    await removeWorkspace({ id: "research" });
+
+    expect(invokeMock).toHaveBeenNthCalledWith(1, "add_workspace", {
+      workspace: { name: "Research", rootPath: "/Users/me/Notes/Research" },
+    });
+    expect(invokeMock).toHaveBeenNthCalledWith(2, "switch_workspace", {
+      workspace: { id: "research" },
+    });
+    expect(invokeMock).toHaveBeenNthCalledWith(3, "rename_workspace", {
+      workspace: { id: "research", name: "Archive" },
+    });
+    expect(invokeMock).toHaveBeenNthCalledWith(4, "remove_workspace", {
+      workspace: { id: "research" },
+    });
+  });
+
   it("rejects invalid Markdown note read results", async () => {
     invokeMock.mockResolvedValue({ content: "# Plan" });
 
@@ -192,6 +263,17 @@ describe("desktop command wrappers", () => {
     ]);
 
     await expect(scanMarkdownWorkspace()).rejects.toThrow("invalid note list");
+  });
+
+  it("rejects invalid workspace command results", async () => {
+    invokeMock.mockResolvedValue({
+      id: "default",
+      name: "Personal Notes",
+      rootPath: "",
+      lastOpenedAtUnixMs: Number.NaN,
+    });
+
+    await expect(getActiveWorkspace()).rejects.toThrow("invalid workspace metadata");
   });
 
   it("preserves structured Tauri command messages when a command fails", async () => {

--- a/apps/desktop/src/shared/api/commands.ts
+++ b/apps/desktop/src/shared/api/commands.ts
@@ -18,6 +18,13 @@ export type ScannedMarkdownNote = {
   updatedAtUnixMs: number;
 };
 
+export type DesktopWorkspace = {
+  id: string;
+  name: string;
+  rootPath: string;
+  lastOpenedAtUnixMs: number;
+};
+
 export type CreateMarkdownNoteCommand = {
   path: string;
   content: string;
@@ -35,6 +42,78 @@ export type WriteMarkdownNoteCommand = {
 export type DeleteMarkdownNoteCommand = {
   path: string;
 };
+
+export type AddWorkspaceCommand = {
+  name: string;
+  rootPath: string;
+};
+
+export type SwitchWorkspaceCommand = {
+  id: string;
+};
+
+export type RenameWorkspaceCommand = {
+  id: string;
+  name: string;
+};
+
+export type RemoveWorkspaceCommand = {
+  id: string;
+};
+
+export async function listWorkspaces(): Promise<DesktopWorkspace[]> {
+  const result = await invokeCommandResult("list_workspaces", {});
+
+  if (!isDesktopWorkspaces(result)) {
+    throw new Error("The desktop workspace command returned invalid workspace metadata.");
+  }
+
+  return result;
+}
+
+export async function getActiveWorkspace(): Promise<DesktopWorkspace> {
+  const result = await invokeCommandResult("get_active_workspace", {});
+
+  if (!isDesktopWorkspace(result)) {
+    throw new Error("The desktop workspace command returned invalid workspace metadata.");
+  }
+
+  return result;
+}
+
+export async function addWorkspace(command: AddWorkspaceCommand): Promise<DesktopWorkspace> {
+  const result = await invokeCommandResult("add_workspace", { workspace: command });
+
+  if (!isDesktopWorkspace(result)) {
+    throw new Error("The desktop workspace command returned invalid workspace metadata.");
+  }
+
+  return result;
+}
+
+export async function switchWorkspace(command: SwitchWorkspaceCommand): Promise<DesktopWorkspace> {
+  const result = await invokeCommandResult("switch_workspace", { workspace: command });
+
+  if (!isDesktopWorkspace(result)) {
+    throw new Error("The desktop workspace command returned invalid workspace metadata.");
+  }
+
+  return result;
+}
+
+export async function renameWorkspace(command: RenameWorkspaceCommand): Promise<DesktopWorkspace> {
+  const result = await invokeCommandResult("rename_workspace", { workspace: command });
+
+  if (!isDesktopWorkspace(result)) {
+    throw new Error("The desktop workspace command returned invalid workspace metadata.");
+  }
+
+  return result;
+}
+
+export async function removeWorkspace(command: RemoveWorkspaceCommand): Promise<void> {
+  await invokeCommand("remove_workspace", { workspace: command });
+}
 
 export async function moveMarkdownFile(command: MoveMarkdownFileCommand): Promise<void> {
   await invokeCommand("move_markdown_file", { change: command });
@@ -134,6 +213,30 @@ function isCommandErrorPayload(error: unknown): error is { message: string } {
 
 function isScannedMarkdownNotes(value: unknown): value is ScannedMarkdownNote[] {
   return Array.isArray(value) && value.every(isScannedMarkdownNote);
+}
+
+function isDesktopWorkspaces(value: unknown): value is DesktopWorkspace[] {
+  return Array.isArray(value) && value.every(isDesktopWorkspace);
+}
+
+function isDesktopWorkspace(value: unknown): value is DesktopWorkspace {
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    "id" in value &&
+    typeof value.id === "string" &&
+    value.id.trim().length > 0 &&
+    "name" in value &&
+    typeof value.name === "string" &&
+    value.name.trim().length > 0 &&
+    "rootPath" in value &&
+    typeof value.rootPath === "string" &&
+    value.rootPath.trim().length > 0 &&
+    "lastOpenedAtUnixMs" in value &&
+    typeof value.lastOpenedAtUnixMs === "number" &&
+    Number.isFinite(value.lastOpenedAtUnixMs) &&
+    value.lastOpenedAtUnixMs >= 0
+  );
 }
 
 function isScannedMarkdownNote(value: unknown): value is ScannedMarkdownNote {

--- a/docs/superpowers/specs/2026-04-19-issue-75-desktop-contextual-actions-design.md
+++ b/docs/superpowers/specs/2026-04-19-issue-75-desktop-contextual-actions-design.md
@@ -1,22 +1,27 @@
 # Issue 75 Desktop Contextual Actions Design
 
 ## Summary
+
 Simplify the desktop editor surface by removing always-visible workspace-management controls from the main pane. Keep note move, folder rename, and note delete available through explicit contextual disclosure panels so the default state stays focused on reading and editing Markdown.
 
 ## Scope
+
 - Move the always-visible `Move selected note` form out of the default editor flow.
 - Move the always-visible `Rename selected folder` form out of the default editor flow.
 - Move `Delete note` behind the same contextual disclosure pattern instead of leaving it permanently visible.
 - Preserve existing dirty-draft, pending-path-change, and path-conflict guardrails.
 
 ## Out Of Scope
+
 - Redesigning the two-pane layout introduced by issue #74.
 - Changing the underlying folder workspace mutation model or path change queue semantics.
 - Hiding tags, links, backlinks, or diagnostics by default beyond what is necessary to keep the action sections contextual.
 - Introducing a new modal or dialog infrastructure.
 
 ## Current State
+
 `ActivePane` in `apps/desktop/src/features/folder-navigation/ui/FolderNavigationWorkspace.tsx` renders the editor together with:
+
 - the note path
 - the links/backlinks sections
 - the move-note form
@@ -26,7 +31,9 @@ Simplify the desktop editor surface by removing always-visible workspace-managem
 This keeps workspace-management controls in view even when the user only wants to read or edit a note.
 
 ## Goals
+
 The default right-pane state should read as:
+
 - note title
 - save state and edit controls
 - Markdown editor
@@ -34,74 +41,91 @@ The default right-pane state should read as:
 Secondary actions should still be reachable without moving them to a different pane or changing the existing mutation logic.
 
 ## Chosen Approach
+
 Use inline disclosure sections in the right pane:
+
 - `Note actions`
 - `Folder actions`
 
 The disclosures are collapsed by default. Users opt in to seeing move / delete / rename controls by expanding the relevant section.
 
 This approach is preferred because it:
+
 - preserves the existing two-pane information architecture from issue #74
 - keeps actions close to the edited note and current folder context
 - avoids adding modal state or new shared UI primitives for a narrowly scoped cleanup
 - leaves a natural place for future details-oriented UI work in issue #73
 
 ## Component Design
+
 ### ActivePane
+
 `ActivePane` will remain responsible for the right-pane composition, but its default visible stack will be reduced.
 
 Default visible content:
+
 - active note heading
 - development-only path change diagnostics toggle
 - note path text, unchanged in the default view for this issue
 - `NoteEditor`
 
 Contextual content:
+
 - `Note actions` disclosure
 - `Folder actions` disclosure
 - development-only path change queue when expanded
 
 ### Note Actions Disclosure
+
 Visible only when a note is selected.
 
 Contents:
+
 - existing move-note control
 - existing delete-note action block
 
 Behavior:
+
 - collapsed by default
 - keeps the current move mutation flow
 - keeps the current delete blocking and error messages
 - delete copy should remain explicit that the Markdown file is permanently removed
 
 ### Folder Actions Disclosure
+
 Visible regardless of note selection because folder context comes from the selected folder.
 
 Contents:
+
 - existing rename-folder control
 - operation feedback message currently shown below the editor
 
 Behavior:
+
 - collapsed by default
 - workspace root keeps the rename input and button disabled
 - descendant-path validation remains unchanged
 
 ## Guardrails To Preserve
+
 - Dirty note drafts must still block workspace changes through the existing note buffer checks.
 - Pending path changes must still block save and delete when the existing model says they should.
 - Existing path-conflict validation for move / rename must stay in the folder workspace model.
 - Path change queue execution remains automatic and development-only diagnostics remain opt-in.
 
 ## Testing Strategy
+
 Update `apps/desktop/src/features/folder-navigation/ui/FolderNavigationWorkspace.test.tsx` first.
 
 Add or adjust tests to verify:
+
 - default `ActivePane` markup does not include always-visible move / rename / delete controls
 - expanded `Note actions` markup includes move and delete controls
 - expanded `Folder actions` markup includes rename controls and operation messaging
 - the diagnostics toggle behavior from issue #74 still works
 
 Implementation should follow TDD:
+
 1. write or update failing UI markup tests
 2. run the focused desktop test file and confirm the expected failure
 3. implement the minimal disclosure UI changes
@@ -109,6 +133,7 @@ Implementation should follow TDD:
 5. run broader desktop verification as needed
 
 ## Risks And Mitigations
+
 - Risk: action controls become harder to discover
   - Mitigation: use explicit disclosure labels (`Note actions`, `Folder actions`) instead of ambiguous icon-only menus
 - Risk: disclosure state adds noise to `ActivePane`
@@ -117,6 +142,7 @@ Implementation should follow TDD:
   - Mitigation: reuse existing handlers and preserve validation paths instead of rewriting mutations
 
 ## Acceptance Criteria
+
 - the primary editor surface shows only reading/editing controls by default
 - move, rename, and delete remain available through deliberate contextual interaction
 - delete remains a clearly destructive action

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -17,7 +17,12 @@ export type { FolderPath, FolderScope, FolderTreeNode, NoteFilePath } from "./fo
 export { deriveNoteTitle, renameNoteFilePath } from "./titles";
 export type { DerivedNoteTitle, DerivedNoteTitleSource } from "./titles";
 export { parseWikiLinks, resolveWikiLinks } from "./wikiLinks";
-export type { ParsedWikiLink, ResolvedNoteLinks, ResolvedWikiLink, WikiLinkNote } from "./wikiLinks";
+export type {
+  ParsedWikiLink,
+  ResolvedNoteLinks,
+  ResolvedWikiLink,
+  WikiLinkNote,
+} from "./wikiLinks";
 
 export type NoteLink = {
   fromId: string;

--- a/packages/core/src/wikiLinks.ts
+++ b/packages/core/src/wikiLinks.ts
@@ -69,7 +69,8 @@ export function resolveWikiLinks(notes: readonly WikiLinkNote[]): ResolvedNoteLi
 
   for (const note of notes) {
     const resolvedLinks = parseWikiLinks(note.content).map((wikiLink) => {
-      const resolvedNoteId = canonicalNoteIdsByTitle.get(wikiLink.target.toLocaleLowerCase()) ?? null;
+      const resolvedNoteId =
+        canonicalNoteIdsByTitle.get(wikiLink.target.toLocaleLowerCase()) ?? null;
 
       return {
         ...wikiLink,


### PR DESCRIPTION
## Summary
- add a persisted desktop workspace registry with default first-run workspace metadata
- add Tauri commands and typed desktop wrappers for listing, adding, switching, renaming, and removing workspaces
- resolve Markdown scan/read/create/write/delete/move operations against the active workspace root
- add Rust and TypeScript coverage for registry behavior, command payloads, validation, and file-preserving removal
- apply oxfmt to pre-existing formatting misses so repository format checks pass

## Testing
- pnpm test
- pnpm typecheck
- pnpm lint
- pnpm format
- pnpm --filter @grove/desktop test
- pnpm --filter @grove/desktop typecheck
- pnpm --filter @grove/desktop build
- cargo test (apps/desktop/src-tauri)
- cargo fmt --check (apps/desktop/src-tauri)
- git diff --check
- git diff --cached --check

Refs #82
