### PR TITLE
Simplify desktop note creation and add folder creation

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -17,6 +17,7 @@
     "@grove/plugin-api": "workspace:*",
     "@tanstack/react-router": "^1.168.21",
     "@tauri-apps/api": "^2.0.0",
+    "@tauri-apps/plugin-dialog": "^2.0.0",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
     "zustand": "^5.0.12"

--- a/apps/desktop/src-tauri/Cargo.lock
+++ b/apps/desktop/src-tauri/Cargo.lock
@@ -1160,6 +1160,7 @@ dependencies = [
  "serde_json",
  "tauri",
  "tauri-build",
+ "tauri-plugin-dialog",
  "tokio",
 ]
 
@@ -2021,6 +2022,7 @@ checksum = "e3e0adef53c21f888deb4fa59fc59f7eb17404926ee8a6f59f5df0fd7f9f3272"
 dependencies = [
  "bitflags 2.11.0",
  "block2",
+ "libc",
  "objc2",
  "objc2-core-foundation",
 ]
@@ -2691,6 +2693,30 @@ dependencies = [
  "wasm-bindgen-futures",
  "wasm-streams",
  "web-sys",
+]
+
+[[package]]
+name = "rfd"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a15ad77d9e70a92437d8f74c35d99b4e4691128df018833e99f90bcd36152672"
+dependencies = [
+ "block2",
+ "dispatch2",
+ "glib-sys",
+ "gobject-sys",
+ "gtk-sys",
+ "js-sys",
+ "log",
+ "objc2",
+ "objc2-app-kit",
+ "objc2-core-foundation",
+ "objc2-foundation",
+ "raw-window-handle",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -3393,6 +3419,65 @@ dependencies = [
  "syn 2.0.117",
  "tauri-codegen",
  "tauri-utils",
+]
+
+[[package]]
+name = "tauri-plugin"
+version = "2.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ddde7d51c907b940fb573006cdda9a642d6a7c8153657e88f8a5c3c9290cd4aa"
+dependencies = [
+ "anyhow",
+ "glob",
+ "plist",
+ "schemars 0.8.22",
+ "serde",
+ "serde_json",
+ "tauri-utils",
+ "toml 0.9.12+spec-1.1.0",
+ "walkdir",
+]
+
+[[package]]
+name = "tauri-plugin-dialog"
+version = "2.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1fa4150c95ae391946cc8b8f905ab14797427caba3a8a2f79628e956da91809"
+dependencies = [
+ "log",
+ "raw-window-handle",
+ "rfd",
+ "serde",
+ "serde_json",
+ "tauri",
+ "tauri-plugin",
+ "tauri-plugin-fs",
+ "thiserror 2.0.18",
+ "url",
+]
+
+[[package]]
+name = "tauri-plugin-fs"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "36e1ec28b79f3d0683f4507e1615c36292c0ea6716668770d4396b9b39871ed8"
+dependencies = [
+ "anyhow",
+ "dunce",
+ "glob",
+ "log",
+ "objc2-foundation",
+ "percent-encoding",
+ "schemars 0.8.22",
+ "serde",
+ "serde_json",
+ "serde_repr",
+ "tauri",
+ "tauri-plugin",
+ "tauri-utils",
+ "thiserror 2.0.18",
+ "toml 0.9.12+spec-1.1.0",
+ "url",
 ]
 
 [[package]]

--- a/apps/desktop/src-tauri/Cargo.toml
+++ b/apps/desktop/src-tauri/Cargo.toml
@@ -13,4 +13,5 @@ anyhow = "1"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 tauri = { version = "2.0.0", features = [] }
+tauri-plugin-dialog = "2.0.0"
 tokio = { version = "1", features = ["fs", "io-util", "rt", "sync"] }

--- a/apps/desktop/src-tauri/capabilities/default.json
+++ b/apps/desktop/src-tauri/capabilities/default.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "../gen/schemas/desktop-schema.json",
+  "identifier": "desktop-default",
+  "description": "Capability for the main desktop window.",
+  "windows": ["main"],
+  "permissions": ["core:default", "dialog:allow-open"]
+}

--- a/apps/desktop/src-tauri/src/main.rs
+++ b/apps/desktop/src-tauri/src/main.rs
@@ -989,7 +989,6 @@ async fn scan_workspace_folders(workspace_root: &Path) -> anyhow::Result<Vec<Str
 
     while let Some(directory) = pending_dirs.pop() {
         let mut entries = tokio::fs::read_dir(&directory).await?;
-        let mut has_visible_entries = false;
 
         while let Some(entry) = entries.next_entry().await? {
             let file_name = entry.file_name();
@@ -999,14 +998,12 @@ async fn scan_workspace_folders(workspace_root: &Path) -> anyhow::Result<Vec<Str
                 continue;
             }
 
-            has_visible_entries = true;
-
             if entry.file_type().await?.is_dir() {
                 pending_dirs.push(entry.path());
             }
         }
 
-        if directory != workspace_root && !has_visible_entries {
+        if directory != workspace_root {
             let relative_path = directory.strip_prefix(workspace_root)?;
             folders.push(relative_path_to_workspace_path(relative_path)?);
         }
@@ -1803,11 +1800,29 @@ mod tests {
 
             let folders = scan_workspace_folders(&workspace_dir).await?;
 
-            assert_eq!(folders, vec!["Projects/Ideas"]);
+            assert_eq!(folders, vec!["Projects", "Projects/Ideas"]);
             tokio::fs::remove_dir_all(&workspace_dir).await?;
             anyhow::Ok(())
         })
         .expect("workspace folder scan should succeed");
+    }
+
+    #[test]
+    fn scans_folders_that_only_contain_non_markdown_files() {
+        run_async(async {
+            let workspace_dir = unique_test_dir("scans-asset-only-folders");
+            let asset_folder_path = workspace_dir.join("Projects").join("Assets");
+            let asset_path = asset_folder_path.join("logo.png");
+            tokio::fs::create_dir_all(&asset_folder_path).await?;
+            tokio::fs::write(&asset_path, "png").await?;
+
+            let folders = scan_workspace_folders(&workspace_dir).await?;
+
+            assert_eq!(folders, vec!["Projects", "Projects/Assets"]);
+            tokio::fs::remove_dir_all(&workspace_dir).await?;
+            anyhow::Ok(())
+        })
+        .expect("asset-only folder scan should succeed");
     }
 
     #[test]

