### PR TITLE
Add native workspace folder picker

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -17,6 +17,7 @@
     "@grove/plugin-api": "workspace:*",
     "@tanstack/react-router": "^1.168.21",
     "@tauri-apps/api": "^2.0.0",
+    "@tauri-apps/plugin-dialog": "^2.0.0",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
     "zustand": "^5.0.12"

--- a/apps/desktop/src-tauri/Cargo.lock
+++ b/apps/desktop/src-tauri/Cargo.lock
@@ -1160,6 +1160,7 @@ dependencies = [
  "serde_json",
  "tauri",
  "tauri-build",
+ "tauri-plugin-dialog",
  "tokio",
 ]
 
@@ -2021,6 +2022,7 @@ checksum = "e3e0adef53c21f888deb4fa59fc59f7eb17404926ee8a6f59f5df0fd7f9f3272"
 dependencies = [
  "bitflags 2.11.0",
  "block2",
+ "libc",
  "objc2",
  "objc2-core-foundation",
 ]
@@ -2691,6 +2693,30 @@ dependencies = [
  "wasm-bindgen-futures",
  "wasm-streams",
  "web-sys",
+]
+
+[[package]]
+name = "rfd"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a15ad77d9e70a92437d8f74c35d99b4e4691128df018833e99f90bcd36152672"
+dependencies = [
+ "block2",
+ "dispatch2",
+ "glib-sys",
+ "gobject-sys",
+ "gtk-sys",
+ "js-sys",
+ "log",
+ "objc2",
+ "objc2-app-kit",
+ "objc2-core-foundation",
+ "objc2-foundation",
+ "raw-window-handle",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -3393,6 +3419,65 @@ dependencies = [
  "syn 2.0.117",
  "tauri-codegen",
  "tauri-utils",
+]
+
+[[package]]
+name = "tauri-plugin"
+version = "2.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ddde7d51c907b940fb573006cdda9a642d6a7c8153657e88f8a5c3c9290cd4aa"
+dependencies = [
+ "anyhow",
+ "glob",
+ "plist",
+ "schemars 0.8.22",
+ "serde",
+ "serde_json",
+ "tauri-utils",
+ "toml 0.9.12+spec-1.1.0",
+ "walkdir",
+]
+
+[[package]]
+name = "tauri-plugin-dialog"
+version = "2.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1fa4150c95ae391946cc8b8f905ab14797427caba3a8a2f79628e956da91809"
+dependencies = [
+ "log",
+ "raw-window-handle",
+ "rfd",
+ "serde",
+ "serde_json",
+ "tauri",
+ "tauri-plugin",
+ "tauri-plugin-fs",
+ "thiserror 2.0.18",
+ "url",
+]
+
+[[package]]
+name = "tauri-plugin-fs"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "36e1ec28b79f3d0683f4507e1615c36292c0ea6716668770d4396b9b39871ed8"
+dependencies = [
+ "anyhow",
+ "dunce",
+ "glob",
+ "log",
+ "objc2-foundation",
+ "percent-encoding",
+ "schemars 0.8.22",
+ "serde",
+ "serde_json",
+ "serde_repr",
+ "tauri",
+ "tauri-plugin",
+ "tauri-utils",
+ "thiserror 2.0.18",
+ "toml 0.9.12+spec-1.1.0",
+ "url",
 ]
 
 [[package]]

--- a/apps/desktop/src-tauri/Cargo.toml
+++ b/apps/desktop/src-tauri/Cargo.toml
@@ -13,4 +13,5 @@ anyhow = "1"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 tauri = { version = "2.0.0", features = [] }
+tauri-plugin-dialog = "2.0.0"
 tokio = { version = "1", features = ["fs", "io-util", "rt", "sync"] }

--- a/apps/desktop/src-tauri/capabilities/default.json
+++ b/apps/desktop/src-tauri/capabilities/default.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "../gen/schemas/desktop-schema.json",
+  "identifier": "desktop-default",
+  "description": "Capability for the main desktop window.",
+  "windows": ["main"],
+  "permissions": ["core:default", "dialog:allow-open"]
+}

