### PR TITLE
Require workspace setup before notes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ dist
 coverage
 .turbo
 .superpowers/
+.worktrees/
 apps/mobile/.expo
 apps/mobile/.expo-shared
 apps/mobile/android/.gradle

--- a/apps/desktop/src-tauri/src/main.rs
+++ b/apps/desktop/src-tauri/src/main.rs
@@ -111,7 +111,8 @@ struct DesktopWorkspace {
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
 struct WorkspaceRegistry {
-    active_workspace_id: String,
+    #[serde(default)]
+    active_workspace_id: Option<String>,
     workspaces: Vec<DesktopWorkspace>,
 }
 
@@ -450,21 +451,8 @@ async fn load_or_create_app_workspace_registry(
     load_or_create_workspace_registry(&app_data_dir(app_handle)?).await
 }
 
-fn default_workspace_root_from_app_data_dir(app_data_dir: &Path) -> PathBuf {
-    app_data_dir.join("workspaces").join("default")
-}
-
 fn workspace_registry_path(app_data_dir: &Path) -> PathBuf {
     app_data_dir.join("workspace-registry.json")
-}
-
-fn default_workspace(app_data_dir: &Path, last_opened_at_unix_ms: u128) -> DesktopWorkspace {
-    DesktopWorkspace {
-        id: "default".to_string(),
-        name: "Personal Notes".to_string(),
-        root_path: default_workspace_root_from_app_data_dir(app_data_dir),
-        last_opened_at_unix_ms,
-    }
 }
 
 async fn load_or_create_workspace_registry(
@@ -482,12 +470,9 @@ async fn load_or_create_workspace_registry(
         })?
     {
         let registry = WorkspaceRegistry {
-            active_workspace_id: "default".to_string(),
-            workspaces: vec![default_workspace(app_data_dir, current_unix_ms()?)],
+            active_workspace_id: None,
+            workspaces: Vec::new(),
         };
-        tokio::fs::create_dir_all(default_workspace_root_from_app_data_dir(app_data_dir))
-            .await
-            .context("Default workspace root is unavailable.")?;
         save_workspace_registry(app_data_dir, &registry).await?;
         return Ok(registry);
     }
@@ -504,15 +489,12 @@ async fn load_or_create_workspace_registry(
         serde_json::from_str(&registry_content).context("Workspace registry is invalid.")?;
 
     if registry.workspaces.is_empty() {
-        registry.active_workspace_id = "default".to_string();
-        registry
-            .workspaces
-            .push(default_workspace(app_data_dir, current_unix_ms()?));
+        registry.active_workspace_id = None;
         save_workspace_registry(app_data_dir, &registry).await?;
     }
 
-    if find_active_workspace(&registry).is_none() {
-        registry.active_workspace_id = registry.workspaces[0].id.clone();
+    if !registry.workspaces.is_empty() && find_active_workspace(&registry).is_none() {
+        registry.active_workspace_id = Some(registry.workspaces[0].id.clone());
         save_workspace_registry(app_data_dir, &registry).await?;
     }
 
@@ -540,7 +522,7 @@ async fn add_and_activate_workspace_in_registry(
         root_path,
         last_opened_at_unix_ms: current_unix_ms()?,
     };
-    registry.active_workspace_id = workspace.id.clone();
+    registry.active_workspace_id = Some(workspace.id.clone());
     registry.workspaces.push(workspace.clone());
     save_workspace_registry(app_data_dir, &registry).await?;
 
@@ -553,7 +535,7 @@ async fn switch_active_workspace_in_registry(
 ) -> anyhow::Result<DesktopWorkspace> {
     let mut registry = load_or_create_workspace_registry(app_data_dir).await?;
     let workspace_index = find_workspace_index(&registry, workspace_id)?;
-    registry.active_workspace_id = workspace_id.to_string();
+    registry.active_workspace_id = Some(workspace_id.to_string());
     registry.workspaces[workspace_index].last_opened_at_unix_ms = current_unix_ms()?;
     let workspace = registry.workspaces[workspace_index].clone();
     tokio::fs::create_dir_all(&workspace.root_path)
@@ -594,18 +576,15 @@ async fn remove_workspace_from_registry(
         .retain(|workspace| workspace.id != workspace_id);
 
     if registry.workspaces.is_empty() {
-        registry.active_workspace_id = "default".to_string();
-        registry
-            .workspaces
-            .push(default_workspace(app_data_dir, current_unix_ms()?));
-    } else if registry.active_workspace_id == workspace_id {
+        registry.active_workspace_id = None;
+    } else if registry.active_workspace_id.as_deref() == Some(workspace_id) {
         let active_workspace_id = registry
             .workspaces
             .iter()
             .max_by_key(|workspace| workspace.last_opened_at_unix_ms)
             .map(|workspace| workspace.id.clone())
             .context("The active workspace is unavailable.")?;
-        registry.active_workspace_id = active_workspace_id;
+        registry.active_workspace_id = Some(active_workspace_id);
     }
 
     save_workspace_registry(app_data_dir, &registry).await
@@ -770,10 +749,12 @@ fn find_workspace_index(registry: &WorkspaceRegistry, workspace_id: &str) -> any
 }
 
 fn find_active_workspace(registry: &WorkspaceRegistry) -> Option<&DesktopWorkspace> {
+    let active_workspace_id = registry.active_workspace_id.as_deref()?;
+
     registry
         .workspaces
         .iter()
-        .find(|workspace| workspace.id == registry.active_workspace_id)
+        .find(|workspace| workspace.id == active_workspace_id)
 }
 
 fn active_workspace_from_registry(
@@ -1338,26 +1319,25 @@ mod tests {
     }
 
     #[test]
-    fn creates_a_default_workspace_registry_on_first_run() {
+    fn creates_an_empty_workspace_registry_on_first_run() {
         run_async(async {
-            let app_data_dir = unique_test_dir("creates-default-workspace-registry");
+            let app_data_dir = unique_test_dir("creates-empty-workspace-registry");
 
             let registry = load_or_create_workspace_registry(&app_data_dir).await?;
+            let registry_content =
+                tokio::fs::read_to_string(app_data_dir.join("workspace-registry.json")).await?;
+            let registry_json: serde_json::Value = serde_json::from_str(&registry_content)?;
 
-            assert_eq!(registry.active_workspace_id, "default");
-            assert_eq!(registry.workspaces.len(), 1);
-            assert_eq!(registry.workspaces[0].id, "default");
-            assert_eq!(registry.workspaces[0].name, "Personal Notes");
-            assert_eq!(
-                registry.workspaces[0].root_path,
-                app_data_dir.join("workspaces").join("default")
-            );
+            assert!(registry.workspaces.is_empty());
+            assert!(registry_json["activeWorkspaceId"].is_null());
             assert!(tokio::fs::try_exists(app_data_dir.join("workspace-registry.json")).await?);
-            assert!(tokio::fs::try_exists(&registry.workspaces[0].root_path).await?);
+            assert!(
+                !tokio::fs::try_exists(app_data_dir.join("workspaces").join("default")).await?
+            );
             tokio::fs::remove_dir_all(&app_data_dir).await?;
             anyhow::Ok(())
         })
-        .expect("default workspace registry should be created");
+        .expect("empty workspace registry should be created");
     }
 
     #[test]
@@ -1377,7 +1357,7 @@ mod tests {
             .await?;
             let registry = load_or_create_workspace_registry(&app_data_dir).await?;
 
-            assert_eq!(registry.active_workspace_id, added_workspace.id);
+            assert_eq!(registry.active_workspace_id, Some(added_workspace.id));
             assert!(registry
                 .workspaces
                 .iter()
@@ -1420,6 +1400,35 @@ mod tests {
             anyhow::Ok(())
         })
         .expect("workspace metadata removal should preserve files");
+    }
+
+    #[test]
+    fn leaves_no_active_workspace_after_removing_the_last_workspace() {
+        run_async(async {
+            let app_data_dir = unique_test_dir("removes-last-workspace");
+            let workspace_root = unique_test_dir("last-workspace-root");
+            tokio::fs::create_dir_all(&workspace_root).await?;
+            load_or_create_workspace_registry(&app_data_dir).await?;
+            let added_workspace = add_and_activate_workspace_in_registry(
+                &app_data_dir,
+                "Research",
+                workspace_root.clone(),
+            )
+            .await?;
+
+            remove_workspace_from_registry(&app_data_dir, &added_workspace.id).await?;
+            let registry = load_or_create_workspace_registry(&app_data_dir).await?;
+            let registry_content =
+                tokio::fs::read_to_string(app_data_dir.join("workspace-registry.json")).await?;
+            let registry_json: serde_json::Value = serde_json::from_str(&registry_content)?;
+
+            assert!(registry.workspaces.is_empty());
+            assert!(registry_json["activeWorkspaceId"].is_null());
+            tokio::fs::remove_dir_all(&app_data_dir).await?;
+            tokio::fs::remove_dir_all(&workspace_root).await?;
+            anyhow::Ok(())
+        })
+        .expect("last workspace removal should leave no active workspace");
     }
 
     #[test]

--- a/apps/desktop/src/features/folder-navigation/model/useWorkspaceStore.test.ts
+++ b/apps/desktop/src/features/folder-navigation/model/useWorkspaceStore.test.ts
@@ -214,6 +214,28 @@ describe("removeCurrent", () => {
     expect(state.allWorkspaces).toEqual([]);
     expect(state.loadState).toEqual({ status: "ready", errorMessage: null });
   });
+
+  it("sets failed state when active lookup fails after removing one of several workspaces", async () => {
+    removeWorkspaceMock.mockResolvedValue(undefined);
+    listWorkspacesMock.mockResolvedValue([workspaceB]);
+    getActiveWorkspaceMock.mockRejectedValue(new Error("Active workspace is unavailable"));
+
+    useWorkspaceStore.setState({
+      activeWorkspace: workspaceA,
+      allWorkspaces: [workspaceA, workspaceB],
+      loadState: { status: "ready", errorMessage: null },
+    });
+
+    await useWorkspaceStore.getState().removeCurrent("ws-a");
+
+    const state = useWorkspaceStore.getState();
+    expect(state.activeWorkspace).toBeNull();
+    expect(state.allWorkspaces).toEqual([workspaceB]);
+    expect(state.loadState).toEqual({
+      status: "failed",
+      errorMessage: "Active workspace is unavailable",
+    });
+  });
 });
 
 describe("getRecentWorkspaces", () => {

--- a/apps/desktop/src/features/folder-navigation/model/useWorkspaceStore.test.ts
+++ b/apps/desktop/src/features/folder-navigation/model/useWorkspaceStore.test.ts
@@ -68,7 +68,7 @@ describe("loadWorkspaces", () => {
 
   it("sets failed state when the command throws", async () => {
     getActiveWorkspaceMock.mockRejectedValue(new Error("No workspace found"));
-    listWorkspacesMock.mockResolvedValue([]);
+    listWorkspacesMock.mockResolvedValue([workspaceA]);
 
     await useWorkspaceStore.getState().loadWorkspaces();
 
@@ -78,6 +78,18 @@ describe("loadWorkspaces", () => {
     expect(state.activeWorkspace).toBeNull();
   });
 
+  it("treats an empty workspace list as a ready setup-required state", async () => {
+    listWorkspacesMock.mockResolvedValue([]);
+
+    await useWorkspaceStore.getState().loadWorkspaces();
+
+    const state = useWorkspaceStore.getState();
+    expect(state.activeWorkspace).toBeNull();
+    expect(state.allWorkspaces).toEqual([]);
+    expect(state.loadState).toEqual({ status: "ready", errorMessage: null });
+    expect(getActiveWorkspaceMock).not.toHaveBeenCalled();
+  });
+
   it("clears stale workspace data when reloading fails after a previous success", async () => {
     useWorkspaceStore.setState({
       activeWorkspace: workspaceA,
@@ -85,7 +97,7 @@ describe("loadWorkspaces", () => {
       loadState: { status: "ready", errorMessage: null },
     });
     getActiveWorkspaceMock.mockRejectedValue(new Error("No workspace found"));
-    listWorkspacesMock.mockResolvedValue([]);
+    listWorkspacesMock.mockResolvedValue([workspaceA]);
 
     await useWorkspaceStore.getState().loadWorkspaces();
 
@@ -136,7 +148,10 @@ describe("addNew", () => {
     const state = useWorkspaceStore.getState();
     expect(state.activeWorkspace).toEqual(newWorkspace);
     expect(state.loadState).toEqual({ status: "ready", errorMessage: null });
-    expect(addWorkspaceMock).toHaveBeenCalledWith({ name: "Research", rootPath: "/Users/me/research" });
+    expect(addWorkspaceMock).toHaveBeenCalledWith({
+      name: "Research",
+      rootPath: "/Users/me/research",
+    });
   });
 });
 

--- a/apps/desktop/src/features/folder-navigation/model/useWorkspaceStore.ts
+++ b/apps/desktop/src/features/folder-navigation/model/useWorkspaceStore.ts
@@ -38,8 +38,23 @@ export const useWorkspaceStore = create<WorkspaceStore>((set) => ({
   loadWorkspaces: async () => {
     set({ loadState: { status: "loading", errorMessage: null } });
     try {
-      const [active, all] = await Promise.all([getActiveWorkspace(), listWorkspaces()]);
-      set({ activeWorkspace: active, allWorkspaces: all, loadState: { status: "ready", errorMessage: null } });
+      const all = await listWorkspaces();
+
+      if (all.length === 0) {
+        set({
+          activeWorkspace: null,
+          allWorkspaces: [],
+          loadState: { status: "ready", errorMessage: null },
+        });
+        return;
+      }
+
+      const active = await getActiveWorkspace();
+      set({
+        activeWorkspace: active,
+        allWorkspaces: all,
+        loadState: { status: "ready", errorMessage: null },
+      });
     } catch (error) {
       set({
         activeWorkspace: null,

--- a/apps/desktop/src/features/folder-navigation/model/useWorkspaceStore.ts
+++ b/apps/desktop/src/features/folder-navigation/model/useWorkspaceStore.ts
@@ -99,6 +99,16 @@ export const useWorkspaceStore = create<WorkspaceStore>((set) => ({
   removeCurrent: async (id: string) => {
     await removeWorkspace({ id });
     const all = await listWorkspaces();
+
+    if (all.length === 0) {
+      set({
+        activeWorkspace: null,
+        allWorkspaces: all,
+        loadState: { status: "ready", errorMessage: null },
+      });
+      return;
+    }
+
     try {
       const newActive = await getActiveWorkspace();
       set({
@@ -106,11 +116,11 @@ export const useWorkspaceStore = create<WorkspaceStore>((set) => ({
         allWorkspaces: all,
         loadState: { status: "ready", errorMessage: null },
       });
-    } catch {
+    } catch (error) {
       set({
         activeWorkspace: null,
         allWorkspaces: all,
-        loadState: { status: "ready", errorMessage: null },
+        loadState: { status: "failed", errorMessage: getWorkspaceErrorMessage(error) },
       });
     }
   },

--- a/apps/desktop/src/features/folder-navigation/model/useWorkspaceStore.ts
+++ b/apps/desktop/src/features/folder-navigation/model/useWorkspaceStore.ts
@@ -10,7 +10,7 @@ import {
 } from "../../../shared";
 import type { DesktopWorkspace } from "../../../shared";
 
-type WorkspaceLoadState = {
+export type WorkspaceLoadState = {
   status: "idle" | "loading" | "ready" | "failed";
   errorMessage: string | null;
 };

--- a/apps/desktop/src/features/folder-navigation/model/useWorkspaceStore.ts
+++ b/apps/desktop/src/features/folder-navigation/model/useWorkspaceStore.ts
@@ -30,6 +30,14 @@ function getWorkspaceErrorMessage(error: unknown): string {
   return error instanceof Error ? error.message : "The workspace operation failed.";
 }
 
+function makeEmptyReadyState(all: readonly DesktopWorkspace[]) {
+  return {
+    activeWorkspace: null,
+    allWorkspaces: all,
+    loadState: { status: "ready" as const, errorMessage: null },
+  };
+}
+
 export const useWorkspaceStore = create<WorkspaceStore>((set) => ({
   activeWorkspace: null,
   allWorkspaces: [],
@@ -41,11 +49,7 @@ export const useWorkspaceStore = create<WorkspaceStore>((set) => ({
       const all = await listWorkspaces();
 
       if (all.length === 0) {
-        set({
-          activeWorkspace: null,
-          allWorkspaces: [],
-          loadState: { status: "ready", errorMessage: null },
-        });
+        set(makeEmptyReadyState(all));
         return;
       }
 
@@ -101,11 +105,7 @@ export const useWorkspaceStore = create<WorkspaceStore>((set) => ({
     const all = await listWorkspaces();
 
     if (all.length === 0) {
-      set({
-        activeWorkspace: null,
-        allWorkspaces: all,
-        loadState: { status: "ready", errorMessage: null },
-      });
+      set(makeEmptyReadyState(all));
       return;
     }
 

--- a/apps/desktop/src/features/folder-navigation/ui/FolderNavigationWorkspace.css
+++ b/apps/desktop/src/features/folder-navigation/ui/FolderNavigationWorkspace.css
@@ -1,4 +1,7 @@
 .folder-navigation {
+  --color-action-text: #ffffff;
+  --color-surface: #ffffff;
+
   background: #f7f8f5;
   color: #17211b;
   display: grid;
@@ -16,7 +19,7 @@
 }
 
 .folder-navigation__setup {
-  background: #ffffff;
+  background: var(--color-surface);
   border: 1px solid #dce4dd;
   border-radius: 8px;
   display: grid;
@@ -41,7 +44,7 @@
 
 .folder-navigation__library-column,
 .folder-navigation__notes-column {
-  background: #ffffff;
+  background: var(--color-surface);
   border-right: 1px solid #dce4dd;
   box-sizing: border-box;
 }
@@ -138,7 +141,7 @@
 }
 
 .folder-navigation__root-button {
-  background: #ffffff;
+  background: var(--color-surface);
   border-color: #dce4dd;
   min-height: 2.5rem;
   padding: 0 0.75rem;
@@ -217,7 +220,7 @@
 .folder-navigation__empty,
 .folder-navigation__editor,
 .folder-navigation__operation-item {
-  background: #ffffff;
+  background: var(--color-surface);
   border: 1px solid #dce4dd;
   border-radius: 8px;
 }
@@ -504,7 +507,7 @@
   background: #1f7a5c;
   border: 0;
   border-radius: 8px;
-  color: #ffffff;
+  color: var(--color-action-text);
   cursor: pointer;
   min-height: 2.25rem;
   padding: 0 0.875rem;
@@ -519,7 +522,7 @@
 }
 
 .folder-navigation__secondary-action {
-  background: #ffffff;
+  background: var(--color-surface);
   border: 1px solid #c8d3ca;
   border-radius: 8px;
   color: #17211b;
@@ -567,7 +570,7 @@
 }
 
 .folder-navigation__workspace-popover {
-  background: #ffffff;
+  background: var(--color-surface);
   border: 1px solid #c8d3ca;
   border-radius: 8px;
   bottom: calc(100% + 0.5rem);
@@ -601,7 +604,7 @@
 }
 
 .folder-navigation__workspace-action {
-  background: #ffffff;
+  background: var(--color-surface);
   border: 1px solid transparent;
   border-radius: 8px;
   color: #17211b;

--- a/apps/desktop/src/features/folder-navigation/ui/FolderNavigationWorkspace.css
+++ b/apps/desktop/src/features/folder-navigation/ui/FolderNavigationWorkspace.css
@@ -7,6 +7,23 @@
   overflow-x: auto;
 }
 
+.folder-navigation--setup {
+  align-items: center;
+  display: grid;
+  grid-template-columns: minmax(18rem, 32rem);
+  justify-content: center;
+  padding: 1.25rem;
+}
+
+.folder-navigation__setup {
+  background: #ffffff;
+  border: 1px solid #dce4dd;
+  border-radius: 8px;
+  display: grid;
+  gap: 1rem;
+  padding: 1.25rem;
+}
+
 .folder-navigation__navigation {
   display: contents;
 }

--- a/apps/desktop/src/features/folder-navigation/ui/FolderNavigationWorkspace.test.tsx
+++ b/apps/desktop/src/features/folder-navigation/ui/FolderNavigationWorkspace.test.tsx
@@ -224,6 +224,31 @@ describe("WorkspaceSwitcher", () => {
     expect(new Set(inputIds).size).toBe(4);
   });
 
+  it("uses unique rename workspace input ids when more than one settings form is rendered", () => {
+    const markup = renderToStaticMarkup(
+      <>
+        <WorkspaceSwitcher
+          {...baseWorkspaceSwitcherProps}
+          initiallyOpen={true}
+          initialView="settings"
+        />
+        <WorkspaceSwitcher
+          {...baseWorkspaceSwitcherProps}
+          initiallyOpen={true}
+          initialView="settings"
+        />
+      </>,
+    );
+
+    const inputIds = Array.from(
+      markup.matchAll(/<(?:input)[^>]+id="([^"]+)"/g),
+      (match) => match[1],
+    );
+
+    expect(inputIds).toHaveLength(2);
+    expect(new Set(inputIds).size).toBe(2);
+  });
+
   it("opens a lightweight popover with workspace actions and no sync copy", () => {
     const markup = renderToStaticMarkup(
       <WorkspaceSwitcher

--- a/apps/desktop/src/features/folder-navigation/ui/FolderNavigationWorkspace.test.tsx
+++ b/apps/desktop/src/features/folder-navigation/ui/FolderNavigationWorkspace.test.tsx
@@ -6,6 +6,7 @@ import {
   ActivePane,
   FolderNavigationWorkspaceContent,
   NavigationPane,
+  WorkspaceSetupLoading,
   WorkspaceSetupRequired,
   WorkspaceSwitcher,
   getActiveWorkspaceName,
@@ -25,41 +26,14 @@ describe("getFolderNavigationWorkspaceClassName", () => {
 });
 
 describe("FolderNavigationWorkspaceContent", () => {
-  it("hides the path change queue by default in development mode and shows the toggle", () => {
-    const markup = renderToStaticMarkup(
-      <FolderNavigationWorkspaceContent isDevelopmentMode={true} />,
-    );
-
-    expect(markup).toContain("Show path change diagnostics");
-    expect(markup).not.toContain("Pending path changes");
-    expect(markup).not.toContain("Path change queue");
-    expect(markup).toContain("folder-navigation__navigation");
-  });
-
-  it("renders the path change queue when development diagnostics are expanded", () => {
-    const markup = renderToStaticMarkup(
-      <FolderNavigationWorkspaceContent
-        isDevelopmentMode={true}
-        initialPathChangeQueueVisibility={true}
-      />,
-    );
-
-    expect(markup).toContain("Hide path change diagnostics");
-    expect(markup).toContain("Pending path changes");
-    expect(markup).toContain("Path change queue");
-    expect(markup).toContain("folder-navigation__navigation");
-  });
-
-  it("hides both the queue and the diagnostics toggle in production mode", () => {
+  it("hides note controls while workspace loading is unresolved", () => {
     const markup = renderToStaticMarkup(
       <FolderNavigationWorkspaceContent isDevelopmentMode={false} />,
     );
 
-    expect(markup).not.toContain("Show path change diagnostics");
-    expect(markup).not.toContain("Hide path change diagnostics");
-    expect(markup).not.toContain("Pending path changes");
-    expect(markup).not.toContain("Path change queue");
-    expect(markup).toContain("folder-navigation__navigation");
+    expect(markup).toContain("Loading workspace");
+    expect(markup).not.toContain("Create note");
+    expect(markup).not.toContain("folder-navigation__navigation");
   });
 });
 
@@ -365,6 +339,15 @@ describe("WorkspaceSetupRequired", () => {
   });
 });
 
+describe("WorkspaceSetupLoading", () => {
+  it("shows a loading surface without note creation controls", () => {
+    const markup = renderToStaticMarkup(<WorkspaceSetupLoading />);
+
+    expect(markup).toContain("Loading workspace");
+    expect(markup).not.toContain("Create note");
+  });
+});
+
 describe("getWorkspaceSwitchBlockedReason", () => {
   it("blocks switching when the current note has unsaved edits", () => {
     const reason = getWorkspaceSwitchBlockedReason(
@@ -625,6 +608,37 @@ describe("ActivePane", () => {
     expect(markup).not.toContain("Move selected note");
     expect(markup).not.toContain("Rename selected folder");
     expect(markup).not.toContain("Delete note");
+  });
+
+  it("hides the path change queue by default in development mode and shows the toggle", () => {
+    const markup = renderActivePaneMarkup({ isDevelopmentMode: true });
+
+    expect(markup).toContain("Show path change diagnostics");
+    expect(markup).not.toContain("Pending path changes");
+    expect(markup).not.toContain("Path change queue");
+  });
+
+  it("renders the path change queue when development diagnostics are expanded", () => {
+    const markup = renderActivePaneMarkup({
+      isDevelopmentMode: true,
+      isPathChangeQueueVisible: true,
+    });
+
+    expect(markup).toContain("Hide path change diagnostics");
+    expect(markup).toContain("Pending path changes");
+    expect(markup).toContain("Path change queue");
+  });
+
+  it("hides both the queue and the diagnostics toggle in production mode", () => {
+    const markup = renderActivePaneMarkup({
+      isDevelopmentMode: false,
+      isPathChangeQueueVisible: true,
+    });
+
+    expect(markup).not.toContain("Show path change diagnostics");
+    expect(markup).not.toContain("Hide path change diagnostics");
+    expect(markup).not.toContain("Pending path changes");
+    expect(markup).not.toContain("Path change queue");
   });
 
   it("shows note actions when the note disclosure starts open", () => {

--- a/apps/desktop/src/features/folder-navigation/ui/FolderNavigationWorkspace.test.tsx
+++ b/apps/desktop/src/features/folder-navigation/ui/FolderNavigationWorkspace.test.tsx
@@ -3,13 +3,16 @@ import { renderToStaticMarkup } from "react-dom/server";
 import { describe, expect, it } from "vitest";
 
 import {
-  ActivePane,
-  FolderNavigationWorkspaceContent,
-  NavigationPane,
   WorkspaceSetupLoading,
   WorkspaceSetupRequired,
   WorkspaceSwitcher,
   getActiveWorkspaceName,
+} from "./WorkspaceControls";
+
+import {
+  ActivePane,
+  FolderNavigationWorkspaceContent,
+  NavigationPane,
   getFolderNavigationWorkspaceClassName,
   getScanStateWithoutActiveWorkspace,
   getWorkspaceSwitchBlockedReason,

--- a/apps/desktop/src/features/folder-navigation/ui/FolderNavigationWorkspace.test.tsx
+++ b/apps/desktop/src/features/folder-navigation/ui/FolderNavigationWorkspace.test.tsx
@@ -204,6 +204,26 @@ describe("WorkspaceSwitcher", () => {
     expect(new Set(popoverIds).size).toBe(2);
   });
 
+  it("uses unique add workspace input ids when more than one add form is rendered", () => {
+    const markup = renderToStaticMarkup(
+      <>
+        <WorkspaceSwitcher {...baseWorkspaceSwitcherProps} initiallyOpen={true} initialView="add" />
+        <WorkspaceSetupRequired
+          loadState={{ status: "ready", errorMessage: null }}
+          onAddWorkspace={() => Promise.resolve()}
+        />
+      </>,
+    );
+
+    const inputIds = Array.from(
+      markup.matchAll(/<(?:input)[^>]+id="([^"]+)"/g),
+      (match) => match[1],
+    );
+
+    expect(inputIds).toHaveLength(4);
+    expect(new Set(inputIds).size).toBe(4);
+  });
+
   it("opens a lightweight popover with workspace actions and no sync copy", () => {
     const markup = renderToStaticMarkup(
       <WorkspaceSwitcher

--- a/apps/desktop/src/features/folder-navigation/ui/FolderNavigationWorkspace.test.tsx
+++ b/apps/desktop/src/features/folder-navigation/ui/FolderNavigationWorkspace.test.tsx
@@ -358,8 +358,9 @@ describe("WorkspaceSetupLoading", () => {
       />,
     );
 
-    expect(markup).toContain("Loading workspace");
+    expect(markup).toContain("Workspace unavailable");
     expect(markup).toContain("Registry corrupted");
+    expect(markup).not.toContain("Create workspace");
     expect(markup).not.toContain("Create note");
   });
 });
@@ -379,8 +380,8 @@ describe("getWorkspaceViewPhase", () => {
     expect(getWorkspaceViewPhase(null, { status: "ready", errorMessage: null })).toBe("setup");
   });
 
-  it("returns setup when failed with no active workspace", () => {
-    expect(getWorkspaceViewPhase(null, { status: "failed", errorMessage: "err" })).toBe("setup");
+  it("returns loading when failed with no active workspace", () => {
+    expect(getWorkspaceViewPhase(null, { status: "failed", errorMessage: "err" })).toBe("loading");
   });
 
   it("returns ready when workspace is active", () => {

--- a/apps/desktop/src/features/folder-navigation/ui/FolderNavigationWorkspace.test.tsx
+++ b/apps/desktop/src/features/folder-navigation/ui/FolderNavigationWorkspace.test.tsx
@@ -13,6 +13,7 @@ import {
   getFolderNavigationWorkspaceClassName,
   getScanStateWithoutActiveWorkspace,
   getWorkspaceSwitchBlockedReason,
+  getWorkspaceViewPhase,
 } from "./FolderNavigationWorkspace";
 
 describe("getFolderNavigationWorkspaceClassName", () => {
@@ -345,6 +346,30 @@ describe("WorkspaceSetupLoading", () => {
 
     expect(markup).toContain("Loading workspace");
     expect(markup).not.toContain("Create note");
+  });
+});
+
+describe("getWorkspaceViewPhase", () => {
+  const workspace = { id: "ws-a", name: "Notes", rootPath: "/notes", lastOpenedAtUnixMs: 1000 };
+
+  it("returns loading when idle with no active workspace", () => {
+    expect(getWorkspaceViewPhase(null, { status: "idle", errorMessage: null })).toBe("loading");
+  });
+
+  it("returns loading when loading with no active workspace", () => {
+    expect(getWorkspaceViewPhase(null, { status: "loading", errorMessage: null })).toBe("loading");
+  });
+
+  it("returns setup when ready with no active workspace", () => {
+    expect(getWorkspaceViewPhase(null, { status: "ready", errorMessage: null })).toBe("setup");
+  });
+
+  it("returns setup when failed with no active workspace", () => {
+    expect(getWorkspaceViewPhase(null, { status: "failed", errorMessage: "err" })).toBe("setup");
+  });
+
+  it("returns ready when workspace is active", () => {
+    expect(getWorkspaceViewPhase(workspace, { status: "ready", errorMessage: null })).toBe("ready");
   });
 });
 

--- a/apps/desktop/src/features/folder-navigation/ui/FolderNavigationWorkspace.test.tsx
+++ b/apps/desktop/src/features/folder-navigation/ui/FolderNavigationWorkspace.test.tsx
@@ -350,6 +350,16 @@ describe("WorkspaceSetupLoading", () => {
     expect(markup).toContain("Loading workspace");
     expect(markup).not.toContain("Create note");
   });
+
+  it("shows the error message when the workspace load failed", () => {
+    const markup = renderToStaticMarkup(
+      <WorkspaceSetupLoading loadState={{ status: "failed", errorMessage: "Registry corrupted" }} />,
+    );
+
+    expect(markup).toContain("Loading workspace");
+    expect(markup).toContain("Registry corrupted");
+    expect(markup).not.toContain("Create note");
+  });
 });
 
 describe("getWorkspaceViewPhase", () => {
@@ -367,8 +377,8 @@ describe("getWorkspaceViewPhase", () => {
     expect(getWorkspaceViewPhase(null, { status: "ready", errorMessage: null })).toBe("setup");
   });
 
-  it("returns setup when failed with no active workspace", () => {
-    expect(getWorkspaceViewPhase(null, { status: "failed", errorMessage: "err" })).toBe("setup");
+  it("returns loading when failed with no active workspace", () => {
+    expect(getWorkspaceViewPhase(null, { status: "failed", errorMessage: "err" })).toBe("loading");
   });
 
   it("returns ready when workspace is active", () => {

--- a/apps/desktop/src/features/folder-navigation/ui/FolderNavigationWorkspace.test.tsx
+++ b/apps/desktop/src/features/folder-navigation/ui/FolderNavigationWorkspace.test.tsx
@@ -6,6 +6,7 @@ import {
   ActivePane,
   FolderNavigationWorkspaceContent,
   NavigationPane,
+  WorkspaceSetupRequired,
   WorkspaceSwitcher,
   getActiveWorkspaceName,
   getFolderNavigationWorkspaceClassName,
@@ -160,7 +161,12 @@ describe("NavigationPane", () => {
 describe("WorkspaceSwitcher", () => {
   const baseWorkspaceSwitcherProps = {
     activeWorkspaceName: "Personal Notes",
-    recentWorkspaces: [] as { id: string; name: string; rootPath: string; lastOpenedAtUnixMs: number }[],
+    recentWorkspaces: [] as {
+      id: string;
+      name: string;
+      rootPath: string;
+      lastOpenedAtUnixMs: number;
+    }[],
     switchBlockedReason: null as string | null,
     onSwitchWorkspace: () => Promise.resolve(),
     onAddWorkspace: () => Promise.resolve(),
@@ -203,8 +209,18 @@ describe("WorkspaceSwitcher", () => {
       <WorkspaceSwitcher
         {...baseWorkspaceSwitcherProps}
         recentWorkspaces={[
-          { id: "ws-research", name: "Research", rootPath: "/notes/research", lastOpenedAtUnixMs: 2000 },
-          { id: "ws-archive", name: "Archive", rootPath: "/notes/archive", lastOpenedAtUnixMs: 1000 },
+          {
+            id: "ws-research",
+            name: "Research",
+            rootPath: "/notes/research",
+            lastOpenedAtUnixMs: 2000,
+          },
+          {
+            id: "ws-archive",
+            name: "Archive",
+            rootPath: "/notes/archive",
+            lastOpenedAtUnixMs: 1000,
+          },
         ]}
         initiallyOpen={true}
       />,
@@ -259,7 +275,9 @@ describe("WorkspaceSwitcher", () => {
       />,
     );
 
-    expect(markup).toMatch(/<button type="button" class="folder-navigation__workspace-action" disabled="">Add workspace<\/button>/);
+    expect(markup).toMatch(
+      /<button type="button" class="folder-navigation__workspace-action" disabled="">Add workspace<\/button>/,
+    );
   });
 
   it("disables remove workspace while note edits are dirty", () => {
@@ -272,7 +290,9 @@ describe("WorkspaceSwitcher", () => {
       />,
     );
 
-    expect(markup).toMatch(/<button type="button" class="folder-navigation__secondary-action" disabled="">Remove from Grove<\/button>/);
+    expect(markup).toMatch(
+      /<button type="button" class="folder-navigation__secondary-action" disabled="">Remove from Grove<\/button>/,
+    );
   });
 
   it("renders the active workspace name from props", () => {
@@ -281,6 +301,22 @@ describe("WorkspaceSwitcher", () => {
     );
 
     expect(markup).toContain("My Research");
+  });
+});
+
+describe("WorkspaceSetupRequired", () => {
+  it("shows workspace setup before note creation controls", () => {
+    const markup = renderToStaticMarkup(
+      <WorkspaceSetupRequired
+        loadState={{ status: "ready", errorMessage: null }}
+        onAddWorkspace={() => Promise.resolve()}
+      />,
+    );
+
+    expect(markup).toContain("Set up a workspace");
+    expect(markup).toContain("Folder path");
+    expect(markup).toContain("Create workspace");
+    expect(markup).not.toContain("Create note");
   });
 });
 

--- a/apps/desktop/src/features/folder-navigation/ui/FolderNavigationWorkspace.test.tsx
+++ b/apps/desktop/src/features/folder-navigation/ui/FolderNavigationWorkspace.test.tsx
@@ -353,7 +353,9 @@ describe("WorkspaceSetupLoading", () => {
 
   it("shows the error message when the workspace load failed", () => {
     const markup = renderToStaticMarkup(
-      <WorkspaceSetupLoading loadState={{ status: "failed", errorMessage: "Registry corrupted" }} />,
+      <WorkspaceSetupLoading
+        loadState={{ status: "failed", errorMessage: "Registry corrupted" }}
+      />,
     );
 
     expect(markup).toContain("Loading workspace");
@@ -377,8 +379,8 @@ describe("getWorkspaceViewPhase", () => {
     expect(getWorkspaceViewPhase(null, { status: "ready", errorMessage: null })).toBe("setup");
   });
 
-  it("returns loading when failed with no active workspace", () => {
-    expect(getWorkspaceViewPhase(null, { status: "failed", errorMessage: "err" })).toBe("loading");
+  it("returns setup when failed with no active workspace", () => {
+    expect(getWorkspaceViewPhase(null, { status: "failed", errorMessage: "err" })).toBe("setup");
   });
 
   it("returns ready when workspace is active", () => {

--- a/apps/desktop/src/features/folder-navigation/ui/FolderNavigationWorkspace.tsx
+++ b/apps/desktop/src/features/folder-navigation/ui/FolderNavigationWorkspace.tsx
@@ -689,8 +689,11 @@ function WorkspaceSetupForm({
     status: "idle",
     errorMessage: null,
   });
+  const formId = useId();
   const [name, setName] = useState("");
   const [rootPath, setRootPath] = useState("");
+  const nameInputId = `${formId}-workspace-name`;
+  const pathInputId = `${formId}-workspace-path`;
 
   async function handleAdd(): Promise<void> {
     if (switchBlockedReason !== null) {
@@ -712,22 +715,22 @@ function WorkspaceSetupForm({
 
   return (
     <div className="folder-navigation__operation">
-      <label className="folder-navigation__label" htmlFor="add-workspace-name">
+      <label className="folder-navigation__label" htmlFor={nameInputId}>
         Name
       </label>
       <input
-        id="add-workspace-name"
+        id={nameInputId}
         className="folder-navigation__input"
         value={name}
         onChange={(event) => setName(event.target.value)}
         placeholder="My Notes"
         disabled={operation.status === "pending"}
       />
-      <label className="folder-navigation__label" htmlFor="add-workspace-path">
+      <label className="folder-navigation__label" htmlFor={pathInputId}>
         Folder path
       </label>
       <input
-        id="add-workspace-path"
+        id={pathInputId}
         className="folder-navigation__input"
         value={rootPath}
         onChange={(event) => setRootPath(event.target.value)}

--- a/apps/desktop/src/features/folder-navigation/ui/FolderNavigationWorkspace.tsx
+++ b/apps/desktop/src/features/folder-navigation/ui/FolderNavigationWorkspace.tsx
@@ -17,6 +17,7 @@ import type { ReactNode } from "react";
 import type { DesktopWorkspace } from "../../../shared";
 import { getRecentWorkspaces, useWorkspaceStore } from "../model/useWorkspaceStore";
 import {
+  WorkspaceSetupLoading,
   WorkspaceSetupRequired,
   WorkspaceSwitcher,
   getActiveWorkspaceName,
@@ -79,6 +80,7 @@ import type { WorkspaceLoadState } from "../model/useWorkspaceStore";
 import "./FolderNavigationWorkspace.css";
 
 export {
+  WorkspaceSetupLoading,
   WorkspaceSetupRequired,
   WorkspaceSwitcher,
   getActiveWorkspaceName,
@@ -2016,8 +2018,12 @@ export function FolderNavigationWorkspaceContent({
 
   if (
     activeWorkspace === null &&
-    (workspaceLoadState.status === "ready" || workspaceLoadState.status === "failed")
+    (workspaceLoadState.status === "idle" || workspaceLoadState.status === "loading")
   ) {
+    return <WorkspaceSetupLoading />;
+  }
+
+  if (activeWorkspace === null) {
     return (
       <WorkspaceSetupRequired loadState={workspaceLoadState} onAddWorkspace={handleAddWorkspace} />
     );

--- a/apps/desktop/src/features/folder-navigation/ui/FolderNavigationWorkspace.tsx
+++ b/apps/desktop/src/features/folder-navigation/ui/FolderNavigationWorkspace.tsx
@@ -392,7 +392,7 @@ export function getWorkspaceViewPhase(
   activeWorkspace: DesktopWorkspace | null,
   loadState: WorkspaceLoadState,
 ): "loading" | "setup" | "ready" {
-  if (activeWorkspace === null && loadState.status !== "ready" && loadState.status !== "failed") {
+  if (activeWorkspace === null && loadState.status !== "ready") {
     return "loading";
   }
   if (activeWorkspace === null) {

--- a/apps/desktop/src/features/folder-navigation/ui/FolderNavigationWorkspace.tsx
+++ b/apps/desktop/src/features/folder-navigation/ui/FolderNavigationWorkspace.tsx
@@ -392,7 +392,7 @@ export function getWorkspaceViewPhase(
   activeWorkspace: DesktopWorkspace | null,
   loadState: WorkspaceLoadState,
 ): "loading" | "setup" | "ready" {
-  if (activeWorkspace === null && loadState.status !== "ready") {
+  if (activeWorkspace === null && loadState.status !== "ready" && loadState.status !== "failed") {
     return "loading";
   }
   if (activeWorkspace === null) {

--- a/apps/desktop/src/features/folder-navigation/ui/FolderNavigationWorkspace.tsx
+++ b/apps/desktop/src/features/folder-navigation/ui/FolderNavigationWorkspace.tsx
@@ -21,7 +21,6 @@ import {
   WorkspaceSwitcher,
   getActiveWorkspaceName,
 } from "./WorkspaceControls";
-import type { WorkspaceLoadState } from "./WorkspaceControls";
 
 import {
   createMarkdownNote,
@@ -76,6 +75,7 @@ import type {
   FolderWorkspaceState,
 } from "../model/folderWorkspaceState";
 import type { NoteEditBuffer } from "../model/noteEditBuffer";
+import type { WorkspaceLoadState } from "../model/useWorkspaceStore";
 import "./FolderNavigationWorkspace.css";
 
 export {

--- a/apps/desktop/src/features/folder-navigation/ui/FolderNavigationWorkspace.tsx
+++ b/apps/desktop/src/features/folder-navigation/ui/FolderNavigationWorkspace.tsx
@@ -392,7 +392,7 @@ export function getWorkspaceViewPhase(
   activeWorkspace: DesktopWorkspace | null,
   loadState: WorkspaceLoadState,
 ): "loading" | "setup" | "ready" {
-  if (activeWorkspace === null && (loadState.status === "idle" || loadState.status === "loading")) {
+  if (activeWorkspace === null && loadState.status !== "ready") {
     return "loading";
   }
   if (activeWorkspace === null) {
@@ -2032,7 +2032,7 @@ export function FolderNavigationWorkspaceContent({
   const workspaceViewPhase = getWorkspaceViewPhase(activeWorkspace, workspaceLoadState);
 
   if (workspaceViewPhase === "loading") {
-    return <WorkspaceSetupLoading />;
+    return <WorkspaceSetupLoading loadState={workspaceLoadState} />;
   }
 
   if (workspaceViewPhase === "setup") {

--- a/apps/desktop/src/features/folder-navigation/ui/FolderNavigationWorkspace.tsx
+++ b/apps/desktop/src/features/folder-navigation/ui/FolderNavigationWorkspace.tsx
@@ -132,6 +132,19 @@ type PopoverOperationState = {
   errorMessage: string | null;
 };
 
+type WorkspaceSetupFormProps = {
+  submitLabel: string;
+  pendingLabel: string;
+  onAddWorkspace: (name: string, rootPath: string) => Promise<void>;
+  switchBlockedReason?: string | null;
+  onCancel?: () => void;
+};
+
+type WorkspaceSetupRequiredProps = {
+  loadState: WorkspaceLoadState;
+  onAddWorkspace: (name: string, rootPath: string) => Promise<void>;
+};
+
 type WorkspaceSwitcherPopoverProps = WorkspaceSwitcherSlice & {
   id: string;
   initialView?: PopoverView;
@@ -665,6 +678,120 @@ export function WorkspaceSwitcher({
   );
 }
 
+function WorkspaceSetupForm({
+  submitLabel,
+  pendingLabel,
+  onAddWorkspace,
+  switchBlockedReason = null,
+  onCancel,
+}: WorkspaceSetupFormProps) {
+  const [operation, setOperation] = useState<PopoverOperationState>({
+    status: "idle",
+    errorMessage: null,
+  });
+  const [name, setName] = useState("");
+  const [rootPath, setRootPath] = useState("");
+
+  async function handleAdd(): Promise<void> {
+    if (switchBlockedReason !== null) {
+      setOperation({ status: "failed", errorMessage: switchBlockedReason });
+      return;
+    }
+
+    if (name.trim() === "" || rootPath.trim() === "") return;
+    setOperation({ status: "pending", errorMessage: null });
+    try {
+      await onAddWorkspace(name.trim(), rootPath.trim());
+    } catch (error) {
+      setOperation({
+        status: "failed",
+        errorMessage: error instanceof Error ? error.message : "Failed to add workspace.",
+      });
+    }
+  }
+
+  return (
+    <div className="folder-navigation__operation">
+      <label className="folder-navigation__label" htmlFor="add-workspace-name">
+        Name
+      </label>
+      <input
+        id="add-workspace-name"
+        className="folder-navigation__input"
+        value={name}
+        onChange={(event) => setName(event.target.value)}
+        placeholder="My Notes"
+        disabled={operation.status === "pending"}
+      />
+      <label className="folder-navigation__label" htmlFor="add-workspace-path">
+        Folder path
+      </label>
+      <input
+        id="add-workspace-path"
+        className="folder-navigation__input"
+        value={rootPath}
+        onChange={(event) => setRootPath(event.target.value)}
+        placeholder="/Users/you/Notes"
+        disabled={operation.status === "pending"}
+      />
+      {operation.errorMessage !== null ? (
+        <p className="folder-navigation__step-error">{operation.errorMessage}</p>
+      ) : null}
+      <div className="folder-navigation__workspace-popover-actions">
+        <button
+          type="button"
+          className="folder-navigation__action"
+          onClick={() => {
+            void handleAdd();
+          }}
+          disabled={
+            switchBlockedReason !== null ||
+            operation.status === "pending" ||
+            name.trim() === "" ||
+            rootPath.trim() === ""
+          }
+        >
+          {operation.status === "pending" ? pendingLabel : submitLabel}
+        </button>
+        {onCancel === undefined ? null : (
+          <button
+            type="button"
+            className="folder-navigation__secondary-action"
+            onClick={onCancel}
+            disabled={operation.status === "pending"}
+          >
+            Cancel
+          </button>
+        )}
+      </div>
+    </div>
+  );
+}
+
+export function WorkspaceSetupRequired({ loadState, onAddWorkspace }: WorkspaceSetupRequiredProps) {
+  return (
+    <section className="folder-navigation folder-navigation--setup">
+      <div className="folder-navigation__setup">
+        <p className="folder-navigation__eyebrow">{appName}</p>
+        <h1 className="folder-navigation__title">Set up a workspace</h1>
+        <p className="folder-navigation__muted">
+          Choose the local folder where Grove will store Markdown notes before creating notes.
+        </p>
+        {loadState.status === "failed" ? (
+          <p className="folder-navigation__step-error">
+            {loadState.errorMessage ?? "The workspace operation failed."}
+          </p>
+        ) : null}
+        <WorkspaceSetupForm
+          submitLabel="Create workspace"
+          pendingLabel="Creating..."
+          onAddWorkspace={onAddWorkspace}
+        />
+      </div>
+    </section>
+  );
+}
+
 function WorkspaceSwitcherPopover({
   id,
   activeWorkspaceName,
@@ -681,8 +808,6 @@ function WorkspaceSwitcherPopover({
     status: "idle",
     errorMessage: null,
   });
-  const [addName, setAddName] = useState("");
-  const [addPath, setAddPath] = useState("");
   const [renameName, setRenameName] = useState(activeWorkspaceName);
 
   function switchView(nextView: PopoverView): void {
@@ -692,8 +817,6 @@ function WorkspaceSwitcherPopover({
 
   function resetToList(): void {
     switchView("list");
-    setAddName("");
-    setAddPath("");
     setRenameName(activeWorkspaceName);
   }
 
@@ -710,24 +833,6 @@ function WorkspaceSwitcherPopover({
       setOperation({
         status: "failed",
         errorMessage: error instanceof Error ? error.message : "Failed to switch workspace.",
-      });
-    }
-  }
-
-  async function handleAdd(): Promise<void> {
-    if (switchBlockedReason !== null) {
-      setOperation({ status: "failed", errorMessage: switchBlockedReason });
-      return;
-    }
-
-    if (addName.trim() === "" || addPath.trim() === "") return;
-    setOperation({ status: "pending", errorMessage: null });
-    try {
-      await onAddWorkspace(addName.trim(), addPath.trim());
-    } catch (error) {
-      setOperation({
-        status: "failed",
-        errorMessage: error instanceof Error ? error.message : "Failed to add workspace.",
       });
     }
   }
@@ -793,7 +898,9 @@ function WorkspaceSwitcherPopover({
                     <button
                       type="button"
                       className="folder-navigation__workspace-action"
-                      onClick={() => { void handleSwitch(workspace.id); }}
+                      onClick={() => {
+                        void handleSwitch(workspace.id);
+                      }}
                       disabled={switchBlockedReason !== null || operation.status === "pending"}
                     >
                       {workspace.name}
@@ -828,56 +935,13 @@ function WorkspaceSwitcherPopover({
       {view === "add" ? (
         <div className="folder-navigation__workspace-popover-section">
           <p className="folder-navigation__group-heading">Add workspace</p>
-          <div className="folder-navigation__operation">
-            <label className="folder-navigation__label" htmlFor="add-workspace-name">
-              Name
-            </label>
-            <input
-              id="add-workspace-name"
-              className="folder-navigation__input"
-              value={addName}
-              onChange={(event) => setAddName(event.target.value)}
-              placeholder="My Notes"
-              disabled={operation.status === "pending"}
-            />
-            <label className="folder-navigation__label" htmlFor="add-workspace-path">
-              Folder path
-            </label>
-            <input
-              id="add-workspace-path"
-              className="folder-navigation__input"
-              value={addPath}
-              onChange={(event) => setAddPath(event.target.value)}
-              placeholder="/Users/you/Notes"
-              disabled={operation.status === "pending"}
-            />
-            {operation.errorMessage !== null ? (
-              <p className="folder-navigation__step-error">{operation.errorMessage}</p>
-            ) : null}
-            <div className="folder-navigation__workspace-popover-actions">
-              <button
-                type="button"
-                className="folder-navigation__action"
-                onClick={() => { void handleAdd(); }}
-                disabled={
-                  switchBlockedReason !== null ||
-                  operation.status === "pending" ||
-                  addName.trim() === "" ||
-                  addPath.trim() === ""
-                }
-              >
-                {operation.status === "pending" ? "Adding..." : "Add"}
-              </button>
-              <button
-                type="button"
-                className="folder-navigation__secondary-action"
-                onClick={resetToList}
-                disabled={operation.status === "pending"}
-              >
-                Cancel
-              </button>
-            </div>
-          </div>
+          <WorkspaceSetupForm
+            submitLabel="Add"
+            pendingLabel="Adding..."
+            switchBlockedReason={switchBlockedReason}
+            onAddWorkspace={onAddWorkspace}
+            onCancel={resetToList}
+          />
         </div>
       ) : null}
 
@@ -902,7 +966,9 @@ function WorkspaceSwitcherPopover({
               <button
                 type="button"
                 className="folder-navigation__action"
-                onClick={() => { void handleRename(); }}
+                onClick={() => {
+                  void handleRename();
+                }}
                 disabled={
                   operation.status === "pending" ||
                   renameName.trim() === "" ||
@@ -924,7 +990,9 @@ function WorkspaceSwitcherPopover({
               <button
                 type="button"
                 className="folder-navigation__secondary-action"
-                onClick={() => { void handleRemove(); }}
+                onClick={() => {
+                  void handleRemove();
+                }}
                 disabled={switchBlockedReason !== null || operation.status === "pending"}
               >
                 Remove from Grove
@@ -1785,10 +1853,7 @@ export function FolderNavigationWorkspaceContent({
     selectedNote === undefined || !isNoteAffectedByPathChange(pathChangeOperations, selectedNote.id)
       ? null
       : "Delete is unavailable while this note has unfinished path changes.";
-  const switchBlockedReason = getWorkspaceSwitchBlockedReason(
-    noteEditBuffer,
-    pathChangeOperations,
-  );
+  const switchBlockedReason = getWorkspaceSwitchBlockedReason(noteEditBuffer, pathChangeOperations);
   const recentWorkspaces = getRecentWorkspaces(allWorkspaces, activeWorkspace?.id);
 
   async function handleSwitchWorkspace(id: string): Promise<void> {
@@ -2376,6 +2441,15 @@ export function FolderNavigationWorkspaceContent({
       window.removeEventListener("keydown", saveOnKeyboardShortcut);
     };
   }, [noteEditBuffer, pathChangeOperations, saveSelectedNoteDraft]);
+
+  if (
+    activeWorkspace === null &&
+    (workspaceLoadState.status === "ready" || workspaceLoadState.status === "failed")
+  ) {
+    return (
+      <WorkspaceSetupRequired loadState={workspaceLoadState} onAddWorkspace={handleAddWorkspace} />
+    );
+  }
 
   return (
     <section

--- a/apps/desktop/src/features/folder-navigation/ui/FolderNavigationWorkspace.tsx
+++ b/apps/desktop/src/features/folder-navigation/ui/FolderNavigationWorkspace.tsx
@@ -388,6 +388,19 @@ export function getScanStateWithoutActiveWorkspace(
   };
 }
 
+export function getWorkspaceViewPhase(
+  activeWorkspace: DesktopWorkspace | null,
+  loadState: WorkspaceLoadState,
+): "loading" | "setup" | "ready" {
+  if (activeWorkspace === null && (loadState.status === "idle" || loadState.status === "loading")) {
+    return "loading";
+  }
+  if (activeWorkspace === null) {
+    return "setup";
+  }
+  return "ready";
+}
+
 function getNoteReadErrorMessage(error: unknown): string {
   return error instanceof Error ? error.message : "The Markdown note could not be read.";
 }
@@ -2016,14 +2029,13 @@ export function FolderNavigationWorkspaceContent({
     };
   }, [noteEditBuffer, pathChangeOperations, saveSelectedNoteDraft]);
 
-  if (
-    activeWorkspace === null &&
-    (workspaceLoadState.status === "idle" || workspaceLoadState.status === "loading")
-  ) {
+  const workspaceViewPhase = getWorkspaceViewPhase(activeWorkspace, workspaceLoadState);
+
+  if (workspaceViewPhase === "loading") {
     return <WorkspaceSetupLoading />;
   }
 
-  if (activeWorkspace === null) {
+  if (workspaceViewPhase === "setup") {
     return (
       <WorkspaceSetupRequired loadState={workspaceLoadState} onAddWorkspace={handleAddWorkspace} />
     );

--- a/apps/desktop/src/features/folder-navigation/ui/FolderNavigationWorkspace.tsx
+++ b/apps/desktop/src/features/folder-navigation/ui/FolderNavigationWorkspace.tsx
@@ -11,11 +11,17 @@ import {
 } from "@grove/core";
 import type { FolderScope, FolderTreeNode, ResolvedWikiLink } from "@grove/core";
 import type { MarkdownCommand, MarkdownSelection } from "@grove/editor";
-import { useCallback, useEffect, useId, useLayoutEffect, useMemo, useRef, useState } from "react";
+import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from "react";
 import type { ReactNode } from "react";
 
 import type { DesktopWorkspace } from "../../../shared";
 import { getRecentWorkspaces, useWorkspaceStore } from "../model/useWorkspaceStore";
+import {
+  WorkspaceSetupRequired,
+  WorkspaceSwitcher,
+  getActiveWorkspaceName,
+} from "./WorkspaceControls";
+import type { WorkspaceLoadState } from "./WorkspaceControls";
 
 import {
   createMarkdownNote,
@@ -72,6 +78,12 @@ import type {
 import type { NoteEditBuffer } from "../model/noteEditBuffer";
 import "./FolderNavigationWorkspace.css";
 
+export {
+  WorkspaceSetupRequired,
+  WorkspaceSwitcher,
+  getActiveWorkspaceName,
+} from "./WorkspaceControls";
+
 type NoteListItem = FolderNavigationNote;
 
 type FolderNodeProps = {
@@ -119,36 +131,6 @@ type NoteListProps = {
 };
 
 type NavigationPaneProps = SidebarProps & NoteListProps;
-
-type WorkspaceSwitcherProps = WorkspaceSwitcherSlice & {
-  initiallyOpen?: boolean;
-  initialView?: PopoverView;
-};
-
-type PopoverView = "list" | "add" | "settings";
-
-type PopoverOperationState = {
-  status: "idle" | "pending" | "failed";
-  errorMessage: string | null;
-};
-
-type WorkspaceSetupFormProps = {
-  submitLabel: string;
-  pendingLabel: string;
-  onAddWorkspace: (name: string, rootPath: string) => Promise<void>;
-  switchBlockedReason?: string | null;
-  onCancel?: () => void;
-};
-
-type WorkspaceSetupRequiredProps = {
-  loadState: WorkspaceLoadState;
-  onAddWorkspace: (name: string, rootPath: string) => Promise<void>;
-};
-
-type WorkspaceSwitcherPopoverProps = WorkspaceSwitcherSlice & {
-  id: string;
-  initialView?: PopoverView;
-};
 
 type FolderOption = {
   path: FolderScope;
@@ -216,11 +198,6 @@ type FolderNavigationWorkspaceContentProps = {
 
 type WorkspaceScanState = {
   status: "loading" | "ready" | "failed";
-  errorMessage: string | null;
-};
-
-type WorkspaceLoadState = {
-  status: "idle" | "loading" | "ready" | "failed";
   errorMessage: string | null;
 };
 
@@ -407,25 +384,6 @@ export function getScanStateWithoutActiveWorkspace(
     status: "ready",
     errorMessage: null,
   };
-}
-
-export function getActiveWorkspaceName(
-  activeWorkspace: DesktopWorkspace | null,
-  workspaceLoadState: WorkspaceLoadState,
-): string {
-  if (activeWorkspace !== null) {
-    return activeWorkspace.name;
-  }
-
-  if (workspaceLoadState.status === "loading") {
-    return "Loading...";
-  }
-
-  if (workspaceLoadState.status === "failed") {
-    return "Workspace unavailable";
-  }
-
-  return "No workspace selected";
 }
 
 function getNoteReadErrorMessage(error: unknown): string {
@@ -619,395 +577,6 @@ function LibraryColumn({
         onRemoveWorkspace={onRemoveWorkspace}
       />
     </aside>
-  );
-}
-
-export function WorkspaceSwitcher({
-  activeWorkspaceName,
-  recentWorkspaces,
-  switchBlockedReason,
-  onSwitchWorkspace,
-  onAddWorkspace,
-  onRenameWorkspace,
-  onRemoveWorkspace,
-  initiallyOpen = false,
-  initialView = "list",
-}: WorkspaceSwitcherProps) {
-  const popoverId = useId();
-  const [isOpen, setIsOpen] = useState(initiallyOpen);
-
-  return (
-    <div className="folder-navigation__workspace-switcher">
-      <button
-        type="button"
-        className="folder-navigation__workspace-switcher-button"
-        onClick={() => setIsOpen((currentIsOpen) => !currentIsOpen)}
-        aria-expanded={isOpen}
-        aria-haspopup="dialog"
-        aria-controls={isOpen ? popoverId : undefined}
-      >
-        <span className="folder-navigation__workspace-name">{activeWorkspaceName}</span>
-        <span className="folder-navigation__workspace-hint">Switch workspace</span>
-      </button>
-      {isOpen ? (
-        <WorkspaceSwitcherPopover
-          id={popoverId}
-          activeWorkspaceName={activeWorkspaceName}
-          recentWorkspaces={recentWorkspaces}
-          switchBlockedReason={switchBlockedReason}
-          initialView={initialView}
-          onSwitchWorkspace={async (id) => {
-            await onSwitchWorkspace(id);
-            setIsOpen(false);
-          }}
-          onAddWorkspace={async (name, rootPath) => {
-            await onAddWorkspace(name, rootPath);
-            setIsOpen(false);
-          }}
-          onRenameWorkspace={async (name) => {
-            await onRenameWorkspace(name);
-            setIsOpen(false);
-          }}
-          onRemoveWorkspace={async () => {
-            await onRemoveWorkspace();
-            setIsOpen(false);
-          }}
-        />
-      ) : null}
-    </div>
-  );
-}
-
-function WorkspaceSetupForm({
-  submitLabel,
-  pendingLabel,
-  onAddWorkspace,
-  switchBlockedReason = null,
-  onCancel,
-}: WorkspaceSetupFormProps) {
-  const [operation, setOperation] = useState<PopoverOperationState>({
-    status: "idle",
-    errorMessage: null,
-  });
-  const formId = useId();
-  const [name, setName] = useState("");
-  const [rootPath, setRootPath] = useState("");
-  const nameInputId = `${formId}-workspace-name`;
-  const pathInputId = `${formId}-workspace-path`;
-
-  async function handleAdd(): Promise<void> {
-    if (switchBlockedReason !== null) {
-      setOperation({ status: "failed", errorMessage: switchBlockedReason });
-      return;
-    }
-
-    if (name.trim() === "" || rootPath.trim() === "") return;
-    setOperation({ status: "pending", errorMessage: null });
-    try {
-      await onAddWorkspace(name.trim(), rootPath.trim());
-    } catch (error) {
-      setOperation({
-        status: "failed",
-        errorMessage: error instanceof Error ? error.message : "Failed to add workspace.",
-      });
-    }
-  }
-
-  return (
-    <div className="folder-navigation__operation">
-      <label className="folder-navigation__label" htmlFor={nameInputId}>
-        Name
-      </label>
-      <input
-        id={nameInputId}
-        className="folder-navigation__input"
-        value={name}
-        onChange={(event) => setName(event.target.value)}
-        placeholder="My Notes"
-        disabled={operation.status === "pending"}
-      />
-      <label className="folder-navigation__label" htmlFor={pathInputId}>
-        Folder path
-      </label>
-      <input
-        id={pathInputId}
-        className="folder-navigation__input"
-        value={rootPath}
-        onChange={(event) => setRootPath(event.target.value)}
-        placeholder="/Users/you/Notes"
-        disabled={operation.status === "pending"}
-      />
-      {operation.errorMessage !== null ? (
-        <p className="folder-navigation__step-error">{operation.errorMessage}</p>
-      ) : null}
-      <div className="folder-navigation__workspace-popover-actions">
-        <button
-          type="button"
-          className="folder-navigation__action"
-          onClick={() => {
-            void handleAdd();
-          }}
-          disabled={
-            switchBlockedReason !== null ||
-            operation.status === "pending" ||
-            name.trim() === "" ||
-            rootPath.trim() === ""
-          }
-        >
-          {operation.status === "pending" ? pendingLabel : submitLabel}
-        </button>
-        {onCancel === undefined ? null : (
-          <button
-            type="button"
-            className="folder-navigation__secondary-action"
-            onClick={onCancel}
-            disabled={operation.status === "pending"}
-          >
-            Cancel
-          </button>
-        )}
-      </div>
-    </div>
-  );
-}
-
-export function WorkspaceSetupRequired({ loadState, onAddWorkspace }: WorkspaceSetupRequiredProps) {
-  return (
-    <section className="folder-navigation folder-navigation--setup">
-      <div className="folder-navigation__setup">
-        <p className="folder-navigation__eyebrow">{appName}</p>
-        <h1 className="folder-navigation__title">Set up a workspace</h1>
-        <p className="folder-navigation__muted">
-          Choose the local folder where Grove will store Markdown notes before creating notes.
-        </p>
-        {loadState.status === "failed" ? (
-          <p className="folder-navigation__step-error">
-            {loadState.errorMessage ?? "The workspace operation failed."}
-          </p>
-        ) : null}
-        <WorkspaceSetupForm
-          submitLabel="Create workspace"
-          pendingLabel="Creating..."
-          onAddWorkspace={onAddWorkspace}
-        />
-      </div>
-    </section>
-  );
-}
-
-function WorkspaceSwitcherPopover({
-  id,
-  activeWorkspaceName,
-  recentWorkspaces,
-  switchBlockedReason,
-  initialView = "list",
-  onSwitchWorkspace,
-  onAddWorkspace,
-  onRenameWorkspace,
-  onRemoveWorkspace,
-}: WorkspaceSwitcherPopoverProps) {
-  const [view, setView] = useState<PopoverView>(initialView);
-  const [operation, setOperation] = useState<PopoverOperationState>({
-    status: "idle",
-    errorMessage: null,
-  });
-  const [renameName, setRenameName] = useState(activeWorkspaceName);
-
-  function switchView(nextView: PopoverView): void {
-    setView(nextView);
-    setOperation({ status: "idle", errorMessage: null });
-  }
-
-  function resetToList(): void {
-    switchView("list");
-    setRenameName(activeWorkspaceName);
-  }
-
-  async function handleSwitch(id: string): Promise<void> {
-    if (switchBlockedReason !== null) {
-      setOperation({ status: "failed", errorMessage: switchBlockedReason });
-      return;
-    }
-
-    setOperation({ status: "pending", errorMessage: null });
-    try {
-      await onSwitchWorkspace(id);
-    } catch (error) {
-      setOperation({
-        status: "failed",
-        errorMessage: error instanceof Error ? error.message : "Failed to switch workspace.",
-      });
-    }
-  }
-
-  async function handleRename(): Promise<void> {
-    if (renameName.trim() === "" || renameName.trim() === activeWorkspaceName) return;
-    setOperation({ status: "pending", errorMessage: null });
-    try {
-      await onRenameWorkspace(renameName.trim());
-    } catch (error) {
-      setOperation({
-        status: "failed",
-        errorMessage: error instanceof Error ? error.message : "Failed to rename workspace.",
-      });
-    }
-  }
-
-  async function handleRemove(): Promise<void> {
-    if (switchBlockedReason !== null) {
-      setOperation({ status: "failed", errorMessage: switchBlockedReason });
-      return;
-    }
-
-    const confirmed = window.confirm(
-      `Remove "${activeWorkspaceName}" from Grove? Your Markdown files will not be deleted.`,
-    );
-    if (!confirmed) return;
-    setOperation({ status: "pending", errorMessage: null });
-    try {
-      await onRemoveWorkspace();
-    } catch (error) {
-      setOperation({
-        status: "failed",
-        errorMessage: error instanceof Error ? error.message : "Failed to remove workspace.",
-      });
-    }
-  }
-
-  return (
-    <div
-      id={id}
-      className="folder-navigation__workspace-popover"
-      role="dialog"
-      aria-label="Workspace switcher"
-    >
-      <p className="folder-navigation__eyebrow">Current workspace</p>
-      <p className="folder-navigation__workspace-popover-title">{activeWorkspaceName}</p>
-
-      {switchBlockedReason !== null ? (
-        <p className="folder-navigation__step-error">{switchBlockedReason}</p>
-      ) : operation.status === "failed" && view === "list" ? (
-        <p className="folder-navigation__step-error">{operation.errorMessage}</p>
-      ) : null}
-
-      {view === "list" ? (
-        <>
-          <div className="folder-navigation__workspace-popover-section">
-            <p className="folder-navigation__group-heading">Recent workspaces</p>
-            {recentWorkspaces.length > 0 ? (
-              <ul className="folder-navigation__workspace-list">
-                {recentWorkspaces.map((workspace) => (
-                  <li key={workspace.id}>
-                    <button
-                      type="button"
-                      className="folder-navigation__workspace-action"
-                      onClick={() => {
-                        void handleSwitch(workspace.id);
-                      }}
-                      disabled={switchBlockedReason !== null || operation.status === "pending"}
-                    >
-                      {workspace.name}
-                    </button>
-                  </li>
-                ))}
-              </ul>
-            ) : (
-              <p className="folder-navigation__muted">No recent workspaces yet.</p>
-            )}
-          </div>
-          <div className="folder-navigation__workspace-popover-actions">
-            <button
-              type="button"
-              className="folder-navigation__workspace-action"
-              onClick={() => switchView("add")}
-              disabled={switchBlockedReason !== null}
-            >
-              Add workspace
-            </button>
-            <button
-              type="button"
-              className="folder-navigation__workspace-action"
-              onClick={() => switchView("settings")}
-            >
-              Workspace settings
-            </button>
-          </div>
-        </>
-      ) : null}
-
-      {view === "add" ? (
-        <div className="folder-navigation__workspace-popover-section">
-          <p className="folder-navigation__group-heading">Add workspace</p>
-          <WorkspaceSetupForm
-            submitLabel="Add"
-            pendingLabel="Adding..."
-            switchBlockedReason={switchBlockedReason}
-            onAddWorkspace={onAddWorkspace}
-            onCancel={resetToList}
-          />
-        </div>
-      ) : null}
-
-      {view === "settings" ? (
-        <div className="folder-navigation__workspace-popover-section">
-          <p className="folder-navigation__group-heading">Workspace settings</p>
-          <div className="folder-navigation__operation">
-            <label className="folder-navigation__label" htmlFor="rename-workspace-name">
-              Name
-            </label>
-            <input
-              id="rename-workspace-name"
-              className="folder-navigation__input"
-              value={renameName}
-              onChange={(event) => setRenameName(event.target.value)}
-              disabled={operation.status === "pending"}
-            />
-            {operation.errorMessage !== null ? (
-              <p className="folder-navigation__step-error">{operation.errorMessage}</p>
-            ) : null}
-            <div className="folder-navigation__workspace-popover-actions">
-              <button
-                type="button"
-                className="folder-navigation__action"
-                onClick={() => {
-                  void handleRename();
-                }}
-                disabled={
-                  operation.status === "pending" ||
-                  renameName.trim() === "" ||
-                  renameName.trim() === activeWorkspaceName
-                }
-              >
-                {operation.status === "pending" ? "Renaming..." : "Rename"}
-              </button>
-              <button
-                type="button"
-                className="folder-navigation__secondary-action"
-                onClick={resetToList}
-                disabled={operation.status === "pending"}
-              >
-                Cancel
-              </button>
-            </div>
-            <div className="folder-navigation__operation">
-              <button
-                type="button"
-                className="folder-navigation__secondary-action"
-                onClick={() => {
-                  void handleRemove();
-                }}
-                disabled={switchBlockedReason !== null || operation.status === "pending"}
-              >
-                Remove from Grove
-              </button>
-              <p className="folder-navigation__muted">
-                Removes this workspace from Grove without deleting your Markdown files.
-              </p>
-            </div>
-          </div>
-        </div>
-      ) : null}
-    </div>
   );
 }
 

--- a/apps/desktop/src/features/folder-navigation/ui/WorkspaceControls.tsx
+++ b/apps/desktop/src/features/folder-navigation/ui/WorkspaceControls.tsx
@@ -155,7 +155,13 @@ function WorkspaceSetupForm({
   }
 
   return (
-    <div className="folder-navigation__operation">
+    <form
+      className="folder-navigation__operation"
+      onSubmit={(event) => {
+        event.preventDefault();
+        void handleAdd();
+      }}
+    >
       <label className="folder-navigation__label" htmlFor={nameInputId}>
         Name
       </label>
@@ -183,11 +189,8 @@ function WorkspaceSetupForm({
       ) : null}
       <div className="folder-navigation__workspace-popover-actions">
         <button
-          type="button"
+          type="submit"
           className="folder-navigation__action"
-          onClick={() => {
-            void handleAdd();
-          }}
           disabled={
             switchBlockedReason !== null ||
             operation.status === "pending" ||
@@ -208,7 +211,7 @@ function WorkspaceSetupForm({
           </button>
         )}
       </div>
-    </div>
+    </form>
   );
 }
 

--- a/apps/desktop/src/features/folder-navigation/ui/WorkspaceControls.tsx
+++ b/apps/desktop/src/features/folder-navigation/ui/WorkspaceControls.tsx
@@ -1,0 +1,457 @@
+import { appName } from "@grove/core";
+import { useId, useState } from "react";
+
+import type { DesktopWorkspace } from "../../../shared";
+
+export type WorkspaceLoadState = {
+  status: "idle" | "loading" | "ready" | "failed";
+  errorMessage: string | null;
+};
+
+type WorkspaceSwitcherSlice = {
+  activeWorkspaceName: string;
+  recentWorkspaces: readonly DesktopWorkspace[];
+  switchBlockedReason: string | null;
+  onSwitchWorkspace: (id: string) => Promise<void>;
+  onAddWorkspace: (name: string, rootPath: string) => Promise<void>;
+  onRenameWorkspace: (name: string) => Promise<void>;
+  onRemoveWorkspace: () => Promise<void>;
+};
+
+type WorkspaceSwitcherProps = WorkspaceSwitcherSlice & {
+  initiallyOpen?: boolean;
+  initialView?: PopoverView;
+};
+
+type PopoverView = "list" | "add" | "settings";
+
+type PopoverOperationState = {
+  status: "idle" | "pending" | "failed";
+  errorMessage: string | null;
+};
+
+type WorkspaceSetupFormProps = {
+  submitLabel: string;
+  pendingLabel: string;
+  onAddWorkspace: (name: string, rootPath: string) => Promise<void>;
+  switchBlockedReason?: string | null;
+  onCancel?: () => void;
+};
+
+type WorkspaceSetupRequiredProps = {
+  loadState: WorkspaceLoadState;
+  onAddWorkspace: (name: string, rootPath: string) => Promise<void>;
+};
+
+type WorkspaceSwitcherPopoverProps = WorkspaceSwitcherSlice & {
+  id: string;
+  initialView?: PopoverView;
+};
+
+export function getActiveWorkspaceName(
+  activeWorkspace: DesktopWorkspace | null,
+  workspaceLoadState: WorkspaceLoadState,
+): string {
+  if (activeWorkspace !== null) {
+    return activeWorkspace.name;
+  }
+
+  if (workspaceLoadState.status === "loading") {
+    return "Loading...";
+  }
+
+  if (workspaceLoadState.status === "failed") {
+    return "Workspace unavailable";
+  }
+
+  return "No workspace selected";
+}
+
+export function WorkspaceSwitcher({
+  activeWorkspaceName,
+  recentWorkspaces,
+  switchBlockedReason,
+  onSwitchWorkspace,
+  onAddWorkspace,
+  onRenameWorkspace,
+  onRemoveWorkspace,
+  initiallyOpen = false,
+  initialView = "list",
+}: WorkspaceSwitcherProps) {
+  const popoverId = useId();
+  const [isOpen, setIsOpen] = useState(initiallyOpen);
+
+  return (
+    <div className="folder-navigation__workspace-switcher">
+      <button
+        type="button"
+        className="folder-navigation__workspace-switcher-button"
+        onClick={() => setIsOpen((currentIsOpen) => !currentIsOpen)}
+        aria-expanded={isOpen}
+        aria-haspopup="dialog"
+        aria-controls={isOpen ? popoverId : undefined}
+      >
+        <span className="folder-navigation__workspace-name">{activeWorkspaceName}</span>
+        <span className="folder-navigation__workspace-hint">Switch workspace</span>
+      </button>
+      {isOpen ? (
+        <WorkspaceSwitcherPopover
+          id={popoverId}
+          activeWorkspaceName={activeWorkspaceName}
+          recentWorkspaces={recentWorkspaces}
+          switchBlockedReason={switchBlockedReason}
+          initialView={initialView}
+          onSwitchWorkspace={async (id) => {
+            await onSwitchWorkspace(id);
+            setIsOpen(false);
+          }}
+          onAddWorkspace={async (name, rootPath) => {
+            await onAddWorkspace(name, rootPath);
+            setIsOpen(false);
+          }}
+          onRenameWorkspace={async (name) => {
+            await onRenameWorkspace(name);
+            setIsOpen(false);
+          }}
+          onRemoveWorkspace={async () => {
+            await onRemoveWorkspace();
+            setIsOpen(false);
+          }}
+        />
+      ) : null}
+    </div>
+  );
+}
+
+function WorkspaceSetupForm({
+  submitLabel,
+  pendingLabel,
+  onAddWorkspace,
+  switchBlockedReason = null,
+  onCancel,
+}: WorkspaceSetupFormProps) {
+  const [operation, setOperation] = useState<PopoverOperationState>({
+    status: "idle",
+    errorMessage: null,
+  });
+  const formId = useId();
+  const [name, setName] = useState("");
+  const [rootPath, setRootPath] = useState("");
+  const nameInputId = `${formId}-workspace-name`;
+  const pathInputId = `${formId}-workspace-path`;
+
+  async function handleAdd(): Promise<void> {
+    if (switchBlockedReason !== null) {
+      setOperation({ status: "failed", errorMessage: switchBlockedReason });
+      return;
+    }
+
+    if (name.trim() === "" || rootPath.trim() === "") return;
+    setOperation({ status: "pending", errorMessage: null });
+    try {
+      await onAddWorkspace(name.trim(), rootPath.trim());
+    } catch (error) {
+      setOperation({
+        status: "failed",
+        errorMessage: error instanceof Error ? error.message : "Failed to add workspace.",
+      });
+    }
+  }
+
+  return (
+    <div className="folder-navigation__operation">
+      <label className="folder-navigation__label" htmlFor={nameInputId}>
+        Name
+      </label>
+      <input
+        id={nameInputId}
+        className="folder-navigation__input"
+        value={name}
+        onChange={(event) => setName(event.target.value)}
+        placeholder="My Notes"
+        disabled={operation.status === "pending"}
+      />
+      <label className="folder-navigation__label" htmlFor={pathInputId}>
+        Folder path
+      </label>
+      <input
+        id={pathInputId}
+        className="folder-navigation__input"
+        value={rootPath}
+        onChange={(event) => setRootPath(event.target.value)}
+        placeholder="/Users/you/Notes"
+        disabled={operation.status === "pending"}
+      />
+      {operation.errorMessage !== null ? (
+        <p className="folder-navigation__step-error">{operation.errorMessage}</p>
+      ) : null}
+      <div className="folder-navigation__workspace-popover-actions">
+        <button
+          type="button"
+          className="folder-navigation__action"
+          onClick={() => {
+            void handleAdd();
+          }}
+          disabled={
+            switchBlockedReason !== null ||
+            operation.status === "pending" ||
+            name.trim() === "" ||
+            rootPath.trim() === ""
+          }
+        >
+          {operation.status === "pending" ? pendingLabel : submitLabel}
+        </button>
+        {onCancel === undefined ? null : (
+          <button
+            type="button"
+            className="folder-navigation__secondary-action"
+            onClick={onCancel}
+            disabled={operation.status === "pending"}
+          >
+            Cancel
+          </button>
+        )}
+      </div>
+    </div>
+  );
+}
+
+export function WorkspaceSetupRequired({ loadState, onAddWorkspace }: WorkspaceSetupRequiredProps) {
+  return (
+    <section className="folder-navigation folder-navigation--setup">
+      <div className="folder-navigation__setup">
+        <p className="folder-navigation__eyebrow">{appName}</p>
+        <h1 className="folder-navigation__title">Set up a workspace</h1>
+        <p className="folder-navigation__muted">
+          Choose the local folder where Grove will store Markdown notes before creating notes.
+        </p>
+        {loadState.status === "failed" ? (
+          <p className="folder-navigation__step-error">
+            {loadState.errorMessage ?? "The workspace operation failed."}
+          </p>
+        ) : null}
+        <WorkspaceSetupForm
+          submitLabel="Create workspace"
+          pendingLabel="Creating..."
+          onAddWorkspace={onAddWorkspace}
+        />
+      </div>
+    </section>
+  );
+}
+
+function WorkspaceSwitcherPopover({
+  id,
+  activeWorkspaceName,
+  recentWorkspaces,
+  switchBlockedReason,
+  initialView = "list",
+  onSwitchWorkspace,
+  onAddWorkspace,
+  onRenameWorkspace,
+  onRemoveWorkspace,
+}: WorkspaceSwitcherPopoverProps) {
+  const [view, setView] = useState<PopoverView>(initialView);
+  const [operation, setOperation] = useState<PopoverOperationState>({
+    status: "idle",
+    errorMessage: null,
+  });
+  const [renameName, setRenameName] = useState(activeWorkspaceName);
+
+  function switchView(nextView: PopoverView): void {
+    setView(nextView);
+    setOperation({ status: "idle", errorMessage: null });
+  }
+
+  function resetToList(): void {
+    switchView("list");
+    setRenameName(activeWorkspaceName);
+  }
+
+  async function handleSwitch(id: string): Promise<void> {
+    if (switchBlockedReason !== null) {
+      setOperation({ status: "failed", errorMessage: switchBlockedReason });
+      return;
+    }
+
+    setOperation({ status: "pending", errorMessage: null });
+    try {
+      await onSwitchWorkspace(id);
+    } catch (error) {
+      setOperation({
+        status: "failed",
+        errorMessage: error instanceof Error ? error.message : "Failed to switch workspace.",
+      });
+    }
+  }
+
+  async function handleRename(): Promise<void> {
+    if (renameName.trim() === "" || renameName.trim() === activeWorkspaceName) return;
+    setOperation({ status: "pending", errorMessage: null });
+    try {
+      await onRenameWorkspace(renameName.trim());
+    } catch (error) {
+      setOperation({
+        status: "failed",
+        errorMessage: error instanceof Error ? error.message : "Failed to rename workspace.",
+      });
+    }
+  }
+
+  async function handleRemove(): Promise<void> {
+    if (switchBlockedReason !== null) {
+      setOperation({ status: "failed", errorMessage: switchBlockedReason });
+      return;
+    }
+
+    const confirmed = window.confirm(
+      `Remove "${activeWorkspaceName}" from Grove? Your Markdown files will not be deleted.`,
+    );
+    if (!confirmed) return;
+    setOperation({ status: "pending", errorMessage: null });
+    try {
+      await onRemoveWorkspace();
+    } catch (error) {
+      setOperation({
+        status: "failed",
+        errorMessage: error instanceof Error ? error.message : "Failed to remove workspace.",
+      });
+    }
+  }
+
+  return (
+    <div
+      id={id}
+      className="folder-navigation__workspace-popover"
+      role="dialog"
+      aria-label="Workspace switcher"
+    >
+      <p className="folder-navigation__eyebrow">Current workspace</p>
+      <p className="folder-navigation__workspace-popover-title">{activeWorkspaceName}</p>
+
+      {switchBlockedReason !== null ? (
+        <p className="folder-navigation__step-error">{switchBlockedReason}</p>
+      ) : operation.status === "failed" && view === "list" ? (
+        <p className="folder-navigation__step-error">{operation.errorMessage}</p>
+      ) : null}
+
+      {view === "list" ? (
+        <>
+          <div className="folder-navigation__workspace-popover-section">
+            <p className="folder-navigation__group-heading">Recent workspaces</p>
+            {recentWorkspaces.length > 0 ? (
+              <ul className="folder-navigation__workspace-list">
+                {recentWorkspaces.map((workspace) => (
+                  <li key={workspace.id}>
+                    <button
+                      type="button"
+                      className="folder-navigation__workspace-action"
+                      onClick={() => {
+                        void handleSwitch(workspace.id);
+                      }}
+                      disabled={switchBlockedReason !== null || operation.status === "pending"}
+                    >
+                      {workspace.name}
+                    </button>
+                  </li>
+                ))}
+              </ul>
+            ) : (
+              <p className="folder-navigation__muted">No recent workspaces yet.</p>
+            )}
+          </div>
+          <div className="folder-navigation__workspace-popover-actions">
+            <button
+              type="button"
+              className="folder-navigation__workspace-action"
+              onClick={() => switchView("add")}
+              disabled={switchBlockedReason !== null}
+            >
+              Add workspace
+            </button>
+            <button
+              type="button"
+              className="folder-navigation__workspace-action"
+              onClick={() => switchView("settings")}
+            >
+              Workspace settings
+            </button>
+          </div>
+        </>
+      ) : null}
+
+      {view === "add" ? (
+        <div className="folder-navigation__workspace-popover-section">
+          <p className="folder-navigation__group-heading">Add workspace</p>
+          <WorkspaceSetupForm
+            submitLabel="Add"
+            pendingLabel="Adding..."
+            switchBlockedReason={switchBlockedReason}
+            onAddWorkspace={onAddWorkspace}
+            onCancel={resetToList}
+          />
+        </div>
+      ) : null}
+
+      {view === "settings" ? (
+        <div className="folder-navigation__workspace-popover-section">
+          <p className="folder-navigation__group-heading">Workspace settings</p>
+          <div className="folder-navigation__operation">
+            <label className="folder-navigation__label" htmlFor="rename-workspace-name">
+              Name
+            </label>
+            <input
+              id="rename-workspace-name"
+              className="folder-navigation__input"
+              value={renameName}
+              onChange={(event) => setRenameName(event.target.value)}
+              disabled={operation.status === "pending"}
+            />
+            {operation.errorMessage !== null ? (
+              <p className="folder-navigation__step-error">{operation.errorMessage}</p>
+            ) : null}
+            <div className="folder-navigation__workspace-popover-actions">
+              <button
+                type="button"
+                className="folder-navigation__action"
+                onClick={() => {
+                  void handleRename();
+                }}
+                disabled={
+                  operation.status === "pending" ||
+                  renameName.trim() === "" ||
+                  renameName.trim() === activeWorkspaceName
+                }
+              >
+                {operation.status === "pending" ? "Renaming..." : "Rename"}
+              </button>
+              <button
+                type="button"
+                className="folder-navigation__secondary-action"
+                onClick={resetToList}
+                disabled={operation.status === "pending"}
+              >
+                Cancel
+              </button>
+            </div>
+            <div className="folder-navigation__operation">
+              <button
+                type="button"
+                className="folder-navigation__secondary-action"
+                onClick={() => {
+                  void handleRemove();
+                }}
+                disabled={switchBlockedReason !== null || operation.status === "pending"}
+              >
+                Remove from Grove
+              </button>
+              <p className="folder-navigation__muted">
+                Removes this workspace from Grove without deleting your Markdown files.
+              </p>
+            </div>
+          </div>
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/apps/desktop/src/features/folder-navigation/ui/WorkspaceControls.tsx
+++ b/apps/desktop/src/features/folder-navigation/ui/WorkspaceControls.tsx
@@ -244,12 +244,16 @@ export function WorkspaceSetupRequired({ loadState, onAddWorkspace }: WorkspaceS
 }
 
 export function WorkspaceSetupLoading({ loadState }: WorkspaceSetupLoadingProps = {}) {
+  const isFailed = loadState?.status === "failed";
+
   return (
     <section className="folder-navigation folder-navigation--setup">
       <div className="folder-navigation__setup">
         <p className="folder-navigation__eyebrow">{appName}</p>
-        <h1 className="folder-navigation__title">Loading workspace</h1>
-        {loadState?.status === "failed" ? (
+        <h1 className="folder-navigation__title">
+          {isFailed ? "Workspace unavailable" : "Loading workspace"}
+        </h1>
+        {isFailed ? (
           <p className="folder-navigation__step-error">
             {loadState.errorMessage ?? "The workspace operation failed."}
           </p>

--- a/apps/desktop/src/features/folder-navigation/ui/WorkspaceControls.tsx
+++ b/apps/desktop/src/features/folder-navigation/ui/WorkspaceControls.tsx
@@ -2,11 +2,7 @@ import { appName } from "@grove/core";
 import { useId, useState } from "react";
 
 import type { DesktopWorkspace } from "../../../shared";
-
-export type WorkspaceLoadState = {
-  status: "idle" | "loading" | "ready" | "failed";
-  errorMessage: string | null;
-};
+import type { WorkspaceLoadState } from "../model/useWorkspaceStore";
 
 type WorkspaceSwitcherSlice = {
   activeWorkspaceName: string;

--- a/apps/desktop/src/features/folder-navigation/ui/WorkspaceControls.tsx
+++ b/apps/desktop/src/features/folder-navigation/ui/WorkspaceControls.tsx
@@ -257,6 +257,7 @@ function WorkspaceSwitcherPopover({
     errorMessage: null,
   });
   const [renameName, setRenameName] = useState(activeWorkspaceName);
+  const renameInputId = `${id}-rename-workspace-name`;
 
   function switchView(nextView: PopoverView): void {
     setView(nextView);
@@ -397,11 +398,11 @@ function WorkspaceSwitcherPopover({
         <div className="folder-navigation__workspace-popover-section">
           <p className="folder-navigation__group-heading">Workspace settings</p>
           <div className="folder-navigation__operation">
-            <label className="folder-navigation__label" htmlFor="rename-workspace-name">
+            <label className="folder-navigation__label" htmlFor={renameInputId}>
               Name
             </label>
             <input
-              id="rename-workspace-name"
+              id={renameInputId}
               className="folder-navigation__input"
               value={renameName}
               onChange={(event) => setRenameName(event.target.value)}

--- a/apps/desktop/src/features/folder-navigation/ui/WorkspaceControls.tsx
+++ b/apps/desktop/src/features/folder-navigation/ui/WorkspaceControls.tsx
@@ -39,6 +39,10 @@ type WorkspaceSetupRequiredProps = {
   onAddWorkspace: (name: string, rootPath: string) => Promise<void>;
 };
 
+type WorkspaceSetupLoadingProps = {
+  loadState?: WorkspaceLoadState;
+};
+
 type WorkspaceSwitcherPopoverProps = WorkspaceSwitcherSlice & {
   id: string;
   initialView?: PopoverView;
@@ -239,15 +243,21 @@ export function WorkspaceSetupRequired({ loadState, onAddWorkspace }: WorkspaceS
   );
 }
 
-export function WorkspaceSetupLoading() {
+export function WorkspaceSetupLoading({ loadState }: WorkspaceSetupLoadingProps = {}) {
   return (
     <section className="folder-navigation folder-navigation--setup">
       <div className="folder-navigation__setup">
         <p className="folder-navigation__eyebrow">{appName}</p>
         <h1 className="folder-navigation__title">Loading workspace</h1>
-        <p className="folder-navigation__muted">
-          Grove is checking the local workspace registry before notes can be created.
-        </p>
+        {loadState?.status === "failed" ? (
+          <p className="folder-navigation__step-error">
+            {loadState.errorMessage ?? "The workspace operation failed."}
+          </p>
+        ) : (
+          <p className="folder-navigation__muted">
+            Grove is checking the local workspace registry before notes can be created.
+          </p>
+        )}
       </div>
     </section>
   );

--- a/apps/desktop/src/features/folder-navigation/ui/WorkspaceControls.tsx
+++ b/apps/desktop/src/features/folder-navigation/ui/WorkspaceControls.tsx
@@ -292,7 +292,7 @@ function WorkspaceSwitcherPopover({
     setRenameName(activeWorkspaceName);
   }
 
-  async function handleSwitch(id: string): Promise<void> {
+  async function handleSwitch(workspaceId: string): Promise<void> {
     if (switchBlockedReason !== null) {
       setOperation({ status: "failed", errorMessage: switchBlockedReason });
       return;
@@ -300,7 +300,7 @@ function WorkspaceSwitcherPopover({
 
     setOperation({ status: "pending", errorMessage: null });
     try {
-      await onSwitchWorkspace(id);
+      await onSwitchWorkspace(workspaceId);
     } catch (error) {
       setOperation({
         status: "failed",

--- a/apps/desktop/src/features/folder-navigation/ui/WorkspaceControls.tsx
+++ b/apps/desktop/src/features/folder-navigation/ui/WorkspaceControls.tsx
@@ -236,6 +236,20 @@ export function WorkspaceSetupRequired({ loadState, onAddWorkspace }: WorkspaceS
   );
 }
 
+export function WorkspaceSetupLoading() {
+  return (
+    <section className="folder-navigation folder-navigation--setup">
+      <div className="folder-navigation__setup">
+        <p className="folder-navigation__eyebrow">{appName}</p>
+        <h1 className="folder-navigation__title">Loading workspace</h1>
+        <p className="folder-navigation__muted">
+          Grove is checking the local workspace registry before notes can be created.
+        </p>
+      </div>
+    </section>
+  );
+}
+
 function WorkspaceSwitcherPopover({
   id,
   activeWorkspaceName,

--- a/docs/superpowers/plans/2026-04-22-workspace-setup-required.md
+++ b/docs/superpowers/plans/2026-04-22-workspace-setup-required.md
@@ -1,0 +1,115 @@
+# Workspace Setup Required Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Require an explicit workspace before Grove exposes note creation.
+
+**Architecture:** Desktop backend will represent no active workspace as `activeWorkspaceId: null` and stop creating `Personal Notes` implicitly. The desktop UI will treat an empty ready workspace state as setup-required and render a focused setup surface that reuses the existing add workspace command path.
+
+**Tech Stack:** Tauri v2 Rust commands, React 19, TypeScript strict mode, Zustand, Vitest.
+
+---
+
+### Task 1: Backend Workspace Registry Semantics
+
+**Files:**
+
+- Modify: `apps/desktop/src-tauri/src/main.rs`
+
+- [ ] **Step 1: Write failing Rust tests**
+
+Change `creates_a_default_workspace_registry_on_first_run` so it expects an empty registry with no active workspace, and add coverage that removing the last workspace leaves the registry empty.
+
+Run: `cd apps/desktop/src-tauri && cargo test creates_an_empty_workspace_registry_on_first_run`
+
+Expected: FAIL because the backend still creates `Personal Notes`.
+
+- [ ] **Step 2: Implement nullable active workspace**
+
+Change `WorkspaceRegistry.active_workspace_id` from `String` to `Option<String>`. Initialize missing registries as `{ active_workspace_id: None, workspaces: [] }`, keep `add_and_activate_workspace_in_registry` and `switch_active_workspace_in_registry` setting `Some(id)`, and make last-workspace removal set `None`.
+
+- [ ] **Step 3: Verify Rust tests**
+
+Run: `cd apps/desktop/src-tauri && cargo test workspace`
+
+Expected: PASS.
+
+### Task 2: Desktop Store Empty-State Loading
+
+**Files:**
+
+- Modify: `apps/desktop/src/features/folder-navigation/model/useWorkspaceStore.ts`
+- Modify: `apps/desktop/src/features/folder-navigation/model/useWorkspaceStore.test.ts`
+
+- [ ] **Step 1: Write failing store tests**
+
+Add a test where `listWorkspaces()` resolves `[]` and `getActiveWorkspace()` rejects with `No workspace found`; `loadWorkspaces()` should set `activeWorkspace: null`, `allWorkspaces: []`, and `loadState.status: "ready"`.
+
+Run: `pnpm --filter @grove/desktop test -- useWorkspaceStore`
+
+Expected: FAIL because the store currently treats all active workspace failures as load failures.
+
+- [ ] **Step 2: Implement empty ready state**
+
+Load workspace list first. If the list is empty, skip `getActiveWorkspace()` and mark the store ready with no active workspace. If the list is non-empty and active lookup fails, keep the existing failed state.
+
+- [ ] **Step 3: Verify store tests**
+
+Run: `pnpm --filter @grove/desktop test -- useWorkspaceStore`
+
+Expected: PASS.
+
+### Task 3: Setup-First Desktop UI
+
+**Files:**
+
+- Modify: `apps/desktop/src/features/folder-navigation/ui/FolderNavigationWorkspace.tsx`
+- Modify: `apps/desktop/src/features/folder-navigation/ui/FolderNavigationWorkspace.css`
+- Modify: `apps/desktop/src/features/folder-navigation/ui/FolderNavigationWorkspace.test.tsx`
+
+- [ ] **Step 1: Write failing UI tests**
+
+Add a rendered markup test for `WorkspaceSetupRequired` that contains workspace setup copy and the add workspace form, and assert it does not render `Create note`.
+
+Run: `pnpm --filter @grove/desktop test -- FolderNavigationWorkspace`
+
+Expected: FAIL because the setup component does not exist yet.
+
+- [ ] **Step 2: Implement setup component**
+
+Extract the add workspace form into a reusable `WorkspaceSetupForm`. Use it in the existing switcher popover and a new setup-first screen. In `FolderNavigationWorkspaceContent`, when workspace load is ready and `activeWorkspace === null`, render setup instead of `NavigationPane` and `ActivePane`.
+
+- [ ] **Step 3: Verify UI tests**
+
+Run: `pnpm --filter @grove/desktop test -- FolderNavigationWorkspace`
+
+Expected: PASS.
+
+### Task 4: Full Verification And PR
+
+**Files:**
+
+- Verify all changed files.
+
+- [ ] **Step 1: Run focused checks**
+
+Run:
+
+- `pnpm --filter @grove/desktop test`
+- `cd apps/desktop/src-tauri && cargo test`
+- `pnpm --filter @grove/desktop typecheck`
+- `pnpm --filter @grove/desktop build`
+
+- [ ] **Step 2: Run workspace checks**
+
+Run:
+
+- `pnpm test`
+- `pnpm typecheck`
+- `pnpm lint`
+- `pnpm format`
+- `git diff --check`
+
+- [ ] **Step 3: Commit and create PR**
+
+Commit all implementation and plan changes, push `issue-88-workspace-setup-required`, and create a PR referencing `#88`.


### PR DESCRIPTION
## Summary
- stop desktop from implicitly creating a default Personal Notes workspace and persist no active workspace as `activeWorkspaceId: null`
- treat an empty workspace list as a ready setup-required state in the desktop workspace store
- preserve failed active-workspace lookup errors after partial workspace removal instead of silently returning to ready
- add a setup-first desktop workspace screen that reuses the add workspace form before note creation controls are shown
- keep failed workspace registry loads in an error-only state instead of showing an unusable create-workspace form
- add an implementation plan for issue #88 and ignore local `.worktrees/` directories

## Testing
- pnpm --filter @grove/desktop test
- cd apps/desktop/src-tauri && cargo test
- pnpm --filter @grove/desktop typecheck
- pnpm --filter @grove/desktop build
- pnpm test
- pnpm typecheck
- pnpm lint
- pnpm format
- git diff --check

Refs #88