--- a/apps/desktop/src-tauri/src/main.rs
+++ b/apps/desktop/src-tauri/src/main.rs
@@ -388,6 +388,7 @@ async fn delete_markdown_note(
 fn main() {
     if let Err(error) = tauri::Builder::default()
         .manage(WorkspaceRegistryMutationLock::default())
+        .plugin(tauri_plugin_dialog::init())
         .invoke_handler(tauri::generate_handler![
             add_workspace,
             create_markdown_note,

--- a/apps/desktop/src-tauri/src/main.rs
+++ b/apps/desktop/src-tauri/src/main.rs
@@ -41,6 +41,12 @@ struct CreateMarkdownNoteRequest {
 
 #[derive(Debug, Deserialize)]
 #[serde(rename_all = "camelCase")]
+struct CreateMarkdownFolderRequest {
+    path: String,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
 struct WriteMarkdownNoteRequest {
     path: String,
     content: String,
@@ -306,6 +312,26 @@ async fn scan_markdown_workspace(
 }
 
 #[tauri::command]
+async fn scan_markdown_folders(
+    app_handle: tauri::AppHandle,
+    lock: tauri::State<'_, WorkspaceRegistryMutationLock>,
+) -> Result<Vec<String>, CommandError> {
+    let workspace_root = run_locked_workspace_registry_mutation(lock.inner(), || async {
+        active_workspace_root(&app_handle).await
+    })
+    .await
+    .map_err(|error| CommandError::new("workspace_scan_failed", error.to_string()))?;
+
+    tokio::fs::create_dir_all(&workspace_root)
+        .await
+        .map_err(|error| CommandError::new("workspace_scan_failed", error.to_string()))?;
+
+    scan_workspace_folders(&workspace_root)
+        .await
+        .map_err(|error| CommandError::new("workspace_scan_failed", error.to_string()))
+}
+
+#[tauri::command]
 async fn read_markdown_note(
     app_handle: tauri::AppHandle,
     lock: tauri::State<'_, WorkspaceRegistryMutationLock>,
@@ -343,6 +369,24 @@ async fn create_markdown_note(
     summarize_markdown_file(&workspace_root, &note_path)
         .await
         .map_err(|error| CommandError::new("note_create_failed", error.to_string()))
+}
+
+#[tauri::command]
+async fn create_markdown_folder(
+    app_handle: tauri::AppHandle,
+    lock: tauri::State<'_, WorkspaceRegistryMutationLock>,
+    folder: CreateMarkdownFolderRequest,
+) -> Result<(), CommandError> {
+    let workspace_root = run_locked_workspace_registry_mutation(lock.inner(), || async {
+        active_workspace_root(&app_handle).await
+    })
+    .await
+    .map_err(|error| CommandError::new("folder_create_failed", error.to_string()))?;
+    let folder_path = resolve_folder_path(&workspace_root, &folder.path)?;
+
+    create_workspace_folder(&folder_path)
+        .await
+        .map_err(|error| CommandError::new("folder_create_failed", error.to_string()))
 }
 
 #[tauri::command]
@@ -391,6 +435,7 @@ fn main() {
         .plugin(tauri_plugin_dialog::init())
         .invoke_handler(tauri::generate_handler![
             add_workspace,
+            create_markdown_folder,
             create_markdown_note,
             delete_markdown_note,
             get_active_workspace,
@@ -400,6 +445,7 @@ fn main() {
             refresh_note_indexes,
             remove_workspace,
             rename_workspace,
+            scan_markdown_folders,
             scan_markdown_workspace,
             switch_workspace,
             write_markdown_note
@@ -815,6 +861,11 @@ fn resolve_markdown_path(workspace_root: &Path, path: &str) -> Result<PathBuf, C
     Ok(workspace_root.join(path))
 }
 
+fn resolve_folder_path(workspace_root: &Path, path: &str) -> Result<PathBuf, CommandError> {
+    validate_folder_path(path)?;
+    Ok(workspace_root.join(path))
+}
+
 fn validate_markdown_path(path: &str) -> Result<(), CommandError> {
     if has_windows_drive_prefix(path) {
         return Err(CommandError::new(
@@ -862,6 +913,42 @@ fn validate_markdown_path(path: &str) -> Result<(), CommandError> {
     Ok(())
 }
 
+fn validate_folder_path(path: &str) -> Result<(), CommandError> {
+    if has_windows_drive_prefix(path) {
+        return Err(CommandError::new(
+            "invalid_folder_path",
+            "Folder paths must not include a drive prefix.",
+        ));
+    }
+
+    if path.contains('\\') {
+        return Err(CommandError::new(
+            "invalid_folder_path",
+            "Folder paths must use workspace separators.",
+        ));
+    }
+
+    let folder_path = Path::new(path);
+
+    if folder_path.components().next().is_none() {
+        return Err(CommandError::new(
+            "invalid_folder_path",
+            "Folder paths cannot be empty.",
+        ));
+    }
+
+    for component in folder_path.components() {
+        if !matches!(component, Component::Normal(_)) {
+            return Err(CommandError::new(
+                "invalid_folder_path",
+                "Folder paths must stay inside the workspace.",
+            ));
+        }
+    }
+
+    Ok(())
+}
+
 fn has_windows_drive_prefix(path: &str) -> bool {
     let path_bytes = path.as_bytes();
 
@@ -894,6 +981,39 @@ async fn scan_markdown_files(workspace_root: &Path) -> anyhow::Result<Vec<Scanne
 
     notes.sort_by(|left, right| left.path.to_lowercase().cmp(&right.path.to_lowercase()));
     Ok(notes)
+}
+
+async fn scan_workspace_folders(workspace_root: &Path) -> anyhow::Result<Vec<String>> {
+    let mut pending_dirs = vec![workspace_root.to_path_buf()];
+    let mut folders = Vec::new();
+
+    while let Some(directory) = pending_dirs.pop() {
+        let mut entries = tokio::fs::read_dir(&directory).await?;
+        let mut has_visible_entries = false;
+
+        while let Some(entry) = entries.next_entry().await? {
+            let file_name = entry.file_name();
+            let file_name = file_name.to_string_lossy();
+
+            if file_name.starts_with('.') {
+                continue;
+            }
+
+            has_visible_entries = true;
+
+            if entry.file_type().await?.is_dir() {
+                pending_dirs.push(entry.path());
+            }
+        }
+
+        if directory != workspace_root && !has_visible_entries {
+            let relative_path = directory.strip_prefix(workspace_root)?;
+            folders.push(relative_path_to_workspace_path(relative_path)?);
+        }
+    }
+
+    folders.sort_by_key(|path| path.to_lowercase());
+    Ok(folders)
 }
 
 fn get_workspace_relative_markdown_path(
@@ -1008,6 +1128,19 @@ async fn create_markdown_file(path: &Path, content: &[u8]) -> anyhow::Result<()>
     }
 
     write_result
+}
+
+async fn create_workspace_folder(path: &Path) -> anyhow::Result<()> {
+    if tokio::fs::try_exists(path).await? {
+        anyhow::bail!("The target folder already exists: {}", path.display());
+    }
+
+    if let Some(parent_path) = path.parent() {
+        tokio::fs::create_dir_all(parent_path).await?;
+    }
+
+    tokio::fs::create_dir(path).await?;
+    Ok(())
 }
 
 fn get_temporary_write_path(path: &Path) -> anyhow::Result<PathBuf> {
@@ -1249,11 +1382,12 @@ mod tests {
     };
 
     use super::{
-        add_and_activate_workspace_in_registry, create_markdown_file, delete_markdown_file,
-        derive_markdown_title, find_first_markdown_heading, get_temporary_write_path,
-        get_workspace_relative_markdown_path, load_or_create_workspace_registry,
-        move_file_without_overwrite, read_markdown_file, remove_workspace_from_registry,
-        rename_workspace_in_registry, run_locked_workspace_registry_mutation, scan_markdown_files,
+        add_and_activate_workspace_in_registry, create_markdown_file, create_workspace_folder,
+        delete_markdown_file, derive_markdown_title, find_first_markdown_heading,
+        get_temporary_write_path, get_workspace_relative_markdown_path,
+        load_or_create_workspace_registry, move_file_without_overwrite, read_markdown_file,
+        remove_workspace_from_registry, rename_workspace_in_registry,
+        run_locked_workspace_registry_mutation, scan_markdown_files, scan_workspace_folders,
         system_time_to_unix_ms, validate_markdown_path, write_markdown_file,
         WorkspaceRegistryMutationLock,
     };
@@ -1657,6 +1791,26 @@ mod tests {
     }
 
     #[test]
+    fn scans_empty_workspace_folders_and_ignores_hidden_directories() {
+        run_async(async {
+            let workspace_dir = unique_test_dir("scans-empty-workspace-folders");
+            let empty_folder_path = workspace_dir.join("Projects").join("Ideas");
+            let hidden_folder_path = workspace_dir.join(".obsidian");
+            let note_path = workspace_dir.join("Projects").join("Plan.md");
+            tokio::fs::create_dir_all(&empty_folder_path).await?;
+            tokio::fs::create_dir_all(&hidden_folder_path).await?;
+            tokio::fs::write(&note_path, "# Plan").await?;
+
+            let folders = scan_workspace_folders(&workspace_dir).await?;
+
+            assert_eq!(folders, vec!["Projects/Ideas"]);
+            tokio::fs::remove_dir_all(&workspace_dir).await?;
+            anyhow::Ok(())
+        })
+        .expect("workspace folder scan should succeed");
+    }
+
+    #[test]
     fn reads_markdown_file_content() {
         run_async(async {
             let workspace_dir = unique_test_dir("reads-markdown-file-content");
@@ -1740,6 +1894,39 @@ mod tests {
             anyhow::Ok(())
         })
         .expect("Markdown create collision test should run");
+    }
+
+    #[test]
+    fn creates_new_workspace_folders_without_overwriting_existing_paths() {
+        run_async(async {
+            let workspace_dir = unique_test_dir("creates-new-workspace-folders");
+            let folder_path = workspace_dir.join("Projects").join("Ideas");
+
+            create_workspace_folder(&folder_path).await?;
+
+            assert!(tokio::fs::try_exists(&folder_path).await?);
+            tokio::fs::remove_dir_all(&workspace_dir).await?;
+            anyhow::Ok(())
+        })
+        .expect("workspace folder create should succeed");
+    }
+
+    #[test]
+    fn rejects_new_workspace_folders_when_the_target_exists() {
+        run_async(async {
+            let workspace_dir = unique_test_dir("rejects-existing-folder-create-target");
+            let folder_path = workspace_dir.join("Projects").join("Ideas");
+            tokio::fs::create_dir_all(&folder_path).await?;
+
+            let error = create_workspace_folder(&folder_path)
+                .await
+                .expect_err("existing folder target should be rejected");
+
+            assert!(error.to_string().contains("already exists"));
+            tokio::fs::remove_dir_all(&workspace_dir).await?;
+            anyhow::Ok(())
+        })
+        .expect("workspace folder create collision test should run");
     }
 
     #[test]

--- a/apps/desktop/src/features/folder-navigation/model/folderWorkspaceState.test.ts
+++ b/apps/desktop/src/features/folder-navigation/model/folderWorkspaceState.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from "vitest";
 import { normalizeFolderPath, normalizeNoteFilePath } from "@grove/core";
 import type { FolderWorkspaceState } from "./folderWorkspaceState";
 import {
+  addExplicitFolderToWorkspace,
   clearCompletedPathChangeOperations,
   completeNextOperationStep,
   createPathChangeOperation,
@@ -115,6 +116,38 @@ describe("moveNoteInFolderWorkspace", () => {
         normalizeFolderPath("Reading"),
       ),
     ).toThrow("target Markdown path");
+  });
+});
+
+describe("addExplicitFolderToWorkspace", () => {
+  it("adds a new empty folder, expands its ancestors, and selects it", () => {
+    const result = addExplicitFolderToWorkspace(
+      workspaceState,
+      normalizeFolderPath("Projects/Grove/Ideas/Inbox"),
+    );
+
+    expect(result.explicitFolders).toStrictEqual([
+      "Projects/Grove/Ideas",
+      "Projects/Grove/Ideas/Inbox",
+      "Reading",
+    ]);
+    expect(result.expandedFolderPaths).toStrictEqual([
+      "Projects",
+      "Projects/Grove",
+      "Projects/Grove/Ideas",
+      "Projects/Grove/Research",
+    ]);
+    expect(result.selectedFolderPath).toBe("Projects/Grove/Ideas/Inbox");
+  });
+
+  it("does not duplicate an existing explicit folder", () => {
+    const result = addExplicitFolderToWorkspace(
+      workspaceState,
+      normalizeFolderPath("Reading"),
+    );
+
+    expect(result.explicitFolders).toStrictEqual(workspaceState.explicitFolders);
+    expect(result.selectedFolderPath).toBe("Reading");
   });
 });
 

--- a/apps/desktop/src/features/folder-navigation/model/folderWorkspaceState.ts
+++ b/apps/desktop/src/features/folder-navigation/model/folderWorkspaceState.ts
@@ -366,6 +366,21 @@ export function reconcileFolderWorkspaceState(state: FolderWorkspaceState): Fold
   };
 }
 
+export function addExplicitFolderToWorkspace(
+  state: FolderWorkspaceState,
+  folderPath: FolderPath,
+): FolderWorkspaceState {
+  return reconcileFolderWorkspaceState({
+    ...state,
+    explicitFolders: dedupeAndSortFolderPaths([...state.explicitFolders, folderPath]),
+    expandedFolderPaths: dedupeExpandedFolderPaths([
+      ...state.expandedFolderPaths,
+      ...getFolderPathAncestors(folderPath),
+    ]),
+    selectedFolderPath: folderPath,
+  });
+}
+
 export function moveNoteInFolderWorkspace(
   state: FolderWorkspaceState,
   noteId: string,

--- a/apps/desktop/src/features/folder-navigation/model/workspaceFolderPicker.test.ts
+++ b/apps/desktop/src/features/folder-navigation/model/workspaceFolderPicker.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from "vitest";
+
+import { chooseWorkspaceFolder } from "./workspaceFolderPicker";
+
+describe("chooseWorkspaceFolder", () => {
+  it("returns the selected folder path", async () => {
+    await expect(chooseWorkspaceFolder(async () => "/Users/me/Notes")).resolves.toEqual({
+      errorMessage: null,
+      path: "/Users/me/Notes",
+    });
+  });
+
+  it("leaves the path unchanged when folder selection is cancelled", async () => {
+    await expect(chooseWorkspaceFolder(async () => null)).resolves.toEqual({
+      errorMessage: null,
+      path: null,
+    });
+  });
+
+  it("returns a user-facing error when the native folder picker fails", async () => {
+    await expect(
+      chooseWorkspaceFolder(async () => {
+        throw new Error("Dialog unavailable");
+      }),
+    ).resolves.toEqual({
+      errorMessage: "Dialog unavailable",
+      path: null,
+    });
+  });
+});

--- a/apps/desktop/src/features/folder-navigation/model/workspaceFolderPicker.ts
+++ b/apps/desktop/src/features/folder-navigation/model/workspaceFolderPicker.ts
@@ -1,0 +1,22 @@
+export type WorkspaceFolderPicker = () => Promise<string | null>;
+
+type WorkspaceFolderChoice = {
+  path: string | null;
+  errorMessage: string | null;
+};
+
+export async function chooseWorkspaceFolder(
+  pickWorkspaceFolder: WorkspaceFolderPicker,
+): Promise<WorkspaceFolderChoice> {
+  try {
+    return {
+      path: await pickWorkspaceFolder(),
+      errorMessage: null,
+    };
+  } catch (error) {
+    return {
+      path: null,
+      errorMessage: error instanceof Error ? error.message : "Failed to choose a workspace folder.",
+    };
+  }
+}

--- a/apps/desktop/src/features/folder-navigation/ui/FolderNavigationWorkspace.test.tsx
+++ b/apps/desktop/src/features/folder-navigation/ui/FolderNavigationWorkspace.test.tsx
@@ -341,6 +341,17 @@ describe("WorkspaceSetupRequired", () => {
     expect(markup).toContain("Create workspace");
     expect(markup).not.toContain("Create note");
   });
+
+  it("offers the native folder picker from the setup form", () => {
+    const markup = renderToStaticMarkup(
+      <WorkspaceSetupRequired
+        loadState={{ status: "ready", errorMessage: null }}
+        onAddWorkspace={() => Promise.resolve()}
+      />,
+    );
+
+    expect(markup).toContain("Choose folder");
+  });
 });
 
 describe("WorkspaceSetupLoading", () => {

--- a/apps/desktop/src/features/folder-navigation/ui/FolderNavigationWorkspace.test.tsx
+++ b/apps/desktop/src/features/folder-navigation/ui/FolderNavigationWorkspace.test.tsx
@@ -13,6 +13,7 @@ import {
   ActivePane,
   FolderNavigationWorkspaceContent,
   NavigationPane,
+  canRenameSelectedFolder,
   getFolderNavigationWorkspaceClassName,
   getInitialNoteContent,
   getScanStateWithoutActiveWorkspace,
@@ -45,6 +46,25 @@ describe("FolderNavigationWorkspaceContent", () => {
 describe("getInitialNoteContent", () => {
   it("creates new notes with an empty body", () => {
     expect(getInitialNoteContent()).toBe("");
+  });
+});
+
+describe("canRenameSelectedFolder", () => {
+  it("requires at least one Markdown note in the selected folder scope", () => {
+    expect(
+      canRenameSelectedFolder(
+        [
+          {
+            id: "note-plan",
+            path: normalizeNoteFilePath("Projects/Grove/Plan.md"),
+            title: "Plan",
+            tags: [],
+            updatedLabel: "Apr 19",
+          },
+        ],
+        normalizeFolderPath("Projects/Grove/Ideas"),
+      ),
+    ).toBe(false);
   });
 });
 
@@ -723,6 +743,25 @@ describe("ActivePane", () => {
     expect(markup).toContain("Rename selected folder");
     expect(markup).toContain(
       "Path changes refresh the folder tree and note list immediately. File and index work runs in the background.",
+    );
+  });
+
+  it("disables folder rename when the selected folder has no Markdown notes", () => {
+    const markup = renderActivePaneMarkup({
+      notes: [],
+      folderOptions: [],
+      selectedFolderPath: normalizeFolderPath("Projects/Grove/Ideas"),
+      selectedNoteId: "",
+      selectedNoteLinks: [],
+      selectedNoteBacklinks: [],
+      noteTitlesById: new Map(),
+      initialFolderActionsOpen: true,
+    });
+
+    expect(markup).toContain("Rename selected folder");
+    expect(markup).toContain("Only folders with Markdown notes can be renamed right now.");
+    expect(markup).toMatch(
+      /<button type="button" class="folder-navigation__action" disabled="">Rename folder<\/button>/,
     );
   });
 

--- a/apps/desktop/src/features/folder-navigation/ui/FolderNavigationWorkspace.test.tsx
+++ b/apps/desktop/src/features/folder-navigation/ui/FolderNavigationWorkspace.test.tsx
@@ -14,6 +14,7 @@ import {
   FolderNavigationWorkspaceContent,
   NavigationPane,
   getFolderNavigationWorkspaceClassName,
+  getInitialNoteContent,
   getScanStateWithoutActiveWorkspace,
   getWorkspaceSwitchBlockedReason,
   getWorkspaceViewPhase,
@@ -38,6 +39,12 @@ describe("FolderNavigationWorkspaceContent", () => {
     expect(markup).toContain("Loading workspace");
     expect(markup).not.toContain("Create note");
     expect(markup).not.toContain("folder-navigation__navigation");
+  });
+});
+
+describe("getInitialNoteContent", () => {
+  it("creates new notes with an empty body", () => {
+    expect(getInitialNoteContent()).toBe("");
   });
 });
 
@@ -80,11 +87,9 @@ describe("NavigationPane", () => {
         selectedNoteId="note-plan"
         scanState={{ status: "ready", errorMessage: null }}
         createState={{ status: "idle", errorMessage: null }}
-        createTitle=""
         searchQuery=""
         searchIndexState={{ status: "ready" }}
         restrictSearchToSelectedFolder={false}
-        onCreateTitleChange={() => {}}
         onSearchQueryChange={() => {}}
         onRestrictSearchToSelectedFolderChange={() => {}}
         onCreateNote={() => {}}
@@ -117,6 +122,13 @@ describe("NavigationPane", () => {
     expect(markup).toContain("Grove");
     expect(markup).toContain("Plan");
     expect(markup).not.toContain("Journal");
+  });
+
+  it("creates notes without showing a separate title input", () => {
+    const markup = renderNavigationPaneMarkup();
+
+    expect(markup).toContain("Create note");
+    expect(markup).not.toContain("create-note-title");
   });
 
   it("places the workspace switcher in the Library column", () => {
@@ -546,6 +558,7 @@ describe("ActivePane", () => {
         onMoveSelectedNote={() => {
           throw new Error("not implemented in test");
         }}
+        onCreateFolder={() => Promise.resolve()}
         onRenameSelectedFolder={() => {
           throw new Error("not implemented in test");
         }}
@@ -706,6 +719,7 @@ describe("ActivePane", () => {
   it("shows folder actions when the folder disclosure starts open", () => {
     const markup = renderActivePaneMarkup({ initialFolderActionsOpen: true });
 
+    expect(markup).toContain("Create folder");
     expect(markup).toContain("Rename selected folder");
     expect(markup).toContain(
       "Path changes refresh the folder tree and note list immediately. File and index work runs in the background.",

--- a/apps/desktop/src/features/folder-navigation/ui/FolderNavigationWorkspace.tsx
+++ b/apps/desktop/src/features/folder-navigation/ui/FolderNavigationWorkspace.tsx
@@ -183,6 +183,7 @@ type MoveNoteControlProps = {
 
 type RenameFolderControlProps = {
   selectedFolderPath: FolderScope;
+  canRename: boolean;
   onRenameSelectedFolder: (targetFolderPath: FolderScope) => FolderWorkspaceMutation;
   onOperationMessage: (message: string) => void;
 };
@@ -290,6 +291,15 @@ export function getWorkspaceSwitchBlockedReason(
 
 function getFolderPathLabel(folderPath: FolderScope): string {
   return folderPath === null ? "Workspace root" : folderPath;
+}
+
+export function canRenameSelectedFolder(
+  notes: readonly NoteListItem[],
+  selectedFolderPath: FolderScope,
+): boolean {
+  return (
+    selectedFolderPath !== null && notes.some((note) => isNoteInFolderScope(note.path, selectedFolderPath))
+  );
 }
 
 function flattenFolderTree(folderTree: readonly FolderTreeNode[]): FolderOption[] {
@@ -825,6 +835,7 @@ function MoveNoteControl({
 
 function RenameFolderControl({
   selectedFolderPath,
+  canRename,
   onRenameSelectedFolder,
   onOperationMessage,
 }: RenameFolderControlProps) {
@@ -864,19 +875,24 @@ function RenameFolderControl({
         className="folder-navigation__input"
         value={renameTargetPath}
         onChange={(event) => setRenameTargetPath(event.target.value)}
-        disabled={selectedFolderPath === null}
+        disabled={!canRename}
       />
       <button
         type="button"
         className="folder-navigation__action"
         onClick={renameSelectedFolder}
-        disabled={selectedFolderPath === null}
+        disabled={!canRename}
       >
         Rename folder
       </button>
       <p className="folder-navigation__muted">
         Current folder: {getFolderPathLabel(selectedFolderPath)}
       </p>
+      {canRename ? null : (
+        <p className="folder-navigation__muted">
+          Only folders with Markdown notes can be renamed right now.
+        </p>
+      )}
     </div>
   );
 }
@@ -1144,6 +1160,7 @@ export function ActivePane({
   initialFolderActionsOpen = false,
 }: ActivePaneProps) {
   const selectedNote = notes.find((note) => note.id === selectedNoteId) ?? notes[0];
+  const selectedFolderCanRename = canRenameSelectedFolder(notes, selectedFolderPath);
   const [noteOperationMessage, setNoteOperationMessage] = useState<string>(defaultOperationMessage);
   const [folderOperationMessage, setFolderOperationMessage] =
     useState<string>(defaultOperationMessage);
@@ -1265,6 +1282,7 @@ export function ActivePane({
           />
           <RenameFolderControl
             selectedFolderPath={selectedFolderPath}
+            canRename={selectedFolderCanRename}
             onRenameSelectedFolder={onRenameSelectedFolder}
             onOperationMessage={setFolderOperationMessage}
           />
@@ -1585,6 +1603,10 @@ export function FolderNavigationWorkspaceContent({
   function renameSelectedFolder(targetFolderPath: FolderScope): FolderWorkspaceMutation {
     if (isNoteEditBufferBlockingWorkspaceChange(noteEditBuffer)) {
       throw new Error("Save or discard the current draft before renaming folders.");
+    }
+
+    if (!canRenameSelectedFolder(workspaceState.notes, selectedFolderPath)) {
+      throw new Error("Only folders with Markdown notes can be renamed right now.");
     }
 
     if (selectedFolderPath === null) {

--- a/apps/desktop/src/features/folder-navigation/ui/FolderNavigationWorkspace.tsx
+++ b/apps/desktop/src/features/folder-navigation/ui/FolderNavigationWorkspace.tsx
@@ -24,8 +24,10 @@ import {
 } from "./WorkspaceControls";
 
 import {
+  createMarkdownFolder,
   createMarkdownNote,
   deleteMarkdownNote,
+  listMarkdownFolders,
   moveMarkdownFile,
   readMarkdownNote,
   refreshNoteIndexes,
@@ -33,6 +35,7 @@ import {
   writeMarkdownNote,
 } from "../../../shared";
 import {
+  addExplicitFolderToWorkspace,
   deleteSelectedNoteFromFolderWorkspace,
   getFailedOperationSteps,
   getNextPendingOperationStep,
@@ -121,11 +124,9 @@ type NoteListProps = {
   selectedNoteId: string;
   scanState: WorkspaceScanState;
   createState: NoteCreateState;
-  createTitle: string;
   searchQuery: string;
   searchIndexState: SearchIndexState;
   restrictSearchToSelectedFolder: boolean;
-  onCreateTitleChange: (title: string) => void;
   onSearchQueryChange: (value: string) => void;
   onRestrictSearchToSelectedFolderChange: (checked: boolean) => void;
   onCreateNote: () => void;
@@ -149,6 +150,7 @@ type ActivePaneProps = {
   editorNotice: string | null;
   deleteState: NoteDeleteState;
   onMoveSelectedNote: (targetFolderPath: FolderScope) => FolderWorkspaceMutation;
+  onCreateFolder: (folderName: string) => Promise<void>;
   onRenameSelectedFolder: (targetFolderPath: FolderScope) => FolderWorkspaceMutation;
   onEditContent: (content: string) => void;
   onSaveDraft: () => void;
@@ -182,6 +184,12 @@ type MoveNoteControlProps = {
 type RenameFolderControlProps = {
   selectedFolderPath: FolderScope;
   onRenameSelectedFolder: (targetFolderPath: FolderScope) => FolderWorkspaceMutation;
+  onOperationMessage: (message: string) => void;
+};
+
+type CreateFolderControlProps = {
+  selectedFolderPath: FolderScope;
+  onCreateFolder: (folderName: string) => Promise<void>;
   onOperationMessage: (message: string) => void;
 };
 
@@ -417,6 +425,10 @@ function getNoteDeleteErrorMessage(error: unknown): string {
   return error instanceof Error ? error.message : "The Markdown note could not be deleted.";
 }
 
+export function getInitialNoteContent(): string {
+  return "";
+}
+
 function getNoteIndexRefreshErrorMessage(error: unknown): string {
   return error instanceof Error ? error.message : "The note indexes could not be refreshed.";
 }
@@ -606,11 +618,9 @@ export function NavigationPane({
   selectedNoteId,
   scanState,
   createState,
-  createTitle,
   searchQuery,
   searchIndexState,
   restrictSearchToSelectedFolder,
-  onCreateTitleChange,
   onSearchQueryChange,
   onRestrictSearchToSelectedFolderChange,
   onCreateNote,
@@ -646,11 +656,9 @@ export function NavigationPane({
         selectedNoteId={selectedNoteId}
         scanState={scanState}
         createState={createState}
-        createTitle={createTitle}
         searchQuery={searchQuery}
         searchIndexState={searchIndexState}
         restrictSearchToSelectedFolder={restrictSearchToSelectedFolder}
-        onCreateTitleChange={onCreateTitleChange}
         onSearchQueryChange={onSearchQueryChange}
         onRestrictSearchToSelectedFolderChange={onRestrictSearchToSelectedFolderChange}
         onCreateNote={onCreateNote}
@@ -666,11 +674,9 @@ function NoteList({
   selectedNoteId,
   scanState,
   createState,
-  createTitle,
   searchQuery,
   searchIndexState,
   restrictSearchToSelectedFolder,
-  onCreateTitleChange,
   onSearchQueryChange,
   onRestrictSearchToSelectedFolderChange,
   onCreateNote,
@@ -718,21 +724,11 @@ function NoteList({
         ) : null}
       </div>
       <div className="folder-navigation__operation">
-        <label className="folder-navigation__label" htmlFor="create-note-title">
-          New note
-        </label>
-        <input
-          id="create-note-title"
-          className="folder-navigation__input"
-          value={createTitle}
-          onChange={(event) => onCreateTitleChange(event.target.value)}
-          placeholder={
-            selectedFolderPath === null
-              ? "Untitled"
-              : `Untitled in ${getFolderDisplayName(selectedFolderPath)}`
-          }
-          disabled={createState.status === "creating" || scanState.status === "loading"}
-        />
+        <p className="folder-navigation__label">New note</p>
+        <p className="folder-navigation__muted">
+          Create an untitled note in {getFolderLabel(selectedFolderPath)}. The visible title comes
+          from frontmatter or the first H1.
+        </p>
         <button
           type="button"
           className="folder-navigation__action"
@@ -881,6 +877,62 @@ function RenameFolderControl({
       <p className="folder-navigation__muted">
         Current folder: {getFolderPathLabel(selectedFolderPath)}
       </p>
+    </div>
+  );
+}
+
+function CreateFolderControl({
+  selectedFolderPath,
+  onCreateFolder,
+  onOperationMessage,
+}: CreateFolderControlProps) {
+  const [folderName, setFolderName] = useState("");
+  const [status, setStatus] = useState<"idle" | "creating">("idle");
+
+  async function createFolder(): Promise<void> {
+    const nextFolderName = folderName.trim();
+
+    if (nextFolderName === "") {
+      onOperationMessage("Enter a folder name.");
+      return;
+    }
+
+    setStatus("creating");
+
+    try {
+      await onCreateFolder(nextFolderName);
+      setFolderName("");
+      onOperationMessage(`Created ${getFolderLabel(selectedFolderPath)} folder "${nextFolderName}".`);
+    } catch (error) {
+      onOperationMessage(getErrorMessage(error));
+    } finally {
+      setStatus("idle");
+    }
+  }
+
+  return (
+    <div className="folder-navigation__operation">
+      <label className="folder-navigation__label" htmlFor="create-folder-name">
+        Create folder
+      </label>
+      <input
+        id="create-folder-name"
+        className="folder-navigation__input"
+        value={folderName}
+        onChange={(event) => setFolderName(event.target.value)}
+        placeholder={selectedFolderPath === null ? "Ideas" : `New folder in ${selectedFolderPath}`}
+        disabled={status === "creating"}
+      />
+      <button
+        type="button"
+        className="folder-navigation__action"
+        onClick={() => {
+          void createFolder();
+        }}
+        disabled={status === "creating"}
+      >
+        {status === "creating" ? "Creating" : "Create folder"}
+      </button>
     </div>
   );
 }
@@ -1068,6 +1120,7 @@ export function ActivePane({
   editorNotice,
   deleteState,
   onMoveSelectedNote,
+  onCreateFolder,
   onRenameSelectedFolder,
   onEditContent,
   onSaveDraft,
@@ -1205,6 +1258,11 @@ export function ActivePane({
           />
         ) : null}
         <ActionDisclosure title="Folder actions" initiallyOpen={initialFolderActionsOpen}>
+          <CreateFolderControl
+            selectedFolderPath={selectedFolderPath}
+            onCreateFolder={onCreateFolder}
+            onOperationMessage={setFolderOperationMessage}
+          />
           <RenameFolderControl
             selectedFolderPath={selectedFolderPath}
             onRenameSelectedFolder={onRenameSelectedFolder}
@@ -1344,7 +1402,6 @@ export function FolderNavigationWorkspaceContent({
   const [noteEditBuffer, setNoteEditBuffer] = useState<NoteEditBuffer | null>(null);
   const [editorLoadState, setEditorLoadState] = useState<NoteEditorLoadState>({ status: "idle" });
   const [editorNotice, setEditorNotice] = useState<string | null>(null);
-  const [createTitle, setCreateTitle] = useState("");
   const [searchQuery, setSearchQuery] = useState("");
   const [restrictSearchToSelectedFolder, setRestrictSearchToSelectedFolder] = useState(false);
   const [searchIndexState, setSearchIndexState] = useState<SearchIndexState>({ status: "idle" });
@@ -1656,7 +1713,7 @@ export function FolderNavigationWorkspaceContent({
     }
 
     const nextPath = createNewNotePath(
-      createTitle,
+      "",
       selectedFolderPath,
       workspaceState.notes.map((note) => note.path),
     );
@@ -1669,7 +1726,7 @@ export function FolderNavigationWorkspaceContent({
     try {
       const createdNote = await createMarkdownNote({
         path: nextPath,
-        content: "",
+        content: getInitialNoteContent(),
       });
       const [mappedNote] = mapScannedMarkdownNotes([createdNote]);
 
@@ -1695,7 +1752,6 @@ export function FolderNavigationWorkspaceContent({
         [mappedNote.id]: "",
       }));
       setSelectedNoteId(mappedNote.id);
-      setCreateTitle("");
       setCreateState({
         status: "idle",
         errorMessage: null,
@@ -1720,12 +1776,26 @@ export function FolderNavigationWorkspaceContent({
     }
   }, [
     createState.status,
-    createTitle,
     noteEditBuffer,
     scanState.status,
     selectedFolderPath,
     workspaceState.notes,
   ]);
+
+  const createFolderInSelectedFolder = useCallback(
+    async (folderName: string): Promise<void> => {
+      const nextFolderPath = normalizeFolderPath(
+        selectedFolderPath === null ? folderName : `${selectedFolderPath}/${folderName}`,
+      );
+
+      await createMarkdownFolder({
+        path: nextFolderPath,
+      });
+
+      setWorkspaceState((currentState) => addExplicitFolderToWorkspace(currentState, nextFolderPath));
+    },
+    [selectedFolderPath],
+  );
 
   function markSelectedNoteDraftSaved(buffer: NoteEditBuffer): void {
     setNoteEditBuffer((currentBuffer) => {
@@ -1888,7 +1958,10 @@ export function FolderNavigationWorkspaceContent({
 
     async function scanWorkspace(): Promise<void> {
       try {
-        const scannedNotes = await scanMarkdownWorkspace();
+        const [scannedNotes, scannedFolders] = await Promise.all([
+          scanMarkdownWorkspace(),
+          listMarkdownFolders(),
+        ]);
         const notes = mapScannedMarkdownNotes(scannedNotes);
 
         if (canceled) {
@@ -1897,7 +1970,7 @@ export function FolderNavigationWorkspaceContent({
 
         setWorkspaceState({
           notes,
-          explicitFolders: [],
+          explicitFolders: scannedFolders.map((folderPath) => normalizeFolderPath(folderPath)),
           selectedFolderPath: null,
           expandedFolderPaths: getExpandedFolderPathsForNotes(notes),
         });
@@ -2058,16 +2131,9 @@ export function FolderNavigationWorkspaceContent({
         selectedNoteId={selectedNoteId}
         scanState={scanState}
         createState={createState}
-        createTitle={createTitle}
         searchQuery={searchQuery}
         searchIndexState={searchIndexState}
         restrictSearchToSelectedFolder={restrictSearchToSelectedFolder}
-        onCreateTitleChange={(title) => {
-          setCreateTitle(title);
-          if (createState.errorMessage !== null) {
-            setCreateState({ status: "idle", errorMessage: null });
-          }
-        }}
         onSearchQueryChange={setSearchQuery}
         onRestrictSearchToSelectedFolderChange={setRestrictSearchToSelectedFolder}
         onCreateNote={() => {
@@ -2092,6 +2158,7 @@ export function FolderNavigationWorkspaceContent({
         editorNotice={editorNotice}
         deleteState={deleteState}
         onMoveSelectedNote={moveSelectedNote}
+        onCreateFolder={createFolderInSelectedFolder}
         onRenameSelectedFolder={renameSelectedFolder}
         onEditContent={editSelectedNoteContent}
         onSaveDraft={() => {

--- a/apps/desktop/src/features/folder-navigation/ui/WorkspaceControls.tsx
+++ b/apps/desktop/src/features/folder-navigation/ui/WorkspaceControls.tsx
@@ -1,8 +1,9 @@
 import { appName } from "@grove/core";
 import { useId, useState } from "react";
 
-import type { DesktopWorkspace } from "../../../shared";
+import { selectWorkspaceFolder, type DesktopWorkspace } from "../../../shared";
 import type { WorkspaceLoadState } from "../model/useWorkspaceStore";
+import { chooseWorkspaceFolder } from "../model/workspaceFolderPicker";
 
 type WorkspaceSwitcherSlice = {
   activeWorkspaceName: string;
@@ -24,6 +25,10 @@ type PopoverView = "list" | "add" | "settings";
 type PopoverOperationState = {
   status: "idle" | "pending" | "failed";
   errorMessage: string | null;
+};
+
+type FolderPickerState = {
+  status: "idle" | "choosing";
 };
 
 type WorkspaceSetupFormProps = {
@@ -134,11 +139,15 @@ function WorkspaceSetupForm({
     status: "idle",
     errorMessage: null,
   });
+  const [folderPicker, setFolderPicker] = useState<FolderPickerState>({
+    status: "idle",
+  });
   const formId = useId();
   const [name, setName] = useState("");
   const [rootPath, setRootPath] = useState("");
   const nameInputId = `${formId}-workspace-name`;
   const pathInputId = `${formId}-workspace-path`;
+  const isBusy = operation.status === "pending" || folderPicker.status === "choosing";
 
   async function handleAdd(): Promise<void> {
     if (switchBlockedReason !== null) {
@@ -155,6 +164,22 @@ function WorkspaceSetupForm({
         status: "failed",
         errorMessage: error instanceof Error ? error.message : "Failed to add workspace.",
       });
+    }
+  }
+
+  async function handleChooseFolder(): Promise<void> {
+    setFolderPicker({ status: "choosing" });
+    setOperation((currentOperation) => ({ ...currentOperation, errorMessage: null }));
+    const choice = await chooseWorkspaceFolder(selectWorkspaceFolder);
+    setFolderPicker({ status: "idle" });
+
+    if (choice.errorMessage !== null) {
+      setOperation({ status: "failed", errorMessage: choice.errorMessage });
+      return;
+    }
+
+    if (choice.path !== null) {
+      setRootPath(choice.path);
     }
   }
 
@@ -175,7 +200,7 @@ function WorkspaceSetupForm({
         value={name}
         onChange={(event) => setName(event.target.value)}
         placeholder="My Notes"
-        disabled={operation.status === "pending"}
+        disabled={isBusy}
       />
       <label className="folder-navigation__label" htmlFor={pathInputId}>
         Folder path
@@ -186,8 +211,18 @@ function WorkspaceSetupForm({
         value={rootPath}
         onChange={(event) => setRootPath(event.target.value)}
         placeholder="/Users/you/Notes"
-        disabled={operation.status === "pending"}
+        disabled={isBusy}
       />
+      <button
+        type="button"
+        className="folder-navigation__secondary-action"
+        onClick={() => {
+          void handleChooseFolder();
+        }}
+        disabled={isBusy}
+      >
+        {folderPicker.status === "choosing" ? "Choosing..." : "Choose folder"}
+      </button>
       {operation.errorMessage !== null ? (
         <p className="folder-navigation__step-error">{operation.errorMessage}</p>
       ) : null}
@@ -196,10 +231,7 @@ function WorkspaceSetupForm({
           type="submit"
           className="folder-navigation__action"
           disabled={
-            switchBlockedReason !== null ||
-            operation.status === "pending" ||
-            name.trim() === "" ||
-            rootPath.trim() === ""
+            switchBlockedReason !== null || isBusy || name.trim() === "" || rootPath.trim() === ""
           }
         >
           {operation.status === "pending" ? pendingLabel : submitLabel}

--- a/apps/desktop/src/shared/api/commands.test.ts
+++ b/apps/desktop/src/shared/api/commands.test.ts
@@ -3,8 +3,10 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import {
   createMarkdownNote,
+  createMarkdownFolder,
   deleteMarkdownNote,
   addWorkspace,
+  listMarkdownFolders,
   getActiveWorkspace,
   listWorkspaces,
   moveMarkdownFile,
@@ -83,6 +85,16 @@ describe("desktop command wrappers", () => {
     expect(invokeMock).toHaveBeenCalledWith("scan_markdown_workspace", {});
   });
 
+  it("invokes the Markdown folder scan command", async () => {
+    invokeMock.mockResolvedValue(["Projects/Grove", "Projects/Grove/Ideas"]);
+
+    await expect(listMarkdownFolders()).resolves.toStrictEqual([
+      "Projects/Grove",
+      "Projects/Grove/Ideas",
+    ]);
+    expect(invokeMock).toHaveBeenCalledWith("scan_markdown_folders", {});
+  });
+
   it("invokes the Markdown note create command", async () => {
     invokeMock.mockResolvedValue({
       path: "Projects/Grove/Plan.md",
@@ -106,6 +118,20 @@ describe("desktop command wrappers", () => {
       note: {
         path: "Projects/Grove/Plan.md",
         content: "",
+      },
+    });
+  });
+
+  it("invokes the Markdown folder create command", async () => {
+    invokeMock.mockResolvedValue(undefined);
+
+    await createMarkdownFolder({
+      path: "Projects/Grove/Ideas",
+    });
+
+    expect(invokeMock).toHaveBeenCalledWith("create_markdown_folder", {
+      folder: {
+        path: "Projects/Grove/Ideas",
       },
     });
   });
@@ -250,6 +276,12 @@ describe("desktop command wrappers", () => {
     invokeMock.mockResolvedValue([{ path: "/Users/me/Notes/Plan.md", title: "Plan" }]);
 
     await expect(scanMarkdownWorkspace()).rejects.toThrow("invalid note list");
+  });
+
+  it("rejects invalid Markdown folder scan results", async () => {
+    invokeMock.mockResolvedValue(["Projects/Grove", 123]);
+
+    await expect(listMarkdownFolders()).rejects.toThrow("invalid folder list");
   });
 
   it("rejects non-finite Markdown workspace scan timestamps", async () => {

--- a/apps/desktop/src/shared/api/commands.ts
+++ b/apps/desktop/src/shared/api/commands.ts
@@ -30,6 +30,10 @@ export type CreateMarkdownNoteCommand = {
   content: string;
 };
 
+export type CreateMarkdownFolderCommand = {
+  path: string;
+};
+
 export type ReadMarkdownNoteCommand = {
   path: string;
 };
@@ -133,6 +137,16 @@ export async function scanMarkdownWorkspace(): Promise<ScannedMarkdownNote[]> {
   return result;
 }
 
+export async function listMarkdownFolders(): Promise<string[]> {
+  const result = await invokeCommandResult("scan_markdown_folders", {});
+
+  if (!isMarkdownFolderPaths(result)) {
+    throw new Error("The desktop scan command returned an invalid folder list.");
+  }
+
+  return result;
+}
+
 export async function createMarkdownNote(
   command: CreateMarkdownNoteCommand,
 ): Promise<ScannedMarkdownNote> {
@@ -143,6 +157,10 @@ export async function createMarkdownNote(
   }
 
   return result;
+}
+
+export async function createMarkdownFolder(command: CreateMarkdownFolderCommand): Promise<void> {
+  await invokeCommand("create_markdown_folder", { folder: command });
 }
 
 export async function readMarkdownNote(command: ReadMarkdownNoteCommand): Promise<string> {
@@ -213,6 +231,10 @@ function isCommandErrorPayload(error: unknown): error is { message: string } {
 
 function isScannedMarkdownNotes(value: unknown): value is ScannedMarkdownNote[] {
   return Array.isArray(value) && value.every(isScannedMarkdownNote);
+}
+
+function isMarkdownFolderPaths(value: unknown): value is string[] {
+  return Array.isArray(value) && value.every((entry) => typeof entry === "string");
 }
 
 function isDesktopWorkspaces(value: unknown): value is DesktopWorkspace[] {

--- a/apps/desktop/src/shared/api/dialog.test.ts
+++ b/apps/desktop/src/shared/api/dialog.test.ts
@@ -1,0 +1,17 @@
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+describe("desktop dialog permissions", () => {
+  it("grants the native folder picker permission to the main window", () => {
+    const capabilityPath = resolve("src-tauri/capabilities/default.json");
+    const capability = JSON.parse(readFileSync(capabilityPath, "utf8")) as {
+      permissions?: unknown;
+      windows?: unknown;
+    };
+
+    expect(capability.windows).toContain("main");
+    expect(capability.permissions).toContain("dialog:allow-open");
+  });
+});

--- a/apps/desktop/src/shared/api/dialog.ts
+++ b/apps/desktop/src/shared/api/dialog.ts
@@ -1,0 +1,11 @@
+import { open } from "@tauri-apps/plugin-dialog";
+
+export async function selectWorkspaceFolder(): Promise<string | null> {
+  const selectedPath = await open({
+    directory: true,
+    multiple: false,
+    title: "Choose workspace folder",
+  });
+
+  return typeof selectedPath === "string" ? selectedPath : null;
+}

--- a/apps/desktop/src/shared/index.ts
+++ b/apps/desktop/src/shared/index.ts
@@ -1,8 +1,10 @@
 export {
   addWorkspace,
   createMarkdownNote,
+  createMarkdownFolder,
   deleteMarkdownNote,
   getActiveWorkspace,
+  listMarkdownFolders,
   listWorkspaces,
   moveMarkdownFile,
   readMarkdownNote,
@@ -15,6 +17,7 @@ export {
 } from "./api/commands";
 export type {
   AddWorkspaceCommand,
+  CreateMarkdownFolderCommand,
   CreateMarkdownNoteCommand,
   DeleteMarkdownNoteCommand,
   DesktopWorkspace,

--- a/apps/desktop/src/shared/index.ts
+++ b/apps/desktop/src/shared/index.ts
@@ -27,4 +27,5 @@ export type {
   SwitchWorkspaceCommand,
   WriteMarkdownNoteCommand,
 } from "./api/commands";
+export { selectWorkspaceFolder } from "./api/dialog";
 export { ShellCard } from "./ui/ShellCard";

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -44,6 +44,9 @@ importers:
       '@tauri-apps/api':
         specifier: ^2.0.0
         version: 2.10.1
+      '@tauri-apps/plugin-dialog':
+        specifier: ^2.0.0
+        version: 2.7.0
       react:
         specifier: ^19.0.0
         version: 19.2.5
@@ -1611,6 +1614,9 @@ packages:
     engines: {node: '>= 10'}
     hasBin: true
 
+  '@tauri-apps/plugin-dialog@2.7.0':
+    resolution: {integrity: sha512-4nS/hfGMGCXiAS3LtVjH9AgsSAPJeG/7R+q8agTFqytjnMa4Zq95Bq8WzVDkckpanX+yyRHXnRtrKXkANKDHvw==}
+
   '@turbo/darwin-64@2.9.6':
     resolution: {integrity: sha512-X/56SnVXIQZBLKwniGTwEQTGmtE5brSACnKMBWpY3YafuxVYefrC2acamfjgxP7BG5w3I+6jf0UrLoSzgPcSJg==}
     cpu: [x64]
@@ -1748,6 +1754,7 @@ packages:
   '@xmldom/xmldom@0.8.12':
     resolution: {integrity: sha512-9k/gHF6n/pAi/9tqr3m3aqkuiNosYTurLLUtc7xQ9sxB/wm7WPygCv8GYa6mS0fLJEHhqMC1ATYhz++U/lRHqg==}
     engines: {node: '>=10.0.0'}
+    deprecated: this version has critical issues, please update to the latest version
 
   abort-controller@3.0.0:
     resolution: {integrity: sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==}
@@ -5794,6 +5801,10 @@ snapshots:
       '@tauri-apps/cli-win32-arm64-msvc': 2.10.1
       '@tauri-apps/cli-win32-ia32-msvc': 2.10.1
       '@tauri-apps/cli-win32-x64-msvc': 2.10.1
+
+  '@tauri-apps/plugin-dialog@2.7.0':
+    dependencies:
+      '@tauri-apps/api': 2.10.1
 
   '@turbo/darwin-64@2.9.6':
     optional: true


### PR DESCRIPTION
## Summary
- remove the separate desktop note title input and create untitled notes with an empty initial body
- add desktop folder creation plus empty-folder scanning/persistence through Tauri commands
- cover the new desktop command, workspace state, UI, and Tauri behavior with tests

## Testing
- pnpm --filter @grove/desktop test -- src/shared/api/commands.test.ts src/features/folder-navigation/model/folderWorkspaceState.test.ts src/features/folder-navigation/ui/FolderNavigationWorkspace.test.tsx
- pnpm --filter @grove/desktop typecheck
- cargo test --manifest-path apps/desktop/src-tauri/Cargo.toml workspace_folder