--- a/apps/desktop/src-tauri/src/main.rs
+++ b/apps/desktop/src-tauri/src/main.rs
@@ -388,6 +388,7 @@ async fn delete_markdown_note(
 fn main() {
     if let Err(error) = tauri::Builder::default()
         .manage(WorkspaceRegistryMutationLock::default())
+        .plugin(tauri_plugin_dialog::init())
         .invoke_handler(tauri::generate_handler![
             add_workspace,
             create_markdown_note,

--- a/apps/desktop/src/features/folder-navigation/model/workspaceFolderPicker.test.ts
+++ b/apps/desktop/src/features/folder-navigation/model/workspaceFolderPicker.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from "vitest";
+
+import { chooseWorkspaceFolder } from "./workspaceFolderPicker";
+
+describe("chooseWorkspaceFolder", () => {
+  it("returns the selected folder path", async () => {
+    await expect(chooseWorkspaceFolder(async () => "/Users/me/Notes")).resolves.toEqual({
+      errorMessage: null,
+      path: "/Users/me/Notes",
+    });
+  });
+
+  it("leaves the path unchanged when folder selection is cancelled", async () => {
+    await expect(chooseWorkspaceFolder(async () => null)).resolves.toEqual({
+      errorMessage: null,
+      path: null,
+    });
+  });
+
+  it("returns a user-facing error when the native folder picker fails", async () => {
+    await expect(
+      chooseWorkspaceFolder(async () => {
+        throw new Error("Dialog unavailable");
+      }),
+    ).resolves.toEqual({
+      errorMessage: "Dialog unavailable",
+      path: null,
+    });
+  });
+});

--- a/apps/desktop/src/features/folder-navigation/model/workspaceFolderPicker.ts
+++ b/apps/desktop/src/features/folder-navigation/model/workspaceFolderPicker.ts
@@ -1,0 +1,22 @@
+export type WorkspaceFolderPicker = () => Promise<string | null>;
+
+type WorkspaceFolderChoice = {
+  path: string | null;
+  errorMessage: string | null;
+};
+
+export async function chooseWorkspaceFolder(
+  pickWorkspaceFolder: WorkspaceFolderPicker,
+): Promise<WorkspaceFolderChoice> {
+  try {
+    return {
+      path: await pickWorkspaceFolder(),
+      errorMessage: null,
+    };
+  } catch (error) {
+    return {
+      path: null,
+      errorMessage: error instanceof Error ? error.message : "Failed to choose a workspace folder.",
+    };
+  }
+}

--- a/apps/desktop/src/features/folder-navigation/ui/FolderNavigationWorkspace.test.tsx
+++ b/apps/desktop/src/features/folder-navigation/ui/FolderNavigationWorkspace.test.tsx
@@ -341,6 +341,17 @@ describe("WorkspaceSetupRequired", () => {
     expect(markup).toContain("Create workspace");
     expect(markup).not.toContain("Create note");
   });
+
+  it("offers the native folder picker from the setup form", () => {
+    const markup = renderToStaticMarkup(
+      <WorkspaceSetupRequired
+        loadState={{ status: "ready", errorMessage: null }}
+        onAddWorkspace={() => Promise.resolve()}
+      />,
+    );
+
+    expect(markup).toContain("Choose folder");
+  });
 });
 
 describe("WorkspaceSetupLoading", () => {

--- a/apps/desktop/src/features/folder-navigation/ui/WorkspaceControls.tsx
+++ b/apps/desktop/src/features/folder-navigation/ui/WorkspaceControls.tsx
@@ -1,8 +1,9 @@
 import { appName } from "@grove/core";
 import { useId, useState } from "react";
 
-import type { DesktopWorkspace } from "../../../shared";
+import { selectWorkspaceFolder, type DesktopWorkspace } from "../../../shared";
 import type { WorkspaceLoadState } from "../model/useWorkspaceStore";
+import { chooseWorkspaceFolder } from "../model/workspaceFolderPicker";
 
 type WorkspaceSwitcherSlice = {
   activeWorkspaceName: string;
@@ -24,6 +25,10 @@ type PopoverView = "list" | "add" | "settings";
 type PopoverOperationState = {
   status: "idle" | "pending" | "failed";
   errorMessage: string | null;
+};
+
+type FolderPickerState = {
+  status: "idle" | "choosing";
 };
 
 type WorkspaceSetupFormProps = {
@@ -134,11 +139,15 @@ function WorkspaceSetupForm({
     status: "idle",
     errorMessage: null,
   });
+  const [folderPicker, setFolderPicker] = useState<FolderPickerState>({
+    status: "idle",
+  });
   const formId = useId();
   const [name, setName] = useState("");
   const [rootPath, setRootPath] = useState("");
   const nameInputId = `${formId}-workspace-name`;
   const pathInputId = `${formId}-workspace-path`;
+  const isBusy = operation.status === "pending" || folderPicker.status === "choosing";
 
   async function handleAdd(): Promise<void> {
     if (switchBlockedReason !== null) {
@@ -155,6 +164,22 @@ function WorkspaceSetupForm({
         status: "failed",
         errorMessage: error instanceof Error ? error.message : "Failed to add workspace.",
       });
+    }
+  }
+
+  async function handleChooseFolder(): Promise<void> {
+    setFolderPicker({ status: "choosing" });
+    setOperation((currentOperation) => ({ ...currentOperation, errorMessage: null }));
+    const choice = await chooseWorkspaceFolder(selectWorkspaceFolder);
+    setFolderPicker({ status: "idle" });
+
+    if (choice.errorMessage !== null) {
+      setOperation({ status: "failed", errorMessage: choice.errorMessage });
+      return;
+    }
+
+    if (choice.path !== null) {
+      setRootPath(choice.path);
     }
   }
 
@@ -175,7 +200,7 @@ function WorkspaceSetupForm({
         value={name}
         onChange={(event) => setName(event.target.value)}
         placeholder="My Notes"
-        disabled={operation.status === "pending"}
+        disabled={isBusy}
       />
       <label className="folder-navigation__label" htmlFor={pathInputId}>
         Folder path
@@ -186,8 +211,18 @@ function WorkspaceSetupForm({
         value={rootPath}
         onChange={(event) => setRootPath(event.target.value)}
         placeholder="/Users/you/Notes"
-        disabled={operation.status === "pending"}
+        disabled={isBusy}
       />
+      <button
+        type="button"
+        className="folder-navigation__secondary-action"
+        onClick={() => {
+          void handleChooseFolder();
+        }}
+        disabled={isBusy}
+      >
+        {folderPicker.status === "choosing" ? "Choosing..." : "Choose folder"}
+      </button>
       {operation.errorMessage !== null ? (
         <p className="folder-navigation__step-error">{operation.errorMessage}</p>
       ) : null}
@@ -196,10 +231,7 @@ function WorkspaceSetupForm({
           type="submit"
           className="folder-navigation__action"
           disabled={
-            switchBlockedReason !== null ||
-            operation.status === "pending" ||
-            name.trim() === "" ||
-            rootPath.trim() === ""
+            switchBlockedReason !== null || isBusy || name.trim() === "" || rootPath.trim() === ""
           }
         >
           {operation.status === "pending" ? pendingLabel : submitLabel}

--- a/apps/desktop/src/shared/api/dialog.test.ts
+++ b/apps/desktop/src/shared/api/dialog.test.ts
@@ -1,0 +1,17 @@
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+describe("desktop dialog permissions", () => {
+  it("grants the native folder picker permission to the main window", () => {
+    const capabilityPath = resolve("src-tauri/capabilities/default.json");
+    const capability = JSON.parse(readFileSync(capabilityPath, "utf8")) as {
+      permissions?: unknown;
+      windows?: unknown;
+    };
+
+    expect(capability.windows).toContain("main");
+    expect(capability.permissions).toContain("dialog:allow-open");
+  });
+});

--- a/apps/desktop/src/shared/api/dialog.ts
+++ b/apps/desktop/src/shared/api/dialog.ts
@@ -1,0 +1,11 @@
+import { open } from "@tauri-apps/plugin-dialog";
+
+export async function selectWorkspaceFolder(): Promise<string | null> {
+  const selectedPath = await open({
+    directory: true,
+    multiple: false,
+    title: "Choose workspace folder",
+  });
+
+  return typeof selectedPath === "string" ? selectedPath : null;
+}

--- a/apps/desktop/src/shared/index.ts
+++ b/apps/desktop/src/shared/index.ts
@@ -27,4 +27,5 @@ export type {
   SwitchWorkspaceCommand,
   WriteMarkdownNoteCommand,
 } from "./api/commands";
+export { selectWorkspaceFolder } from "./api/dialog";
 export { ShellCard } from "./ui/ShellCard";

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -44,6 +44,9 @@ importers:
       '@tauri-apps/api':
         specifier: ^2.0.0
         version: 2.10.1
+      '@tauri-apps/plugin-dialog':
+        specifier: ^2.0.0
+        version: 2.7.0
       react:
         specifier: ^19.0.0
         version: 19.2.5
@@ -1611,6 +1614,9 @@ packages:
     engines: {node: '>= 10'}
     hasBin: true
 
+  '@tauri-apps/plugin-dialog@2.7.0':
+    resolution: {integrity: sha512-4nS/hfGMGCXiAS3LtVjH9AgsSAPJeG/7R+q8agTFqytjnMa4Zq95Bq8WzVDkckpanX+yyRHXnRtrKXkANKDHvw==}
+
   '@turbo/darwin-64@2.9.6':
     resolution: {integrity: sha512-X/56SnVXIQZBLKwniGTwEQTGmtE5brSACnKMBWpY3YafuxVYefrC2acamfjgxP7BG5w3I+6jf0UrLoSzgPcSJg==}
     cpu: [x64]
@@ -1748,6 +1754,7 @@ packages:
   '@xmldom/xmldom@0.8.12':
     resolution: {integrity: sha512-9k/gHF6n/pAi/9tqr3m3aqkuiNosYTurLLUtc7xQ9sxB/wm7WPygCv8GYa6mS0fLJEHhqMC1ATYhz++U/lRHqg==}
     engines: {node: '>=10.0.0'}
+    deprecated: this version has critical issues, please update to the latest version
 
   abort-controller@3.0.0:
     resolution: {integrity: sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==}
@@ -5794,6 +5801,10 @@ snapshots:
       '@tauri-apps/cli-win32-arm64-msvc': 2.10.1
       '@tauri-apps/cli-win32-ia32-msvc': 2.10.1
       '@tauri-apps/cli-win32-x64-msvc': 2.10.1
+
+  '@tauri-apps/plugin-dialog@2.7.0':
+    dependencies:
+      '@tauri-apps/api': 2.10.1
 
   '@turbo/darwin-64@2.9.6':
     optional: true


### PR DESCRIPTION
## Summary
- add Tauri dialog plugin support for native desktop folder selection
- add a Choose folder action to workspace setup/add forms while preserving manual path entry
- keep picker cancellation non-destructive and surface picker failures inline
- add focused coverage for picker selection, cancellation, failure, and setup form affordance

## Testing
- pnpm --filter @grove/desktop test -- workspaceFolderPicker.test.ts
- pnpm --filter @grove/desktop test -- FolderNavigationWorkspace.test.tsx
- pnpm --filter @grove/desktop typecheck
- pnpm --filter @grove/desktop build
- pnpm --filter @grove/desktop test
- pnpm test
- pnpm typecheck
- pnpm lint
- pnpm exec oxfmt --check apps/desktop/src/features/folder-navigation/model/workspaceFolderPicker.test.ts apps/desktop/src/features/folder-navigation/model/workspaceFolderPicker.ts apps/desktop/src/features/folder-navigation/ui/WorkspaceControls.tsx apps/desktop/src/features/folder-navigation/ui/FolderNavigationWorkspace.test.tsx apps/desktop/src/shared/api/dialog.ts apps/desktop/src/shared/index.ts
- git diff --check
- git diff --cached --check
- pnpm --filter @grove/desktop tauri:build

Note: root `pnpm format` currently also checks unrelated untracked local files under `docs/superpowers/plans/2026-04-19-issue-75-contextual-actions.md` and `tmp/`; changed files were checked with `pnpm exec oxfmt --check`.

Refs #91
