### PR TITLE
Wire desktop workspace switcher to real workspace state

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -18,7 +18,8 @@
     "@tanstack/react-router": "^1.168.21",
     "@tauri-apps/api": "^2.0.0",
     "react": "^19.0.0",
-    "react-dom": "^19.0.0"
+    "react-dom": "^19.0.0",
+    "zustand": "^5.0.12"
   },
   "devDependencies": {
     "@tauri-apps/cli": "^2.0.0",

--- a/apps/desktop/src/features/folder-navigation/model/usePathChangeQueue.ts
+++ b/apps/desktop/src/features/folder-navigation/model/usePathChangeQueue.ts
@@ -20,6 +20,7 @@ export type PathChangeQueueState = {
   queuePathChangeOperation: (mutation: FolderWorkspaceMutation) => void;
   retryPathChangeStep: (operationId: string, stepId: FolderWorkspaceOperationStepId) => void;
   clearCompletedPathChanges: () => void;
+  resetPathChangeQueue: () => void;
   runNextPathChangeStep: (operationId: string) => Promise<void>;
 };
 
@@ -58,6 +59,13 @@ export function usePathChangeQueue(
 
   const clearCompletedPathChanges = useCallback((): void => {
     setPathChangeOperations(clearCompletedPathChangeOperations);
+  }, []);
+
+  const resetPathChangeQueue = useCallback((): void => {
+    runningOperationIdSet.current.clear();
+    nextOperationNumber.current = 1;
+    setRunningOperationIds([]);
+    setPathChangeOperations([]);
   }, []);
 
   const runNextPathChangeStep = useCallback(
@@ -110,6 +118,7 @@ export function usePathChangeQueue(
     queuePathChangeOperation,
     retryPathChangeStep,
     clearCompletedPathChanges,
+    resetPathChangeQueue,
     runNextPathChangeStep,
   };
 }

--- a/apps/desktop/src/features/folder-navigation/model/useWorkspaceStore.test.ts
+++ b/apps/desktop/src/features/folder-navigation/model/useWorkspaceStore.test.ts
@@ -1,0 +1,171 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import * as commands from "../../../shared";
+import { getRecentWorkspaces, useWorkspaceStore } from "./useWorkspaceStore";
+
+vi.mock("../../../shared", async (importOriginal) => {
+  const actual = await importOriginal<typeof commands>();
+  return {
+    ...actual,
+    getActiveWorkspace: vi.fn(),
+    listWorkspaces: vi.fn(),
+    addWorkspace: vi.fn(),
+    switchWorkspace: vi.fn(),
+    renameWorkspace: vi.fn(),
+    removeWorkspace: vi.fn(),
+  };
+});
+
+const getActiveWorkspaceMock = vi.mocked(commands.getActiveWorkspace);
+const listWorkspacesMock = vi.mocked(commands.listWorkspaces);
+const switchWorkspaceMock = vi.mocked(commands.switchWorkspace);
+const addWorkspaceMock = vi.mocked(commands.addWorkspace);
+const renameWorkspaceMock = vi.mocked(commands.renameWorkspace);
+const removeWorkspaceMock = vi.mocked(commands.removeWorkspace);
+
+const workspaceA = {
+  id: "ws-a",
+  name: "Personal Notes",
+  rootPath: "/Users/me/notes",
+  lastOpenedAtUnixMs: 2000,
+};
+
+const workspaceB = {
+  id: "ws-b",
+  name: "Work Notes",
+  rootPath: "/Users/me/work",
+  lastOpenedAtUnixMs: 1000,
+};
+
+const workspaceC = {
+  id: "ws-c",
+  name: "Archive",
+  rootPath: "/Users/me/archive",
+  lastOpenedAtUnixMs: 3000,
+};
+
+beforeEach(() => {
+  useWorkspaceStore.setState({
+    activeWorkspace: null,
+    allWorkspaces: [],
+    loadState: { status: "idle", errorMessage: null },
+  });
+  vi.resetAllMocks();
+});
+
+describe("loadWorkspaces", () => {
+  it("loads the active workspace and all workspaces on success", async () => {
+    getActiveWorkspaceMock.mockResolvedValue(workspaceA);
+    listWorkspacesMock.mockResolvedValue([workspaceA, workspaceB]);
+
+    await useWorkspaceStore.getState().loadWorkspaces();
+
+    const state = useWorkspaceStore.getState();
+    expect(state.activeWorkspace).toEqual(workspaceA);
+    expect(state.allWorkspaces).toEqual([workspaceA, workspaceB]);
+    expect(state.loadState.status).toBe("ready");
+  });
+
+  it("sets failed state when the command throws", async () => {
+    getActiveWorkspaceMock.mockRejectedValue(new Error("No workspace found"));
+    listWorkspacesMock.mockResolvedValue([]);
+
+    await useWorkspaceStore.getState().loadWorkspaces();
+
+    const state = useWorkspaceStore.getState();
+    expect(state.loadState.status).toBe("failed");
+    expect(state.loadState.errorMessage).toBe("No workspace found");
+    expect(state.activeWorkspace).toBeNull();
+  });
+});
+
+describe("switchTo", () => {
+  it("updates the active workspace and refreshes the list on switch", async () => {
+    const switched = { ...workspaceB, lastOpenedAtUnixMs: 4000 };
+    switchWorkspaceMock.mockResolvedValue(switched);
+    listWorkspacesMock.mockResolvedValue([workspaceA, switched]);
+
+    await useWorkspaceStore.getState().switchTo("ws-b");
+
+    const state = useWorkspaceStore.getState();
+    expect(state.activeWorkspace).toEqual(switched);
+    expect(switchWorkspaceMock).toHaveBeenCalledWith({ id: "ws-b" });
+  });
+});
+
+describe("addNew", () => {
+  it("adds a workspace and makes it the active workspace", async () => {
+    const newWorkspace = {
+      id: "ws-new",
+      name: "Research",
+      rootPath: "/Users/me/research",
+      lastOpenedAtUnixMs: 5000,
+    };
+    addWorkspaceMock.mockResolvedValue(newWorkspace);
+    listWorkspacesMock.mockResolvedValue([workspaceA, newWorkspace]);
+
+    await useWorkspaceStore.getState().addNew("Research", "/Users/me/research");
+
+    const state = useWorkspaceStore.getState();
+    expect(state.activeWorkspace).toEqual(newWorkspace);
+    expect(addWorkspaceMock).toHaveBeenCalledWith({ name: "Research", rootPath: "/Users/me/research" });
+  });
+});
+
+describe("renameCurrent", () => {
+  it("renames the workspace and updates it in the list", async () => {
+    const renamed = { ...workspaceA, name: "My Notes" };
+    renameWorkspaceMock.mockResolvedValue(renamed);
+    useWorkspaceStore.setState({
+      activeWorkspace: workspaceA,
+      allWorkspaces: [workspaceA, workspaceB],
+    });
+
+    await useWorkspaceStore.getState().renameCurrent("ws-a", "My Notes");
+
+    const state = useWorkspaceStore.getState();
+    expect(state.activeWorkspace?.name).toBe("My Notes");
+    expect(state.allWorkspaces.find((ws) => ws.id === "ws-a")?.name).toBe("My Notes");
+    expect(renameWorkspaceMock).toHaveBeenCalledWith({ id: "ws-a", name: "My Notes" });
+  });
+});
+
+describe("removeCurrent", () => {
+  it("removes the workspace and sets the new active workspace", async () => {
+    removeWorkspaceMock.mockResolvedValue(undefined);
+    listWorkspacesMock.mockResolvedValue([workspaceB]);
+    getActiveWorkspaceMock.mockResolvedValue(workspaceB);
+
+    useWorkspaceStore.setState({
+      activeWorkspace: workspaceA,
+      allWorkspaces: [workspaceA, workspaceB],
+    });
+
+    await useWorkspaceStore.getState().removeCurrent("ws-a");
+
+    const state = useWorkspaceStore.getState();
+    expect(state.activeWorkspace).toEqual(workspaceB);
+    expect(state.allWorkspaces).toEqual([workspaceB]);
+    expect(removeWorkspaceMock).toHaveBeenCalledWith({ id: "ws-a" });
+  });
+});
+
+describe("getRecentWorkspaces", () => {
+  it("returns all workspaces except the active one, sorted by lastOpenedAtUnixMs descending", () => {
+    const recent = getRecentWorkspaces([workspaceA, workspaceB, workspaceC], "ws-a");
+
+    expect(recent.map((ws) => ws.id)).toEqual(["ws-c", "ws-b"]);
+  });
+
+  it("returns an empty list when there are no other workspaces", () => {
+    const recent = getRecentWorkspaces([workspaceA], "ws-a");
+
+    expect(recent).toHaveLength(0);
+  });
+
+  it("returns all workspaces when there is no active workspace", () => {
+    const recent = getRecentWorkspaces([workspaceA, workspaceB], undefined);
+
+    expect(recent).toHaveLength(2);
+  });
+});

--- a/apps/desktop/src/features/folder-navigation/model/useWorkspaceStore.test.ts
+++ b/apps/desktop/src/features/folder-navigation/model/useWorkspaceStore.test.ts
@@ -77,6 +77,26 @@ describe("loadWorkspaces", () => {
     expect(state.loadState.errorMessage).toBe("No workspace found");
     expect(state.activeWorkspace).toBeNull();
   });
+
+  it("clears stale workspace data when reloading fails after a previous success", async () => {
+    useWorkspaceStore.setState({
+      activeWorkspace: workspaceA,
+      allWorkspaces: [workspaceA, workspaceB],
+      loadState: { status: "ready", errorMessage: null },
+    });
+    getActiveWorkspaceMock.mockRejectedValue(new Error("No workspace found"));
+    listWorkspacesMock.mockResolvedValue([]);
+
+    await useWorkspaceStore.getState().loadWorkspaces();
+
+    const state = useWorkspaceStore.getState();
+    expect(state.activeWorkspace).toBeNull();
+    expect(state.allWorkspaces).toEqual([]);
+    expect(state.loadState).toEqual({
+      status: "failed",
+      errorMessage: "No workspace found",
+    });
+  });
 });
 
 describe("switchTo", () => {
@@ -84,11 +104,15 @@ describe("switchTo", () => {
     const switched = { ...workspaceB, lastOpenedAtUnixMs: 4000 };
     switchWorkspaceMock.mockResolvedValue(switched);
     listWorkspacesMock.mockResolvedValue([workspaceA, switched]);
+    useWorkspaceStore.setState({
+      loadState: { status: "failed", errorMessage: "No workspace found" },
+    });
 
     await useWorkspaceStore.getState().switchTo("ws-b");
 
     const state = useWorkspaceStore.getState();
     expect(state.activeWorkspace).toEqual(switched);
+    expect(state.loadState).toEqual({ status: "ready", errorMessage: null });
     expect(switchWorkspaceMock).toHaveBeenCalledWith({ id: "ws-b" });
   });
 });
@@ -103,11 +127,15 @@ describe("addNew", () => {
     };
     addWorkspaceMock.mockResolvedValue(newWorkspace);
     listWorkspacesMock.mockResolvedValue([workspaceA, newWorkspace]);
+    useWorkspaceStore.setState({
+      loadState: { status: "failed", errorMessage: "No workspace found" },
+    });
 
     await useWorkspaceStore.getState().addNew("Research", "/Users/me/research");
 
     const state = useWorkspaceStore.getState();
     expect(state.activeWorkspace).toEqual(newWorkspace);
+    expect(state.loadState).toEqual({ status: "ready", errorMessage: null });
     expect(addWorkspaceMock).toHaveBeenCalledWith({ name: "Research", rootPath: "/Users/me/research" });
   });
 });
@@ -119,6 +147,7 @@ describe("renameCurrent", () => {
     useWorkspaceStore.setState({
       activeWorkspace: workspaceA,
       allWorkspaces: [workspaceA, workspaceB],
+      loadState: { status: "failed", errorMessage: "No workspace found" },
     });
 
     await useWorkspaceStore.getState().renameCurrent("ws-a", "My Notes");
@@ -126,6 +155,7 @@ describe("renameCurrent", () => {
     const state = useWorkspaceStore.getState();
     expect(state.activeWorkspace?.name).toBe("My Notes");
     expect(state.allWorkspaces.find((ws) => ws.id === "ws-a")?.name).toBe("My Notes");
+    expect(state.loadState).toEqual({ status: "ready", errorMessage: null });
     expect(renameWorkspaceMock).toHaveBeenCalledWith({ id: "ws-a", name: "My Notes" });
   });
 });
@@ -139,6 +169,7 @@ describe("removeCurrent", () => {
     useWorkspaceStore.setState({
       activeWorkspace: workspaceA,
       allWorkspaces: [workspaceA, workspaceB],
+      loadState: { status: "failed", errorMessage: "No workspace found" },
     });
 
     await useWorkspaceStore.getState().removeCurrent("ws-a");
@@ -146,7 +177,27 @@ describe("removeCurrent", () => {
     const state = useWorkspaceStore.getState();
     expect(state.activeWorkspace).toEqual(workspaceB);
     expect(state.allWorkspaces).toEqual([workspaceB]);
+    expect(state.loadState).toEqual({ status: "ready", errorMessage: null });
     expect(removeWorkspaceMock).toHaveBeenCalledWith({ id: "ws-a" });
+  });
+
+  it("clears the failed load state when the last workspace is removed", async () => {
+    removeWorkspaceMock.mockResolvedValue(undefined);
+    listWorkspacesMock.mockResolvedValue([]);
+    getActiveWorkspaceMock.mockRejectedValue(new Error("No workspace found"));
+
+    useWorkspaceStore.setState({
+      activeWorkspace: workspaceA,
+      allWorkspaces: [workspaceA],
+      loadState: { status: "failed", errorMessage: "No workspace found" },
+    });
+
+    await useWorkspaceStore.getState().removeCurrent("ws-a");
+
+    const state = useWorkspaceStore.getState();
+    expect(state.activeWorkspace).toBeNull();
+    expect(state.allWorkspaces).toEqual([]);
+    expect(state.loadState).toEqual({ status: "ready", errorMessage: null });
   });
 });
 

--- a/apps/desktop/src/features/folder-navigation/model/useWorkspaceStore.ts
+++ b/apps/desktop/src/features/folder-navigation/model/useWorkspaceStore.ts
@@ -41,21 +41,33 @@ export const useWorkspaceStore = create<WorkspaceStore>((set) => ({
       const [active, all] = await Promise.all([getActiveWorkspace(), listWorkspaces()]);
       set({ activeWorkspace: active, allWorkspaces: all, loadState: { status: "ready", errorMessage: null } });
     } catch (error) {
-      set({ loadState: { status: "failed", errorMessage: getWorkspaceErrorMessage(error) } });
+      set({
+        activeWorkspace: null,
+        allWorkspaces: [],
+        loadState: { status: "failed", errorMessage: getWorkspaceErrorMessage(error) },
+      });
     }
   },
 
   switchTo: async (id: string) => {
     const workspace = await switchWorkspace({ id });
     const all = await listWorkspaces();
-    set({ activeWorkspace: workspace, allWorkspaces: all });
+    set({
+      activeWorkspace: workspace,
+      allWorkspaces: all,
+      loadState: { status: "ready", errorMessage: null },
+    });
     return workspace;
   },
 
   addNew: async (name: string, rootPath: string) => {
     const workspace = await addWorkspace({ name, rootPath });
     const all = await listWorkspaces();
-    set({ activeWorkspace: workspace, allWorkspaces: all });
+    set({
+      activeWorkspace: workspace,
+      allWorkspaces: all,
+      loadState: { status: "ready", errorMessage: null },
+    });
     return workspace;
   },
 
@@ -64,6 +76,7 @@ export const useWorkspaceStore = create<WorkspaceStore>((set) => ({
     set((state) => ({
       activeWorkspace: state.activeWorkspace?.id === id ? workspace : state.activeWorkspace,
       allWorkspaces: state.allWorkspaces.map((ws) => (ws.id === id ? workspace : ws)),
+      loadState: { status: "ready", errorMessage: null },
     }));
     return workspace;
   },
@@ -73,9 +86,17 @@ export const useWorkspaceStore = create<WorkspaceStore>((set) => ({
     const all = await listWorkspaces();
     try {
       const newActive = await getActiveWorkspace();
-      set({ activeWorkspace: newActive, allWorkspaces: all });
+      set({
+        activeWorkspace: newActive,
+        allWorkspaces: all,
+        loadState: { status: "ready", errorMessage: null },
+      });
     } catch {
-      set({ activeWorkspace: null, allWorkspaces: all });
+      set({
+        activeWorkspace: null,
+        allWorkspaces: all,
+        loadState: { status: "ready", errorMessage: null },
+      });
     }
   },
 }));

--- a/apps/desktop/src/features/folder-navigation/model/useWorkspaceStore.ts
+++ b/apps/desktop/src/features/folder-navigation/model/useWorkspaceStore.ts
@@ -1,0 +1,90 @@
+import { create } from "zustand";
+
+import {
+  addWorkspace,
+  getActiveWorkspace,
+  listWorkspaces,
+  removeWorkspace,
+  renameWorkspace,
+  switchWorkspace,
+} from "../../../shared";
+import type { DesktopWorkspace } from "../../../shared";
+
+type WorkspaceLoadState = {
+  status: "idle" | "loading" | "ready" | "failed";
+  errorMessage: string | null;
+};
+
+type WorkspaceStore = {
+  activeWorkspace: DesktopWorkspace | null;
+  allWorkspaces: readonly DesktopWorkspace[];
+  loadState: WorkspaceLoadState;
+  loadWorkspaces: () => Promise<void>;
+  switchTo: (id: string) => Promise<DesktopWorkspace>;
+  addNew: (name: string, rootPath: string) => Promise<DesktopWorkspace>;
+  renameCurrent: (id: string, name: string) => Promise<DesktopWorkspace>;
+  removeCurrent: (id: string) => Promise<void>;
+};
+
+function getWorkspaceErrorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : "The workspace operation failed.";
+}
+
+export const useWorkspaceStore = create<WorkspaceStore>((set) => ({
+  activeWorkspace: null,
+  allWorkspaces: [],
+  loadState: { status: "idle", errorMessage: null },
+
+  loadWorkspaces: async () => {
+    set({ loadState: { status: "loading", errorMessage: null } });
+    try {
+      const [active, all] = await Promise.all([getActiveWorkspace(), listWorkspaces()]);
+      set({ activeWorkspace: active, allWorkspaces: all, loadState: { status: "ready", errorMessage: null } });
+    } catch (error) {
+      set({ loadState: { status: "failed", errorMessage: getWorkspaceErrorMessage(error) } });
+    }
+  },
+
+  switchTo: async (id: string) => {
+    const workspace = await switchWorkspace({ id });
+    const all = await listWorkspaces();
+    set({ activeWorkspace: workspace, allWorkspaces: all });
+    return workspace;
+  },
+
+  addNew: async (name: string, rootPath: string) => {
+    const workspace = await addWorkspace({ name, rootPath });
+    const all = await listWorkspaces();
+    set({ activeWorkspace: workspace, allWorkspaces: all });
+    return workspace;
+  },
+
+  renameCurrent: async (id: string, name: string) => {
+    const workspace = await renameWorkspace({ id, name });
+    set((state) => ({
+      activeWorkspace: state.activeWorkspace?.id === id ? workspace : state.activeWorkspace,
+      allWorkspaces: state.allWorkspaces.map((ws) => (ws.id === id ? workspace : ws)),
+    }));
+    return workspace;
+  },
+
+  removeCurrent: async (id: string) => {
+    await removeWorkspace({ id });
+    const all = await listWorkspaces();
+    try {
+      const newActive = await getActiveWorkspace();
+      set({ activeWorkspace: newActive, allWorkspaces: all });
+    } catch {
+      set({ activeWorkspace: null, allWorkspaces: all });
+    }
+  },
+}));
+
+export function getRecentWorkspaces(
+  allWorkspaces: readonly DesktopWorkspace[],
+  activeWorkspaceId: string | undefined,
+): DesktopWorkspace[] {
+  return [...allWorkspaces]
+    .filter((ws) => ws.id !== activeWorkspaceId)
+    .sort((a, b) => b.lastOpenedAtUnixMs - a.lastOpenedAtUnixMs);
+}

--- a/apps/desktop/src/features/folder-navigation/ui/FolderNavigationWorkspace.test.tsx
+++ b/apps/desktop/src/features/folder-navigation/ui/FolderNavigationWorkspace.test.tsx
@@ -7,7 +7,9 @@ import {
   FolderNavigationWorkspaceContent,
   NavigationPane,
   WorkspaceSwitcher,
+  getActiveWorkspaceName,
   getFolderNavigationWorkspaceClassName,
+  getScanStateWithoutActiveWorkspace,
   getWorkspaceSwitchBlockedReason,
 } from "./FolderNavigationWorkspace";
 
@@ -346,6 +348,52 @@ describe("getWorkspaceSwitchBlockedReason", () => {
     );
 
     expect(reason).toBeNull();
+  });
+});
+
+describe("getScanStateWithoutActiveWorkspace", () => {
+  it("surfaces workspace load failures instead of leaving the note list loading forever", () => {
+    expect(
+      getScanStateWithoutActiveWorkspace({
+        status: "failed",
+        errorMessage: "No workspace found",
+      }),
+    ).toEqual({
+      status: "failed",
+      errorMessage: "No workspace found",
+    });
+  });
+
+  it("treats a missing active workspace after a successful load as an empty ready state", () => {
+    expect(
+      getScanStateWithoutActiveWorkspace({
+        status: "ready",
+        errorMessage: null,
+      }),
+    ).toEqual({
+      status: "ready",
+      errorMessage: null,
+    });
+  });
+});
+
+describe("getActiveWorkspaceName", () => {
+  it("shows a fallback label when no workspace is selected", () => {
+    expect(
+      getActiveWorkspaceName(null, {
+        status: "ready",
+        errorMessage: null,
+      }),
+    ).toBe("No workspace selected");
+  });
+
+  it("shows that workspaces are unavailable when loading failed", () => {
+    expect(
+      getActiveWorkspaceName(null, {
+        status: "failed",
+        errorMessage: "No workspace found",
+      }),
+    ).toBe("Workspace unavailable");
   });
 });
 

--- a/apps/desktop/src/features/folder-navigation/ui/FolderNavigationWorkspace.test.tsx
+++ b/apps/desktop/src/features/folder-navigation/ui/FolderNavigationWorkspace.test.tsx
@@ -225,6 +225,31 @@ describe("WorkspaceSwitcher", () => {
     expect(markup).toContain("Save or discard the current draft before switching workspaces.");
   });
 
+  it("disables add workspace while note edits are dirty", () => {
+    const markup = renderToStaticMarkup(
+      <WorkspaceSwitcher
+        {...baseWorkspaceSwitcherProps}
+        switchBlockedReason="Save or discard the current draft before switching workspaces."
+        initiallyOpen={true}
+      />,
+    );
+
+    expect(markup).toMatch(/<button type="button" class="folder-navigation__workspace-action" disabled="">Add workspace<\/button>/);
+  });
+
+  it("disables remove workspace while note edits are dirty", () => {
+    const markup = renderToStaticMarkup(
+      <WorkspaceSwitcher
+        {...baseWorkspaceSwitcherProps}
+        switchBlockedReason="Save or discard the current draft before switching workspaces."
+        initiallyOpen={true}
+        initialView="settings"
+      />,
+    );
+
+    expect(markup).toMatch(/<button type="button" class="folder-navigation__secondary-action" disabled="">Remove from Grove<\/button>/);
+  });
+
   it("renders the active workspace name from props", () => {
     const markup = renderToStaticMarkup(
       <WorkspaceSwitcher {...baseWorkspaceSwitcherProps} activeWorkspaceName="My Research" />,

--- a/apps/desktop/src/features/folder-navigation/ui/FolderNavigationWorkspace.test.tsx
+++ b/apps/desktop/src/features/folder-navigation/ui/FolderNavigationWorkspace.test.tsx
@@ -100,6 +100,13 @@ describe("NavigationPane", () => {
         onCreateTitleChange={() => {}}
         onCreateNote={() => {}}
         onSelectNote={() => {}}
+        activeWorkspaceName=""
+        recentWorkspaces={[]}
+        switchBlockedReason={null}
+        onSwitchWorkspace={() => Promise.resolve()}
+        onAddWorkspace={() => Promise.resolve()}
+        onRenameWorkspace={() => Promise.resolve()}
+        onRemoveWorkspace={() => Promise.resolve()}
         {...overrides}
       />,
     );
@@ -124,7 +131,15 @@ describe("NavigationPane", () => {
   });
 
   it("places the workspace switcher in the Library column", () => {
-    const markup = renderNavigationPaneMarkup();
+    const markup = renderNavigationPaneMarkup({
+      activeWorkspaceName: "Personal Notes",
+      recentWorkspaces: [],
+      switchBlockedReason: null,
+      onSwitchWorkspace: () => Promise.resolve(),
+      onAddWorkspace: () => Promise.resolve(),
+      onRenameWorkspace: () => Promise.resolve(),
+      onRemoveWorkspace: () => Promise.resolve(),
+    });
 
     expect(markup).toContain("folder-navigation__workspace-switcher");
     expect(markup).toContain("Personal Notes");
@@ -133,13 +148,19 @@ describe("NavigationPane", () => {
 });
 
 describe("WorkspaceSwitcher", () => {
+  const baseWorkspaceSwitcherProps = {
+    activeWorkspaceName: "Personal Notes",
+    recentWorkspaces: [] as { id: string; name: string; rootPath: string; lastOpenedAtUnixMs: number }[],
+    switchBlockedReason: null as string | null,
+    onSwitchWorkspace: () => Promise.resolve(),
+    onAddWorkspace: () => Promise.resolve(),
+    onRenameWorkspace: () => Promise.resolve(),
+    onRemoveWorkspace: () => Promise.resolve(),
+  };
+
   it("connects the trigger to the workspace popover for assistive technology", () => {
     const markup = renderToStaticMarkup(
-      <WorkspaceSwitcher
-        currentWorkspaceName="Personal Notes"
-        recentWorkspaceNames={[]}
-        initiallyOpen={true}
-      />,
+      <WorkspaceSwitcher {...baseWorkspaceSwitcherProps} initiallyOpen={true} />,
     );
     const controlsMatch = markup.match(/aria-controls="([^"]+)"/);
     const idMatch = markup.match(/id="([^"]+)"/);
@@ -152,14 +173,10 @@ describe("WorkspaceSwitcher", () => {
   it("uses unique popover ids when more than one switcher is rendered", () => {
     const markup = renderToStaticMarkup(
       <>
+        <WorkspaceSwitcher {...baseWorkspaceSwitcherProps} initiallyOpen={true} />
         <WorkspaceSwitcher
-          currentWorkspaceName="Personal Notes"
-          recentWorkspaceNames={[]}
-          initiallyOpen={true}
-        />
-        <WorkspaceSwitcher
-          currentWorkspaceName="Archive"
-          recentWorkspaceNames={[]}
+          {...baseWorkspaceSwitcherProps}
+          activeWorkspaceName="Archive"
           initiallyOpen={true}
         />
       </>,
@@ -174,8 +191,11 @@ describe("WorkspaceSwitcher", () => {
   it("opens a lightweight popover with workspace actions and no sync copy", () => {
     const markup = renderToStaticMarkup(
       <WorkspaceSwitcher
-        currentWorkspaceName="Personal Notes"
-        recentWorkspaceNames={["Research", "Archive"]}
+        {...baseWorkspaceSwitcherProps}
+        recentWorkspaces={[
+          { id: "ws-research", name: "Research", rootPath: "/notes/research", lastOpenedAtUnixMs: 2000 },
+          { id: "ws-archive", name: "Archive", rootPath: "/notes/archive", lastOpenedAtUnixMs: 1000 },
+        ]}
         initiallyOpen={true}
       />,
     );
@@ -188,6 +208,29 @@ describe("WorkspaceSwitcher", () => {
     expect(markup).not.toContain("Synced");
     expect(markup).not.toContain("Sync status");
     expect(markup).not.toContain("Cloud status");
+  });
+
+  it("shows the switch blocked reason when note edits are dirty", () => {
+    const markup = renderToStaticMarkup(
+      <WorkspaceSwitcher
+        {...baseWorkspaceSwitcherProps}
+        switchBlockedReason="Save or discard the current draft before switching workspaces."
+        recentWorkspaces={[
+          { id: "ws-b", name: "Work Notes", rootPath: "/notes/work", lastOpenedAtUnixMs: 1000 },
+        ]}
+        initiallyOpen={true}
+      />,
+    );
+
+    expect(markup).toContain("Save or discard the current draft before switching workspaces.");
+  });
+
+  it("renders the active workspace name from props", () => {
+    const markup = renderToStaticMarkup(
+      <WorkspaceSwitcher {...baseWorkspaceSwitcherProps} activeWorkspaceName="My Research" />,
+    );
+
+    expect(markup).toContain("My Research");
   });
 });
 

--- a/apps/desktop/src/features/folder-navigation/ui/FolderNavigationWorkspace.test.tsx
+++ b/apps/desktop/src/features/folder-navigation/ui/FolderNavigationWorkspace.test.tsx
@@ -8,6 +8,7 @@ import {
   NavigationPane,
   WorkspaceSwitcher,
   getFolderNavigationWorkspaceClassName,
+  getWorkspaceSwitchBlockedReason,
 } from "./FolderNavigationWorkspace";
 
 describe("getFolderNavigationWorkspaceClassName", () => {
@@ -225,6 +226,21 @@ describe("WorkspaceSwitcher", () => {
     expect(markup).toContain("Save or discard the current draft before switching workspaces.");
   });
 
+  it("shows the switch blocked reason when path changes are unfinished", () => {
+    const markup = renderToStaticMarkup(
+      <WorkspaceSwitcher
+        {...baseWorkspaceSwitcherProps}
+        switchBlockedReason="Finish pending path changes before switching workspaces."
+        recentWorkspaces={[
+          { id: "ws-b", name: "Work Notes", rootPath: "/notes/work", lastOpenedAtUnixMs: 1000 },
+        ]}
+        initiallyOpen={true}
+      />,
+    );
+
+    expect(markup).toContain("Finish pending path changes before switching workspaces.");
+  });
+
   it("disables add workspace while note edits are dirty", () => {
     const markup = renderToStaticMarkup(
       <WorkspaceSwitcher
@@ -256,6 +272,80 @@ describe("WorkspaceSwitcher", () => {
     );
 
     expect(markup).toContain("My Research");
+  });
+});
+
+describe("getWorkspaceSwitchBlockedReason", () => {
+  it("blocks switching when the current note has unsaved edits", () => {
+    const reason = getWorkspaceSwitchBlockedReason(
+      {
+        noteId: "note-1",
+        path: normalizeNoteFilePath("Projects/Grove/Plan.md"),
+        baseContent: "before",
+        draftContent: "after",
+        status: "dirty",
+        errorMessage: null,
+      },
+      [],
+    );
+
+    expect(reason).toBe("Save or discard the current draft before switching workspaces.");
+  });
+
+  it("blocks switching when path changes are unfinished", () => {
+    const reason = getWorkspaceSwitchBlockedReason(null, [
+      {
+        id: "path-change-1",
+        reason: "note-move",
+        affectedNoteIds: ["note-1"],
+        pathChanges: [
+          {
+            noteId: "note-1",
+            previousPath: normalizeNoteFilePath("Projects/Grove/Plan.md"),
+            nextPath: normalizeNoteFilePath("Archive/Plan.md"),
+          },
+        ],
+        steps: [
+          { id: "file-move", status: "completed" },
+          { id: "index-refresh", status: "pending" },
+        ],
+      },
+    ]);
+
+    expect(reason).toBe("Finish pending path changes before switching workspaces.");
+  });
+
+  it("allows switching when drafts are clean and path changes are complete", () => {
+    const reason = getWorkspaceSwitchBlockedReason(
+      {
+        noteId: "note-1",
+        path: normalizeNoteFilePath("Projects/Grove/Plan.md"),
+        baseContent: "same",
+        draftContent: "same",
+        status: "clean",
+        errorMessage: null,
+      },
+      [
+        {
+          id: "path-change-1",
+          reason: "note-move",
+          affectedNoteIds: ["note-1"],
+          pathChanges: [
+            {
+              noteId: "note-1",
+              previousPath: normalizeNoteFilePath("Projects/Grove/Plan.md"),
+              nextPath: normalizeNoteFilePath("Archive/Plan.md"),
+            },
+          ],
+          steps: [
+            { id: "file-move", status: "completed" },
+            { id: "index-refresh", status: "completed" },
+          ],
+        },
+      ],
+    );
+
+    expect(reason).toBeNull();
   });
 });
 

--- a/apps/desktop/src/features/folder-navigation/ui/FolderNavigationWorkspace.tsx
+++ b/apps/desktop/src/features/folder-navigation/ui/FolderNavigationWorkspace.tsx
@@ -116,6 +116,7 @@ type NavigationPaneProps = SidebarProps & NoteListProps;
 
 type WorkspaceSwitcherProps = WorkspaceSwitcherSlice & {
   initiallyOpen?: boolean;
+  initialView?: PopoverView;
 };
 
 type PopoverView = "list" | "add" | "settings";
@@ -127,6 +128,7 @@ type PopoverOperationState = {
 
 type WorkspaceSwitcherPopoverProps = WorkspaceSwitcherSlice & {
   id: string;
+  initialView?: PopoverView;
 };
 
 type FolderOption = {
@@ -546,6 +548,7 @@ export function WorkspaceSwitcher({
   onRenameWorkspace,
   onRemoveWorkspace,
   initiallyOpen = false,
+  initialView = "list",
 }: WorkspaceSwitcherProps) {
   const popoverId = useId();
   const [isOpen, setIsOpen] = useState(initiallyOpen);
@@ -569,6 +572,7 @@ export function WorkspaceSwitcher({
           activeWorkspaceName={activeWorkspaceName}
           recentWorkspaces={recentWorkspaces}
           switchBlockedReason={switchBlockedReason}
+          initialView={initialView}
           onSwitchWorkspace={async (id) => {
             await onSwitchWorkspace(id);
             setIsOpen(false);
@@ -596,12 +600,13 @@ function WorkspaceSwitcherPopover({
   activeWorkspaceName,
   recentWorkspaces,
   switchBlockedReason,
+  initialView = "list",
   onSwitchWorkspace,
   onAddWorkspace,
   onRenameWorkspace,
   onRemoveWorkspace,
 }: WorkspaceSwitcherPopoverProps) {
-  const [view, setView] = useState<PopoverView>("list");
+  const [view, setView] = useState<PopoverView>(initialView);
   const [operation, setOperation] = useState<PopoverOperationState>({
     status: "idle",
     errorMessage: null,
@@ -623,6 +628,11 @@ function WorkspaceSwitcherPopover({
   }
 
   async function handleSwitch(id: string): Promise<void> {
+    if (switchBlockedReason !== null) {
+      setOperation({ status: "failed", errorMessage: switchBlockedReason });
+      return;
+    }
+
     setOperation({ status: "pending", errorMessage: null });
     try {
       await onSwitchWorkspace(id);
@@ -635,6 +645,11 @@ function WorkspaceSwitcherPopover({
   }
 
   async function handleAdd(): Promise<void> {
+    if (switchBlockedReason !== null) {
+      setOperation({ status: "failed", errorMessage: switchBlockedReason });
+      return;
+    }
+
     if (addName.trim() === "" || addPath.trim() === "") return;
     setOperation({ status: "pending", errorMessage: null });
     try {
@@ -661,6 +676,11 @@ function WorkspaceSwitcherPopover({
   }
 
   async function handleRemove(): Promise<void> {
+    if (switchBlockedReason !== null) {
+      setOperation({ status: "failed", errorMessage: switchBlockedReason });
+      return;
+    }
+
     const confirmed = window.confirm(
       `Remove "${activeWorkspaceName}" from Grove? Your Markdown files will not be deleted.`,
     );
@@ -720,6 +740,7 @@ function WorkspaceSwitcherPopover({
               type="button"
               className="folder-navigation__workspace-action"
               onClick={() => switchView("add")}
+              disabled={switchBlockedReason !== null}
             >
               Add workspace
             </button>
@@ -768,7 +789,12 @@ function WorkspaceSwitcherPopover({
                 type="button"
                 className="folder-navigation__action"
                 onClick={() => { void handleAdd(); }}
-                disabled={operation.status === "pending" || addName.trim() === "" || addPath.trim() === ""}
+                disabled={
+                  switchBlockedReason !== null ||
+                  operation.status === "pending" ||
+                  addName.trim() === "" ||
+                  addPath.trim() === ""
+                }
               >
                 {operation.status === "pending" ? "Adding..." : "Add"}
               </button>
@@ -829,7 +855,7 @@ function WorkspaceSwitcherPopover({
                 type="button"
                 className="folder-navigation__secondary-action"
                 onClick={() => { void handleRemove(); }}
-                disabled={operation.status === "pending"}
+                disabled={switchBlockedReason !== null || operation.status === "pending"}
               >
                 Remove from Grove
               </button>
@@ -1544,6 +1570,7 @@ export function FolderNavigationWorkspaceContent({
     queuePathChangeOperation,
     retryPathChangeStep,
     clearCompletedPathChanges,
+    resetPathChangeQueue,
     runNextPathChangeStep,
   } = usePathChangeQueue(desktopPathChangeExecutor);
   const { notes, explicitFolders, selectedFolderPath, expandedFolderPaths } = workspaceState;
@@ -1972,6 +1999,7 @@ export function FolderNavigationWorkspaceContent({
     setSelectedNoteId("");
     setNoteEditBuffer(null);
     setEditorNotice(null);
+    resetPathChangeQueue();
     setScanState({ status: "loading", errorMessage: null });
     setCreateState({ status: "idle", errorMessage: null });
     setDeleteState({ status: "idle", errorMessage: null });
@@ -2023,7 +2051,7 @@ export function FolderNavigationWorkspaceContent({
     return () => {
       canceled = true;
     };
-  }, [activeWorkspace?.id]);
+  }, [activeWorkspace?.id, resetPathChangeQueue]);
 
   useEffect(() => {
     if (selectedNote === undefined) {

--- a/apps/desktop/src/features/folder-navigation/ui/FolderNavigationWorkspace.tsx
+++ b/apps/desktop/src/features/folder-navigation/ui/FolderNavigationWorkspace.tsx
@@ -260,6 +260,19 @@ function getFolderLabel(folderPath: FolderScope): string {
   return folderPath === null ? "Workspace" : getFolderDisplayName(folderPath);
 }
 
+export function getWorkspaceSwitchBlockedReason(
+  noteEditBuffer: NoteEditBuffer | null,
+  pathChangeOperations: readonly FolderWorkspacePathChangeOperation[],
+): string | null {
+  if (isNoteEditBufferBlockingWorkspaceChange(noteEditBuffer)) {
+    return "Save or discard the current draft before switching workspaces.";
+  }
+
+  return pathChangeOperations.some((operation) => !isPathChangeOperationComplete(operation))
+    ? "Finish pending path changes before switching workspaces."
+    : null;
+}
+
 function getFolderPathLabel(folderPath: FolderScope): string {
   return folderPath === null ? "Workspace root" : folderPath;
 }
@@ -1617,9 +1630,10 @@ export function FolderNavigationWorkspaceContent({
     selectedNote === undefined || !isNoteAffectedByPathChange(pathChangeOperations, selectedNote.id)
       ? null
       : "Delete is unavailable while this note has unfinished path changes.";
-  const switchBlockedReason = isNoteEditBufferBlockingWorkspaceChange(noteEditBuffer)
-    ? "Save or discard the current draft before switching workspaces."
-    : null;
+  const switchBlockedReason = getWorkspaceSwitchBlockedReason(
+    noteEditBuffer,
+    pathChangeOperations,
+  );
   const recentWorkspaces = getRecentWorkspaces(allWorkspaces, activeWorkspace?.id);
 
   async function handleSwitchWorkspace(id: string): Promise<void> {

--- a/apps/desktop/src/features/folder-navigation/ui/FolderNavigationWorkspace.tsx
+++ b/apps/desktop/src/features/folder-navigation/ui/FolderNavigationWorkspace.tsx
@@ -14,6 +14,9 @@ import type { MarkdownCommand, MarkdownSelection } from "@grove/editor";
 import { useCallback, useEffect, useId, useLayoutEffect, useMemo, useRef, useState } from "react";
 import type { ReactNode } from "react";
 
+import type { DesktopWorkspace } from "../../../shared";
+import { getRecentWorkspaces, useWorkspaceStore } from "../model/useWorkspaceStore";
+
 import {
   createMarkdownNote,
   deleteMarkdownNote,
@@ -78,6 +81,16 @@ type FolderNodeProps = {
   onToggle: (path: string) => void;
 };
 
+type WorkspaceSwitcherSlice = {
+  activeWorkspaceName: string;
+  recentWorkspaces: readonly DesktopWorkspace[];
+  switchBlockedReason: string | null;
+  onSwitchWorkspace: (id: string) => Promise<void>;
+  onAddWorkspace: (name: string, rootPath: string) => Promise<void>;
+  onRenameWorkspace: (name: string) => Promise<void>;
+  onRemoveWorkspace: () => Promise<void>;
+};
+
 type SidebarProps = {
   noteCount: number;
   folderTree: readonly FolderTreeNode[];
@@ -85,7 +98,7 @@ type SidebarProps = {
   expandedFolderPaths: readonly string[];
   onSelect: (path: FolderScope) => void;
   onToggle: (path: string) => void;
-};
+} & WorkspaceSwitcherSlice;
 
 type NoteListProps = {
   selectedFolderPath: FolderScope;
@@ -101,16 +114,19 @@ type NoteListProps = {
 
 type NavigationPaneProps = SidebarProps & NoteListProps;
 
-type WorkspaceSwitcherProps = {
-  currentWorkspaceName: string;
-  recentWorkspaceNames: readonly string[];
+type WorkspaceSwitcherProps = WorkspaceSwitcherSlice & {
   initiallyOpen?: boolean;
 };
 
-type WorkspaceSwitcherPopoverProps = {
+type PopoverView = "list" | "add" | "settings";
+
+type PopoverOperationState = {
+  status: "idle" | "pending" | "failed";
+  errorMessage: string | null;
+};
+
+type WorkspaceSwitcherPopoverProps = WorkspaceSwitcherSlice & {
   id: string;
-  currentWorkspaceName: string;
-  recentWorkspaceNames: readonly string[];
 };
 
 type FolderOption = {
@@ -466,6 +482,13 @@ function LibraryColumn({
   expandedFolderPaths,
   onSelect,
   onToggle,
+  activeWorkspaceName,
+  recentWorkspaces,
+  switchBlockedReason,
+  onSwitchWorkspace,
+  onAddWorkspace,
+  onRenameWorkspace,
+  onRemoveWorkspace,
 }: SidebarProps) {
   return (
     <aside className="folder-navigation__library-column" aria-label="Library">
@@ -501,14 +524,27 @@ function LibraryColumn({
           </ol>
         </section>
       </div>
-      <WorkspaceSwitcher currentWorkspaceName="Personal Notes" recentWorkspaceNames={[]} />
+      <WorkspaceSwitcher
+        activeWorkspaceName={activeWorkspaceName}
+        recentWorkspaces={recentWorkspaces}
+        switchBlockedReason={switchBlockedReason}
+        onSwitchWorkspace={onSwitchWorkspace}
+        onAddWorkspace={onAddWorkspace}
+        onRenameWorkspace={onRenameWorkspace}
+        onRemoveWorkspace={onRemoveWorkspace}
+      />
     </aside>
   );
 }
 
 export function WorkspaceSwitcher({
-  currentWorkspaceName,
-  recentWorkspaceNames,
+  activeWorkspaceName,
+  recentWorkspaces,
+  switchBlockedReason,
+  onSwitchWorkspace,
+  onAddWorkspace,
+  onRenameWorkspace,
+  onRemoveWorkspace,
   initiallyOpen = false,
 }: WorkspaceSwitcherProps) {
   const popoverId = useId();
@@ -524,14 +560,31 @@ export function WorkspaceSwitcher({
         aria-haspopup="dialog"
         aria-controls={isOpen ? popoverId : undefined}
       >
-        <span className="folder-navigation__workspace-name">{currentWorkspaceName}</span>
+        <span className="folder-navigation__workspace-name">{activeWorkspaceName}</span>
         <span className="folder-navigation__workspace-hint">Switch workspace</span>
       </button>
       {isOpen ? (
         <WorkspaceSwitcherPopover
           id={popoverId}
-          currentWorkspaceName={currentWorkspaceName}
-          recentWorkspaceNames={recentWorkspaceNames}
+          activeWorkspaceName={activeWorkspaceName}
+          recentWorkspaces={recentWorkspaces}
+          switchBlockedReason={switchBlockedReason}
+          onSwitchWorkspace={async (id) => {
+            await onSwitchWorkspace(id);
+            setIsOpen(false);
+          }}
+          onAddWorkspace={async (name, rootPath) => {
+            await onAddWorkspace(name, rootPath);
+            setIsOpen(false);
+          }}
+          onRenameWorkspace={async (name) => {
+            await onRenameWorkspace(name);
+            setIsOpen(false);
+          }}
+          onRemoveWorkspace={async () => {
+            await onRemoveWorkspace();
+            setIsOpen(false);
+          }}
         />
       ) : null}
     </div>
@@ -540,9 +593,89 @@ export function WorkspaceSwitcher({
 
 function WorkspaceSwitcherPopover({
   id,
-  currentWorkspaceName,
-  recentWorkspaceNames,
+  activeWorkspaceName,
+  recentWorkspaces,
+  switchBlockedReason,
+  onSwitchWorkspace,
+  onAddWorkspace,
+  onRenameWorkspace,
+  onRemoveWorkspace,
 }: WorkspaceSwitcherPopoverProps) {
+  const [view, setView] = useState<PopoverView>("list");
+  const [operation, setOperation] = useState<PopoverOperationState>({
+    status: "idle",
+    errorMessage: null,
+  });
+  const [addName, setAddName] = useState("");
+  const [addPath, setAddPath] = useState("");
+  const [renameName, setRenameName] = useState(activeWorkspaceName);
+
+  function switchView(nextView: PopoverView): void {
+    setView(nextView);
+    setOperation({ status: "idle", errorMessage: null });
+  }
+
+  function resetToList(): void {
+    switchView("list");
+    setAddName("");
+    setAddPath("");
+    setRenameName(activeWorkspaceName);
+  }
+
+  async function handleSwitch(id: string): Promise<void> {
+    setOperation({ status: "pending", errorMessage: null });
+    try {
+      await onSwitchWorkspace(id);
+    } catch (error) {
+      setOperation({
+        status: "failed",
+        errorMessage: error instanceof Error ? error.message : "Failed to switch workspace.",
+      });
+    }
+  }
+
+  async function handleAdd(): Promise<void> {
+    if (addName.trim() === "" || addPath.trim() === "") return;
+    setOperation({ status: "pending", errorMessage: null });
+    try {
+      await onAddWorkspace(addName.trim(), addPath.trim());
+    } catch (error) {
+      setOperation({
+        status: "failed",
+        errorMessage: error instanceof Error ? error.message : "Failed to add workspace.",
+      });
+    }
+  }
+
+  async function handleRename(): Promise<void> {
+    if (renameName.trim() === "" || renameName.trim() === activeWorkspaceName) return;
+    setOperation({ status: "pending", errorMessage: null });
+    try {
+      await onRenameWorkspace(renameName.trim());
+    } catch (error) {
+      setOperation({
+        status: "failed",
+        errorMessage: error instanceof Error ? error.message : "Failed to rename workspace.",
+      });
+    }
+  }
+
+  async function handleRemove(): Promise<void> {
+    const confirmed = window.confirm(
+      `Remove "${activeWorkspaceName}" from Grove? Your Markdown files will not be deleted.`,
+    );
+    if (!confirmed) return;
+    setOperation({ status: "pending", errorMessage: null });
+    try {
+      await onRemoveWorkspace();
+    } catch (error) {
+      setOperation({
+        status: "failed",
+        errorMessage: error instanceof Error ? error.message : "Failed to remove workspace.",
+      });
+    }
+  }
+
   return (
     <div
       id={id}
@@ -551,31 +684,162 @@ function WorkspaceSwitcherPopover({
       aria-label="Workspace switcher"
     >
       <p className="folder-navigation__eyebrow">Current workspace</p>
-      <p className="folder-navigation__workspace-popover-title">{currentWorkspaceName}</p>
-      <div className="folder-navigation__workspace-popover-section">
-        <p className="folder-navigation__group-heading">Recent workspaces</p>
-        {recentWorkspaceNames.length > 0 ? (
-          <ul className="folder-navigation__workspace-list">
-            {recentWorkspaceNames.map((workspaceName) => (
-              <li key={workspaceName}>
-                <button type="button" className="folder-navigation__workspace-action">
-                  {workspaceName}
-                </button>
-              </li>
-            ))}
-          </ul>
-        ) : (
-          <p className="folder-navigation__muted">No recent workspaces yet.</p>
-        )}
-      </div>
-      <div className="folder-navigation__workspace-popover-actions">
-        <button type="button" className="folder-navigation__workspace-action">
-          Add workspace
-        </button>
-        <button type="button" className="folder-navigation__workspace-action">
-          Workspace settings
-        </button>
-      </div>
+      <p className="folder-navigation__workspace-popover-title">{activeWorkspaceName}</p>
+
+      {switchBlockedReason !== null ? (
+        <p className="folder-navigation__step-error">{switchBlockedReason}</p>
+      ) : operation.status === "failed" && view === "list" ? (
+        <p className="folder-navigation__step-error">{operation.errorMessage}</p>
+      ) : null}
+
+      {view === "list" ? (
+        <>
+          <div className="folder-navigation__workspace-popover-section">
+            <p className="folder-navigation__group-heading">Recent workspaces</p>
+            {recentWorkspaces.length > 0 ? (
+              <ul className="folder-navigation__workspace-list">
+                {recentWorkspaces.map((workspace) => (
+                  <li key={workspace.id}>
+                    <button
+                      type="button"
+                      className="folder-navigation__workspace-action"
+                      onClick={() => { void handleSwitch(workspace.id); }}
+                      disabled={switchBlockedReason !== null || operation.status === "pending"}
+                    >
+                      {workspace.name}
+                    </button>
+                  </li>
+                ))}
+              </ul>
+            ) : (
+              <p className="folder-navigation__muted">No recent workspaces yet.</p>
+            )}
+          </div>
+          <div className="folder-navigation__workspace-popover-actions">
+            <button
+              type="button"
+              className="folder-navigation__workspace-action"
+              onClick={() => switchView("add")}
+            >
+              Add workspace
+            </button>
+            <button
+              type="button"
+              className="folder-navigation__workspace-action"
+              onClick={() => switchView("settings")}
+            >
+              Workspace settings
+            </button>
+          </div>
+        </>
+      ) : null}
+
+      {view === "add" ? (
+        <div className="folder-navigation__workspace-popover-section">
+          <p className="folder-navigation__group-heading">Add workspace</p>
+          <div className="folder-navigation__operation">
+            <label className="folder-navigation__label" htmlFor="add-workspace-name">
+              Name
+            </label>
+            <input
+              id="add-workspace-name"
+              className="folder-navigation__input"
+              value={addName}
+              onChange={(event) => setAddName(event.target.value)}
+              placeholder="My Notes"
+              disabled={operation.status === "pending"}
+            />
+            <label className="folder-navigation__label" htmlFor="add-workspace-path">
+              Folder path
+            </label>
+            <input
+              id="add-workspace-path"
+              className="folder-navigation__input"
+              value={addPath}
+              onChange={(event) => setAddPath(event.target.value)}
+              placeholder="/Users/you/Notes"
+              disabled={operation.status === "pending"}
+            />
+            {operation.errorMessage !== null ? (
+              <p className="folder-navigation__step-error">{operation.errorMessage}</p>
+            ) : null}
+            <div className="folder-navigation__workspace-popover-actions">
+              <button
+                type="button"
+                className="folder-navigation__action"
+                onClick={() => { void handleAdd(); }}
+                disabled={operation.status === "pending" || addName.trim() === "" || addPath.trim() === ""}
+              >
+                {operation.status === "pending" ? "Adding..." : "Add"}
+              </button>
+              <button
+                type="button"
+                className="folder-navigation__secondary-action"
+                onClick={resetToList}
+                disabled={operation.status === "pending"}
+              >
+                Cancel
+              </button>
+            </div>
+          </div>
+        </div>
+      ) : null}
+
+      {view === "settings" ? (
+        <div className="folder-navigation__workspace-popover-section">
+          <p className="folder-navigation__group-heading">Workspace settings</p>
+          <div className="folder-navigation__operation">
+            <label className="folder-navigation__label" htmlFor="rename-workspace-name">
+              Name
+            </label>
+            <input
+              id="rename-workspace-name"
+              className="folder-navigation__input"
+              value={renameName}
+              onChange={(event) => setRenameName(event.target.value)}
+              disabled={operation.status === "pending"}
+            />
+            {operation.errorMessage !== null ? (
+              <p className="folder-navigation__step-error">{operation.errorMessage}</p>
+            ) : null}
+            <div className="folder-navigation__workspace-popover-actions">
+              <button
+                type="button"
+                className="folder-navigation__action"
+                onClick={() => { void handleRename(); }}
+                disabled={
+                  operation.status === "pending" ||
+                  renameName.trim() === "" ||
+                  renameName.trim() === activeWorkspaceName
+                }
+              >
+                {operation.status === "pending" ? "Renaming..." : "Rename"}
+              </button>
+              <button
+                type="button"
+                className="folder-navigation__secondary-action"
+                onClick={resetToList}
+                disabled={operation.status === "pending"}
+              >
+                Cancel
+              </button>
+            </div>
+            <div className="folder-navigation__operation">
+              <button
+                type="button"
+                className="folder-navigation__secondary-action"
+                onClick={() => { void handleRemove(); }}
+                disabled={operation.status === "pending"}
+              >
+                Remove from Grove
+              </button>
+              <p className="folder-navigation__muted">
+                Removes this workspace from Grove without deleting your Markdown files.
+              </p>
+            </div>
+          </div>
+        </div>
+      ) : null}
     </div>
   );
 }
@@ -595,6 +859,13 @@ export function NavigationPane({
   onCreateTitleChange,
   onCreateNote,
   onSelectNote,
+  activeWorkspaceName,
+  recentWorkspaces,
+  switchBlockedReason,
+  onSwitchWorkspace,
+  onAddWorkspace,
+  onRenameWorkspace,
+  onRemoveWorkspace,
 }: NavigationPaneProps) {
   return (
     <div className="folder-navigation__navigation">
@@ -605,6 +876,13 @@ export function NavigationPane({
         expandedFolderPaths={expandedFolderPaths}
         onSelect={onSelect}
         onToggle={onToggle}
+        activeWorkspaceName={activeWorkspaceName}
+        recentWorkspaces={recentWorkspaces}
+        switchBlockedReason={switchBlockedReason}
+        onSwitchWorkspace={onSwitchWorkspace}
+        onAddWorkspace={onAddWorkspace}
+        onRenameWorkspace={onRenameWorkspace}
+        onRemoveWorkspace={onRemoveWorkspace}
       />
       <NoteList
         selectedFolderPath={selectedFolderPath}
@@ -1233,6 +1511,10 @@ export function FolderNavigationWorkspaceContent({
   isDevelopmentMode,
   initialPathChangeQueueVisibility = false,
 }: FolderNavigationWorkspaceContentProps) {
+  const activeWorkspace = useWorkspaceStore((state) => state.activeWorkspace);
+  const allWorkspaces = useWorkspaceStore((state) => state.allWorkspaces);
+  const workspaceLoadState = useWorkspaceStore((state) => state.loadState);
+
   const [isPathChangeQueueVisible, setIsPathChangeQueueVisible] = useState(
     initialPathChangeQueueVisibility,
   );
@@ -1308,6 +1590,30 @@ export function FolderNavigationWorkspaceContent({
     selectedNote === undefined || !isNoteAffectedByPathChange(pathChangeOperations, selectedNote.id)
       ? null
       : "Delete is unavailable while this note has unfinished path changes.";
+  const switchBlockedReason = isNoteEditBufferBlockingWorkspaceChange(noteEditBuffer)
+    ? "Save or discard the current draft before switching workspaces."
+    : null;
+  const recentWorkspaces = getRecentWorkspaces(allWorkspaces, activeWorkspace?.id);
+
+  async function handleSwitchWorkspace(id: string): Promise<void> {
+    await useWorkspaceStore.getState().switchTo(id);
+  }
+
+  async function handleAddWorkspace(name: string, rootPath: string): Promise<void> {
+    await useWorkspaceStore.getState().addNew(name, rootPath);
+  }
+
+  async function handleRenameWorkspace(name: string): Promise<void> {
+    const id = useWorkspaceStore.getState().activeWorkspace?.id;
+    if (id === undefined) return;
+    await useWorkspaceStore.getState().renameCurrent(id, name);
+  }
+
+  async function handleRemoveWorkspace(): Promise<void> {
+    const id = useWorkspaceStore.getState().activeWorkspace?.id;
+    if (id === undefined) return;
+    await useWorkspaceStore.getState().removeCurrent(id);
+  }
 
   useEffect(() => {
     selectedNoteIdRef.current = selectedNoteId;
@@ -1654,6 +1960,22 @@ export function FolderNavigationWorkspaceContent({
   }
 
   useEffect(() => {
+    void useWorkspaceStore.getState().loadWorkspaces();
+  }, []);
+
+  useEffect(() => {
+    if (activeWorkspace === null) {
+      return;
+    }
+
+    setWorkspaceState(initialWorkspaceState);
+    setSelectedNoteId("");
+    setNoteEditBuffer(null);
+    setEditorNotice(null);
+    setScanState({ status: "loading", errorMessage: null });
+    setCreateState({ status: "idle", errorMessage: null });
+    setDeleteState({ status: "idle", errorMessage: null });
+
     let canceled = false;
 
     async function scanWorkspace(): Promise<void> {
@@ -1701,7 +2023,7 @@ export function FolderNavigationWorkspaceContent({
     return () => {
       canceled = true;
     };
-  }, []);
+  }, [activeWorkspace?.id]);
 
   useEffect(() => {
     if (selectedNote === undefined) {
@@ -1823,6 +2145,13 @@ export function FolderNavigationWorkspaceContent({
           void createNoteInSelectedFolder();
         }}
         onSelectNote={selectNote}
+        activeWorkspaceName={activeWorkspace?.name ?? (workspaceLoadState.status === "loading" ? "Loading..." : "")}
+        recentWorkspaces={recentWorkspaces}
+        switchBlockedReason={switchBlockedReason}
+        onSwitchWorkspace={handleSwitchWorkspace}
+        onAddWorkspace={handleAddWorkspace}
+        onRenameWorkspace={handleRenameWorkspace}
+        onRemoveWorkspace={handleRemoveWorkspace}
       />
       <ActivePane
         notes={notes}

--- a/apps/desktop/src/features/folder-navigation/ui/FolderNavigationWorkspace.tsx
+++ b/apps/desktop/src/features/folder-navigation/ui/FolderNavigationWorkspace.tsx
@@ -200,6 +200,11 @@ type WorkspaceScanState = {
   errorMessage: string | null;
 };
 
+type WorkspaceLoadState = {
+  status: "idle" | "loading" | "ready" | "failed";
+  errorMessage: string | null;
+};
+
 type NoteCreateState = {
   status: "idle" | "creating" | "failed";
   errorMessage: string | null;
@@ -356,6 +361,48 @@ function getExpandedFolderPathsForNotes(notes: readonly NoteListItem[]): string[
 
 function getScanErrorMessage(error: unknown): string {
   return error instanceof Error ? error.message : "The Markdown workspace scan failed.";
+}
+
+export function getScanStateWithoutActiveWorkspace(
+  workspaceLoadState: WorkspaceLoadState,
+): WorkspaceScanState {
+  if (workspaceLoadState.status === "failed") {
+    return {
+      status: "failed",
+      errorMessage: workspaceLoadState.errorMessage ?? "The workspace operation failed.",
+    };
+  }
+
+  if (workspaceLoadState.status === "loading") {
+    return {
+      status: "loading",
+      errorMessage: null,
+    };
+  }
+
+  return {
+    status: "ready",
+    errorMessage: null,
+  };
+}
+
+export function getActiveWorkspaceName(
+  activeWorkspace: DesktopWorkspace | null,
+  workspaceLoadState: WorkspaceLoadState,
+): string {
+  if (activeWorkspace !== null) {
+    return activeWorkspace.name;
+  }
+
+  if (workspaceLoadState.status === "loading") {
+    return "Loading...";
+  }
+
+  if (workspaceLoadState.status === "failed") {
+    return "Workspace unavailable";
+  }
+
+  return "No workspace selected";
 }
 
 function getNoteReadErrorMessage(error: unknown): string {
@@ -2006,6 +2053,14 @@ export function FolderNavigationWorkspaceContent({
 
   useEffect(() => {
     if (activeWorkspace === null) {
+      setWorkspaceState(initialWorkspaceState);
+      setSelectedNoteId("");
+      setNoteEditBuffer(null);
+      setEditorNotice(null);
+      resetPathChangeQueue();
+      setCreateState({ status: "idle", errorMessage: null });
+      setDeleteState({ status: "idle", errorMessage: null });
+      setScanState(getScanStateWithoutActiveWorkspace(workspaceLoadState));
       return;
     }
 
@@ -2065,7 +2120,7 @@ export function FolderNavigationWorkspaceContent({
     return () => {
       canceled = true;
     };
-  }, [activeWorkspace?.id, resetPathChangeQueue]);
+  }, [activeWorkspace, activeWorkspace?.id, resetPathChangeQueue, workspaceLoadState]);
 
   useEffect(() => {
     if (selectedNote === undefined) {
@@ -2187,7 +2242,7 @@ export function FolderNavigationWorkspaceContent({
           void createNoteInSelectedFolder();
         }}
         onSelectNote={selectNote}
-        activeWorkspaceName={activeWorkspace?.name ?? (workspaceLoadState.status === "loading" ? "Loading..." : "")}
+        activeWorkspaceName={getActiveWorkspaceName(activeWorkspace, workspaceLoadState)}
         recentWorkspaces={recentWorkspaces}
         switchBlockedReason={switchBlockedReason}
         onSwitchWorkspace={handleSwitchWorkspace}

--- a/apps/desktop/src/shared/index.ts
+++ b/apps/desktop/src/shared/index.ts
@@ -1,19 +1,30 @@
 export {
+  addWorkspace,
   createMarkdownNote,
   deleteMarkdownNote,
+  getActiveWorkspace,
+  listWorkspaces,
   moveMarkdownFile,
   readMarkdownNote,
   refreshNoteIndexes,
+  removeWorkspace,
+  renameWorkspace,
   scanMarkdownWorkspace,
+  switchWorkspace,
   writeMarkdownNote,
 } from "./api/commands";
 export type {
+  AddWorkspaceCommand,
   CreateMarkdownNoteCommand,
   DeleteMarkdownNoteCommand,
+  DesktopWorkspace,
   MoveMarkdownFileCommand,
   ReadMarkdownNoteCommand,
   RefreshNoteIndexesCommand,
+  RemoveWorkspaceCommand,
+  RenameWorkspaceCommand,
+  ScannedMarkdownNote,
+  SwitchWorkspaceCommand,
   WriteMarkdownNoteCommand,
 } from "./api/commands";
-export type { ScannedMarkdownNote } from "./api/commands";
 export { ShellCard } from "./ui/ShellCard";

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -50,6 +50,9 @@ importers:
       react-dom:
         specifier: ^19.0.0
         version: 19.2.5(react@19.2.5)
+      zustand:
+        specifier: ^5.0.12
+        version: 5.0.12(@types/react@19.2.14)(react@19.2.5)(use-sync-external-store@1.6.0(react@19.2.5))
     devDependencies:
       '@tauri-apps/cli':
         specifier: ^2.0.0
@@ -4087,6 +4090,24 @@ packages:
   yocto-queue@0.1.0:
     resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
     engines: {node: '>=10'}
+
+  zustand@5.0.12:
+    resolution: {integrity: sha512-i77ae3aZq4dhMlRhJVCYgMLKuSiZAaUPAct2AksxQ+gOtimhGMdXljRT21P5BNpeT4kXlLIckvkPM029OljD7g==}
+    engines: {node: '>=12.20.0'}
+    peerDependencies:
+      '@types/react': '>=18.0.0'
+      immer: '>=9.0.6'
+      react: '>=18.0.0'
+      use-sync-external-store: '>=1.2.0'
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      immer:
+        optional: true
+      react:
+        optional: true
+      use-sync-external-store:
+        optional: true
 
 snapshots:
 
@@ -8502,3 +8523,9 @@ snapshots:
       yargs-parser: 21.1.1
 
   yocto-queue@0.1.0: {}
+
+  zustand@5.0.12(@types/react@19.2.14)(react@19.2.5)(use-sync-external-store@1.6.0(react@19.2.5)):
+    optionalDependencies:
+      '@types/react': 19.2.14
+      react: 19.2.5
+      use-sync-external-store: 1.6.0(react@19.2.5)


### PR DESCRIPTION
Closes #83

## Summary

- Add **zustand** to the desktop app and create `useWorkspaceStore` — a Zustand store managing `activeWorkspace`, `allWorkspaces`, and `loadState`, with actions: `loadWorkspaces`, `switchTo`, `addNew`, `renameCurrent`, `removeCurrent`. Exports a pure `getRecentWorkspaces` helper for deriving sorted recent workspaces excluding the active one.
- Export all workspace commands and `DesktopWorkspace` type from `shared/index.ts` so features can import without reaching into `api/commands` directly.
- Refactor `WorkspaceSwitcher` to accept real workspace data (`activeWorkspaceName`, `recentWorkspaces`) and async action callbacks instead of static strings.
- Replace the inert `WorkspaceSwitcherPopover` with an interactive three-view popover (`list` / `add` / `settings`), each with inline forms and per-view error feedback. Switching views resets the shared operation state to prevent error bleed-through between views.
- `FolderNavigationWorkspaceContent` loads workspaces on mount and re-scans Markdown notes whenever `activeWorkspace.id` changes — resetting all note/editor state before each scan.
- `switchBlockedReason` is computed from the note edit buffer: dirty or saving buffers block workspace switching with clear copy.
- Switch errors surface in the list view rather than being swallowed silently; workspace action handlers read `activeWorkspace.id` from `getState()` at call time to avoid stale closure issues.

## Test plan

- [ ] `pnpm --filter @grove/desktop test` — 120 tests passing
- [ ] `pnpm --filter @grove/desktop typecheck` — no errors
- [ ] `pnpm --filter @grove/desktop build` — builds cleanly
- [ ] Manual: workspace switcher shows active workspace name from Tauri registry
- [ ] Manual: recent workspaces appear and clicking one switches and rescans
- [ ] Manual: Add workspace form accepts name + path and makes new workspace active
- [ ] Manual: Workspace settings allows rename and remove (with confirm dialog)
- [ ] Manual: dirty note edit buffer shows blocked reason and prevents switch

🤖 Generated with [Claude Code](https://claude.com/claude-code)